### PR TITLE
Test updated ruby 2.3.3 and new 2.4.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
-- '2.3.1'
+- '2.3.3'
+- '2.4.1'
 sudo: false
 cache: bundler
 env:


### PR DESCRIPTION
I believe this depends on merging https://github.com/ManageIQ/manageiq/pull/13104 first since ruby_parser doesn't support 2.4.0+.