### PR TITLE
remove controller specs again

### DIFF
--- a/spec/controllers/cloud_network_controller_spec.rb
+++ b/spec/controllers/cloud_network_controller_spec.rb
@@ -1,5 +1,0 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_cloud_network_controller')
-
-describe CloudNetworkController do
-  include_examples :shared_examples_for_cloud_network_controller, %w(amazon)
-end

--- a/spec/controllers/cloud_subnet_controller_spec.rb
+++ b/spec/controllers/cloud_subnet_controller_spec.rb
@@ -1,5 +1,0 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_cloud_subnet_controller')
-
-describe CloudSubnetController do
-  include_examples :shared_examples_for_cloud_subnet_controller, %w(amazon)
-end

--- a/spec/controllers/ems_network_controller_spec.rb
+++ b/spec/controllers/ems_network_controller_spec.rb
@@ -1,5 +1,0 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_ems_network_controller')
-
-describe EmsNetworkController do
-  include_examples :shared_examples_for_ems_network_controller, %w(amazon)
-end

--- a/spec/controllers/floating_ip_controller_spec.rb
+++ b/spec/controllers/floating_ip_controller_spec.rb
@@ -1,5 +1,0 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_floating_ip_controller')
-
-describe FloatingIpController do
-  include_examples :shared_examples_for_floating_ip_controller, %w(amazon)
-end

--- a/spec/controllers/load_balancer_controller_spec.rb
+++ b/spec/controllers/load_balancer_controller_spec.rb
@@ -1,5 +1,0 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_load_balancer_controller')
-
-describe LoadBalancerController do
-  include_examples :shared_examples_for_load_balancer_controller, %w(amazon)
-end

--- a/spec/controllers/network_port_controller_spec.rb
+++ b/spec/controllers/network_port_controller_spec.rb
@@ -1,5 +1,0 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_network_port_controller')
-
-describe NetworkPortController do
-  include_examples :shared_examples_for_network_port_controller, %w(amazon)
-end

--- a/spec/controllers/network_router_controller_spec.rb
+++ b/spec/controllers/network_router_controller_spec.rb
@@ -1,5 +1,0 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_network_router_controller')
-
-describe NetworkRouterController do
-  include_examples :shared_examples_for_network_router_controller, %w(amazon)
-end

--- a/spec/controllers/security_group_controller_spec.rb
+++ b/spec/controllers/security_group_controller_spec.rb
@@ -1,5 +1,0 @@
-require Rails.root.join('spec/shared/controllers/shared_examples_for_security_group_controller')
-
-describe SecurityGroupController do
-  include_examples :shared_examples_for_security_group_controller, %w(amazon)
-end


### PR DESCRIPTION
no need to run controller specs
for one they were running the specs for amazon and also they
only should run if you have models of that kind

weird, they have been removed here https://github.com/ManageIQ/manageiq-providers-lenovo/pull/10 already. How did they re-appear?

Let's do it again