### PR TITLE
Remove method "name" from physical_server

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
@@ -1,7 +1,4 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalServer < ::PhysicalServer
-    def name
-      "physical_server"
-    end
   end
 end


### PR DESCRIPTION
The method "name" in physical server class is causing inconsistency when we are trying show a Physical server's name in the UI and in the REST API as well.

The method was removed to solve this issue. 