### PR TITLE
Add refresh_parser support for location LED state

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -123,7 +123,8 @@ module ManageIQ::Providers::Lenovo
             :networks  => [],
             :firmwares => [] # Filled in later conditionally on what's available
           }
-        }
+        },
+        :location_led_state    	=> find_loc_led_state(node.leds)
       }
       new_result[:computer_system][:hardware] = get_hardwares(node)
       return node.uuid, new_result
@@ -149,6 +150,19 @@ module ManageIQ::Providers::Lenovo
       nodes += nodes_chassis
 
       @all_server_resources = nodes
+    end
+
+    def find_loc_led_state(leds)
+      loc_led_state = ""
+
+      leds.each do |led|
+        if led["name"] == "Identify"
+          loc_led_state = led["state"]
+          break
+        end
+      end
+
+      loc_led_state
     end
   end
 end


### PR DESCRIPTION
Adding support for parsing the location LED state, so it can be stored in the database.