### PR TITLE
Change source name and add physical_server_id

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
@@ -1,14 +1,15 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser
   def self.event_to_hash(event, ems_id)
     event_hash = {
-      :event_type    => event.eventID,
-      :source        => "LenovoXclarity",
-      :message       => event.msg,
-      :timestamp     => event.timeStamp,
-      :lxca_severity => event.severity,
-      :lxca_cn       => event.cn,
-      :full_data     => event.to_hash,
-      :ems_id        => ems_id
+      :event_type           => event.eventID,
+      :source               => "LenovoXclarity",
+      :physical_server_ref  => event.componentID,
+      :message              => event.msg,
+      :timeStamp            => event.timeStamp,
+      :lxca_severity        => event.severity,
+      :lxca_cn              => event.cn,
+      :full_data            => event.to_hash,
+      :ems_id               => ems_id
     }
 
     event_hash

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser
   def self.event_to_hash(event, ems_id)
     event_hash = {
       :event_type    => event.eventID,
-      :source        => "LXCA",
+      :source        => "LenovoXclarity",
       :message       => event.msg,
       :timestamp     => event.timeStamp,
       :lxca_severity => event.severity,


### PR DESCRIPTION
This PR do the follow changes:
- Change the source name of the Lenovo's provider.
- Add the physical server identify into event hash.

This PR depends on a migration in Event Stream to add `physical_server_id`