### PR TITLE
[WIP] Add the network data to providers parse

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -66,8 +66,17 @@ module ManageIQ::Providers::Lenovo
       {
         :memory_mb       => get_memory_info(node),
         :cpu_total_cores => get_total_cores(node),
+        :networks        => get_networks(node),
         :firmwares       => get_firmwares(node.firmware)
       }
+    end
+
+    def get_networks(node)
+      [{
+        :mac_addresses => node.macAddress,
+        :ipaddress     => node.ipv4Addresses.join(", "),
+        :ipv6address   => node.ipv6Addresses.join(", ")
+      }]
     end
 
     def get_memory_info(node)


### PR DESCRIPTION
This PR is able to:
 * Add the attributes of network in the providers parse: 
     - ipaddress
     - ipv6address
     - mac_addresses 

  Depends on: https://github.com/ManageIQ/manageiq/pull/14763
