### PR TITLE
Fixes the definition of spec.files in gemspec

### DIFF
--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "Lenovo Provider for ManageIQ"
   s.licenses    = ["Apache-2.0"]
 
-  s.files = Dir["{app,config.lib}/**/*"]
+  s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_dependency "xclarity_client", "~> 0.4.1"
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"


### PR DESCRIPTION
With `Dir["{app,config.lib}"]`, that only tries to find two dirs: `app`, and `config.lib` (this one isn't real, obviously).

With the fix to `Dir["{app,config.lib}"]`, it then will search through the app, config, and lib directories properly