### PR TITLE
Changes uuid references to ems_ref in operations.rb

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
@@ -46,6 +46,6 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher::Stream
   end
 
   def get_last_cnn_from_events(ems_id)
-    EventStream.where("ems_id = '#{ems_id}'").maximum("lxca_cn")
+    EventStream.where(:ems_id => ems_id).maximum("lxca_cn")
   end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
@@ -28,7 +28,7 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
   private
 
   def change_resource_state(verb, args, options = {})
-    $lenovo_log.info("Entering change resource state for #{verb} and uuid: #{args.uuid} ")
+    $lenovo_log.info("Entering change resource state for #{verb} and uuid: #{args.ems_ref} ")
 
     # Connect to the LXCA instance
     auth = authentications.first
@@ -38,8 +38,8 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
                      :host => endpoint.hostname)
 
     # Turn on the location LED using the xclarity_client API
-    client.send(verb, options[:uuid])
+    client.send(verb, args.ems_ref)
 
-    $lenovo_log.info("Exiting change resource state for #{verb} and uuid: #{args.uuid}")
+    $lenovo_log.info("Exiting change resource state for #{verb} and uuid: #{args.ems_ref}")
   end
 end


### PR DESCRIPTION
Changes references to uuid to ems_ref in operations.rb.   Changes from previous PRs removing the UUID from the physical_server model where not reflected here.

@miq-bot add_label providers/physical-infrastructure