### PR TITLE
Fetches nodes from cabinets instead of its own resource

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -34,18 +34,18 @@ module ManageIQ::Providers::Lenovo
       cabinets = @connection.discover_cabinet(:status => "includestandalone")
 
       nodes = cabinets.map(&:nodeList).flatten
-      nodes = nodes.map do |nodes|
-        nodes["itemInventory"]
+      nodes = nodes.map do |node|
+        node["itemInventory"]
       end.flatten
 
       chassis = cabinets.map(&:chassisList).flatten
 
-      nodesChassis = chassis.map do |chassi|
+      nodes_chassis = chassis.map do |chassi|
         chassi["itemInventory"]["nodes"]
       end.flatten
-      nodesChassis = nodesChassis.select{ |node| node["type"] != "SCU" }
+      nodes_chassis = nodes_chassis.select { |node| node["type"] != "SCU" }
 
-      nodes += nodesChassis
+      nodes += nodes_chassis
 
       nodes = nodes.map do |node|
         XClarityClient::Node.new node
@@ -55,14 +55,13 @@ module ManageIQ::Providers::Lenovo
 
 
     def parse_nodes(node)
-
       # physical_server = ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.new(node)
 
       new_result = {
-        :type     => ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.name,
-        :name     => node.name,
-        :ems_ref  => node.uuid,
-        :uid_ems  => node.uuid,
+        :type    => ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.name,
+        :name    => node.name,
+        :ems_ref => node.uuid,
+        :uid_ems => node.uuid
       }
 
       return node.uuid, new_result

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -31,9 +31,9 @@ module ManageIQ::Providers::Lenovo
     private
 
     def get_physical_servers
-      cabinets = @connection.discover_cabinet({status: "includestandalone"})
-      nodes = cabinets.map { |cabinet| cabinet.nodeList }.flatten
-      nodes = nodes.map do |node| 
+      cabinets = @connection.discover_cabinet(:status => "includestandalone")
+      nodes = cabinets.map(&:nodeList).flatten
+      nodes = nodes.map do |node|
         XClarityClient::Node.new node["itemInventory"]
       end
       process_collection(nodes, :physical_servers) { |node| parse_nodes(node) }

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -31,7 +31,11 @@ module ManageIQ::Providers::Lenovo
     private
 
     def get_physical_servers
-      nodes = @connection.discover_nodes
+      cabinets = @connection.discover_cabinet({status: "includestandalone"})
+      nodes = cabinets.map { |cabinet| cabinet.nodeList }.flatten
+      nodes = nodes.map do |node| 
+        XClarityClient::Node.new node["itemInventory"]
+      end
       process_collection(nodes, :physical_servers) { |node| parse_nodes(node) }
     end
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
@@ -2,12 +2,12 @@ module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
-    
+
     def parse_legacy_inventory(ems)
 
       log_header = "MIQ_LENOVO(#{self.class.name}.#{__method__} Calling for [#{ems.name}])"
       $log.info("#{log_header}")
-    
+
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
     end
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
@@ -2,7 +2,6 @@ module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     include ::EmsRefresh::Refreshers::EmsRefresherMixin
 
-
     def parse_legacy_inventory(ems)
 
       log_header = "MIQ_LENOVO(#{self.class.name}.#{__method__} Calling for [#{ems.name}])"


### PR DESCRIPTION
Many of the current resource paths in LXCA API are being deprecated and will be discontinued soon. Thus, the way to fetch nodes through the REST API is using the `/cabinet` resource. This is how this the goal of this PR.

PS: We must wait the https://github.com/juliancheal/xclarity_client gem to support query strings through the merging of https://github.com/juliancheal/xclarity_client/pull/17, before merging this very PR.