### PR TITLE
Fix unused HTTP interactions problem

### DIFF
--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_ems_inv_to_hashes.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_ems_inv_to_hashes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://admin:password@10.243.9.123/cabinet?status=includestandalone
+    uri: https://10.243.9.123/cabinet?status=includestandalone
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/refresher_parse_legacy_inventory.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/refresher_parse_legacy_inventory.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://admin:password@10.243.9.123/cabinet?status=includestandalone
+    uri: https://10.243.9.123/cabinet?status=includestandalone
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_blink_loc_led.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_blink_loc_led.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://admin:password@10.243.9.123/nodes/BD775D06821111E189A3E41F13ED5A1A
+    uri: https://10.243.9.123/nodes/BD775D06821111E189A3E41F13ED5A1A
     body:
       encoding: UTF-8
       string: '{"leds":[{"name":"Identify","state":"Blinking"}]}'

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_power_off.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_power_off.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://admin:password@10.243.9.123/nodes/EADEBE8316174750A27FEC2E8226AC48
+    uri: https://10.243.9.123/nodes/EADEBE8316174750A27FEC2E8226AC48
     body:
       encoding: UTF-8
       string: '{"powerState":"powerOff"}'

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_power_on.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_power_on.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://admin:password@10.243.9.123/nodes/EADEBE8316174750A27FEC2E8226AC48
+    uri: https://10.243.9.123/nodes/EADEBE8316174750A27FEC2E8226AC48
     body:
       encoding: UTF-8
       string: '{"powerState":"powerOn"}'

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_restart.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_restart.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://admin:password@10.243.9.123/nodes/EADEBE8316174750A27FEC2E8226AC48
+    uri: https://10.243.9.123/nodes/EADEBE8316174750A27FEC2E8226AC48
     body:
       encoding: UTF-8
       string: '{"powerState":"powerCycleSoftGrace"}'

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_turn_off_loc_led.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_turn_off_loc_led.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://admin:password@10.243.9.123/nodes/BD775D06821111E189A3E41F13ED5A1A
+    uri: https://10.243.9.123/nodes/BD775D06821111E189A3E41F13ED5A1A
     body:
       encoding: UTF-8
       string: '{"leds":[{"name":"Identify","state":"Off"}]}'

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_turn_on_loc_led.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager_turn_on_loc_led.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://admin:password@10.243.9.123/nodes/BD775D06821111E189A3E41F13ED5A1A
+    uri: https://10.243.9.123/nodes/BD775D06821111E189A3E41F13ED5A1A
     body:
       encoding: UTF-8
       string: '{"leds":[{"name":"Identify","state":"On"}]}'


### PR DESCRIPTION
ManageIQ now seems to be using webmock-2.3.2. In this new version, it appears that the authentication details (userid/password) are no longer included in the URI of the generated HTTP request. The exclusion of the authentication details, causes webmock to not use the requests stored in the cassettes because they now differ (the newly generated requests do not include the authentication details, but the requests stored cassettes do). In the prior version, webmock-1.24.6, the authentication details were included, so we did not have this problem.