### PR TITLE
Do not define the same key twice within hash

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -115,7 +115,6 @@ module ManageIQ::Providers::Lenovo
         :model                  => node.model,
         :serial_number          => node.serialNumber,
         :field_replaceable_unit => node.FRU,
-        :computer_system        => {:hardware => {:networks => [], :firmwares => []}},
         :host                   => get_host_relationship(node),
         :power_state            => POWER_STATE_MAP[node.powerStatus],
         :health_state           => HEALTH_STATE_MAP[node.cmmHealthState.downcase],


### PR DESCRIPTION
It's no good.

Addressing:
`refresh_parser.rb:118: warning: key :computer_system is duplicated and overwritten on line 123`