### PR TITLE
Change attribute name and add physical server id

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
@@ -46,6 +46,6 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher::Stream
   end
 
   def get_last_cnn_from_events(ems_id)
-    EventStream.where(:ems_id => ems_id).maximum("lxca_cn")
+    EventStream.where(:ems_id => ems_id).select(:full_data).map { |event| event.full_data["cn"].to_i }.max
   end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
@@ -1,17 +1,19 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser
   def self.event_to_hash(event, ems_id)
     event_hash = {
-      :event_type           => event.eventID,
-      :source               => "LenovoXclarity",
-      :physical_server_ref  => event.componentID,
-      :message              => event.msg,
-      :timeStamp            => event.timeStamp,
-      :lxca_severity        => event.severity,
-      :lxca_cn              => event.cn,
-      :full_data            => event.to_hash,
-      :ems_id               => ems_id
+      :event_type         => event.eventID,
+      :source             => "LenovoXclarity",
+      :physical_server_id => get_physical_server_id(event.componentID),
+      :message            => event.msg,
+      :timestamp          => event.timeStamp,
+      :full_data          => event.to_hash,
+      :ems_id             => ems_id
     }
 
     event_hash
+  end
+
+  def self.get_physical_server_id(ems_ref)
+    PhysicalServer.find_by(:ems_ref => ems_ref).try(:id)
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_parser_spec.rb
@@ -3,12 +3,13 @@ require 'xclarity_client'
 describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser do
   let(:event_attrs1) do
     {
-      :eventID   => 1,
-      :msg       => "This is a test event.",
-      :timeStamp => "2017-04-26T13:55:49.749552",
-      :severity  => "",
-      :cn        => "",
-      :to_hash   => ""
+      :eventID            => 1,
+      :source             => "LenovoXclarity",
+      :msg                => "This is a test event.",
+      :timeStamp          => "2017-04-26T13:55:49.749552",
+      :physical_server_id => "",
+      :to_hash            => "",
+      :ems_id             => 3
     }
   end
 
@@ -17,8 +18,9 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser do
   it 'will parse events' do
     event_hash = described_class.event_to_hash(event1, 3)
     expect(event_hash[:event_type]).to eq(1)
+    expect(event_hash[:source]).to eq("LenovoXclarity")
     expect(event_hash[:message]).to eq("This is a test event.")
-    expect(event_hash[:timeStamp]).to eq("2017-04-26T13:55:49.749552")
+    expect(event_hash[:timestamp]).to eq("2017-04-26T13:55:49.749552")
     expect(event_hash[:ems_id]).to eq(3)
   end
 end


### PR DESCRIPTION
This PR make the fallowing changes:
- Change physical_server_ref to physical_server_id
- Change timeStamp camelcase to timestamp
- Create the function get_physical_server_id that get the id based on ref of physical server

Depends on https://github.com/ManageIQ/manageiq/pull/15133