### PR TITLE
Set correct base class for Lenovo Manager

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -1,4 +1,4 @@
-class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::InfraManager
+class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::PhysicalInfraManager
   has_many :physical_servers, foreign_key: "ems_id", class_name: "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer"
 
   include ManageIQ::Providers::Lenovo::ManagerMixin


### PR DESCRIPTION
The base manager class for `Lenovo::PhysicalInfraManager` was accidentally left as `InfraManager`.  This was a hold over from before the base `PhysicalInfraManager` class existed.

By updating to the correct base class, functions like `ManageIQ::Providers::PhysicalInfraManager.supported_subclasses` and `ManageIQ::Providers::PhysicalInfraManager.supported_types_and_descriptions_hash` will now return the correct list.  For example:

```
irb(main):003:0> ManageIQ::Providers::PhysicalInfraManager.supported_subclasses.map(&:name)
=> ["ManageIQ::Providers::Lenovo::PhysicalInfraManager"]
irb(main):004:0> ManageIQ::Providers::PhysicalInfraManager.supported_types_and_descriptions_hash
=> {"lenovo_ph_infra"=>"Lenovo XClarity"}
```

