### PR TITLE
Fix vendor in the physical server parse

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -118,7 +118,7 @@ module ManageIQ::Providers::Lenovo
         :host                   => get_host_relationship(node),
         :power_state            => POWER_STATE_MAP[node.powerStatus],
         :health_state           => HEALTH_STATE_MAP[node.cmmHealthState.downcase],
-        :vendor                 => "Lenovo",
+        :vendor                 => "lenovo",
         :computer_system        => {
           :hardware             => {
             :networks  => [],


### PR DESCRIPTION
This PR is able to fix the vendor value, because the ManageIQ expects a downcased value  in the  [`physical_server.rb`](https://github.com/ManageIQ/manageiq/blob/master/app/models/physical_server.rb#L19) .