### PR TITLE
Adds operations to the lenovo provider

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -2,6 +2,7 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   has_many :physical_servers, foreign_key: "ems_id", class_name: "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer"
 
   include ManageIQ::Providers::Lenovo::ManagerMixin
+  include_concern 'Operations'
 
   require_nested :Refresher
   require_nested :RefreshParser

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
@@ -1,0 +1,45 @@
+module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
+  extend ActiveSupport::Concern
+
+  def blink_loc_led(server, options = {})
+    change_resource_state(:blink_loc_led, server, options)
+  end
+
+  def turn_on_loc_led(server, options = {})
+    change_resource_state(:turn_on_loc_led, server, options)
+  end
+
+  def turn_off_loc_led(server, options = {})
+    change_resource_state(:turn_off_loc_led, server, options)
+  end
+
+  def power_on(args, options = {})
+    change_resource_state(:power_on_node, args, options)
+  end
+
+  def power_off(args, options = {})
+    change_resource_state(:power_off_node, args, options)
+  end
+
+  def restart(args, options = {})
+    change_resource_state(:power_restart_node, args, options)
+  end
+
+  private
+
+  def change_resource_state(verb, args, options = {})
+    $lenovo_log.info("Entering change resource state for #{verb} and uuid: #{args.uuid} ")
+
+    # Connect to the LXCA instance
+    auth = authentications.first
+    endpoint = endpoints.first
+    client = connect(:user => auth.userid,
+                     :pass => auth.password,
+                     :host => endpoint.hostname)
+
+    # Turn on the location LED using the xclarity_client API
+    client.send(verb, options[:uuid])
+
+    $lenovo_log.info("Exiting change resource state for #{verb} and uuid: #{args.uuid}")
+  end
+end


### PR DESCRIPTION
-includes  power operations (power off, on, restart)
- location Led operations  (on, off, blinking)

@miq-bot add_label: wip, providers/physical-infrastructure