### PR TITLE
Adds structure to hardware relationship, parse_hardware and missed attributes

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
@@ -1,5 +1,8 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalServer < ::PhysicalServer
+    
+    has_one :hardware
+    
     def name
       "physical_server"
     end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
@@ -1,8 +1,8 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalServer < ::PhysicalServer
-    
+
     has_one :hardware
-    
+
     def name
       "physical_server"
     end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
@@ -1,6 +1,5 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalServer < ::PhysicalServer
-
     has_one :hardware
 
     def name

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -110,25 +110,21 @@ module ManageIQ::Providers::Lenovo
 
     def parse_nodes(node)
       new_result = {
-        :type          => ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.name,
-        :name          => node.name,
-        :ems_ref       => node.uuid,
-        :uid_ems       => @ems.uid_ems,
-        :hostname      => node.hostname,
-        :product_name  => node.productName,
-        :manufacturer  => node.manufacturer,
-        :machine_type  => node.machineType,
-        :model         => node.model,
-        :serial_number => node.serialNumber,
-        :uuid          => node.uuid,
-        :FRU           => node.FRU,
-        :macAddresses  => node.macAddress.split(",").flatten,
-        :ipv4Addresses => node.ipv4Addresses.split.flatten,
-        :ipv6Addresses => node.ipv6Addresses.split.flatten,
-        :health_state  => HEALTH_STATE[node.cmmHealthState.downcase],
-        :power_state   => POWER_STATE_MAP[node.powerStatus],
-        :vendor        => "lenovo",
-        :hardware      => parse_hardware(node)
+        :type                  => ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.name,
+        :name                  => node.name,
+        :ems_ref               => node.uuid,
+        :uid_ems               => @ems.uid_ems,
+        :hostname              => node.hostname,
+        :product_name          => node.productName,
+        :manufacturer          => node.manufacturer,
+        :machine_type          => node.machineType,
+        :model                 => node.model,
+        :serial_number         => node.serialNumber,
+        :field_replaceble_unit => node.FRU,
+        :health_state          => HEALTH_STATE[node.cmmHealthState.downcase],
+        :power_state           => POWER_STATE_MAP[node.powerStatus],
+        :vendor                => "lenovo",
+        :hardware              => parse_hardware(node)
       }
 
       return node.uuid, new_result

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -3,11 +3,11 @@ module ManageIQ::Providers::Lenovo
     include ManageIQ::Providers::Lenovo::RefreshHelperMethods
 
     POWER_STATE_MAP = {
-                      8 => "on",
-                      5 => "off",
-                      18 => "Standby",
-                      0 => "Unknown"
-    }
+      8  => "on",
+      5  => "off",
+      18 => "Standby",
+      0  => "Unknown"
+    }.freeze
 
     HEALTH_STATE = {
       "normal"          => "Valid",
@@ -19,7 +19,7 @@ module ManageIQ::Providers::Lenovo
       "major-failure"   => "Critical",
       "non-recoverable" => "Critical",
       "fatal"           => "Critical"
-    }
+    }.freeze
 
     def initialize(ems, options = nil)
       ems_auth = ems.authentications.first

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -2,6 +2,25 @@ module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::RefreshParser < EmsRefresh::Parsers::Infra
     include ManageIQ::Providers::Lenovo::RefreshHelperMethods
 
+    POWER_STATE_MAP = {
+                      8 => "on",
+                      5 => "off",
+                      18 => "Standby",
+                      0 => "Unknown"
+    }
+
+    HEALTH_STATE = {
+      "normal"          => "Valid",
+      "non-critical"    => "Valid",
+      "warning"         => "Warning",
+      "critical"        => "Critical",
+      "unknown"         => "None",
+      "minor-failure"   => "Critical",
+      "major-failure"   => "Critical",
+      "non-recoverable" => "Critical",
+      "fatal"           => "Critical"
+    }
+
     def initialize(ems, options = nil)
       ems_auth = ems.authentications.first
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -68,14 +68,14 @@ module ManageIQ::Providers::Lenovo
         :ph_server_uuid => uuid
       }
     end
-    
+
     def parse_hardware(node)
-      return nil if (node.memoryModules.blank? and node.processors.blank?)
+      return nil if node.memoryModules.blank? && node.processors.blank?
 
       new_result = {
-        :memory_mb => 0,
+        :memory_mb       => 0,
         :cpu_total_cores => 0,
-        :cpu_speed  =>  0,
+        :cpu_speed       => 0
       }
 
       node.memoryModules.each do |mem|


### PR DESCRIPTION
Adding structure needed to relationship between physical server and hardware, such as:

1. `parse_hardware` method
2. `has_one` relationship into PhysicalServer model
3. adding some missed attributes into `parse_nodes` method

Depends on: https://github.com/ManageIQ/manageiq-providers-lenovo/pull/34