### PR TITLE
Passing the API Port to Xclarity_client

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -14,9 +14,10 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
     username   = options[:user] || authentication_userid(options[:auth_type])
     password   = options[:pass] || authentication_password(options[:auth_type])
     host       = options[:host]
+    port       = options[:port]
     # TODO: improve this SSL verification
     verify_ssl = options[:verify_ssl] == 1 ? 'PEER' : 'NONE'
-    self.class.raw_connect(username, password, host, verify_ssl)
+    self.class.raw_connect(username, password, host, port, verify_ssl)
   end
 
   def translate_exception(err)
@@ -31,12 +32,13 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
     #
     # Connections
     #
-    def raw_connect(username, password, host, verify_ssl)
+    def raw_connect(username, password, host, port, verify_ssl)
       require 'xclarity_client'
       xclarity = XClarityClient::Configuration.new(
         :username   => username,
         :password   => password,
         :host       => host,
+        :port       => port,
         :verify_ssl => verify_ssl
       )
       XClarityClient::Client.new(xclarity)
@@ -49,10 +51,10 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
     # Factory method to create EmsLenovo with instances
     #   or images for the given authentication.  Created EmsLenovo instances
     #   will automatically have EmsRefreshes queued up.
-    def discover(username, password, host, verify_ssl = 0)
+    def discover(username, password, host, port, verify_ssl = 0)
       new_emses = []
 
-      raw_connect(username, password, host, verify_ssl)
+      raw_connect(username, password, host, port, verify_ssl)
 
       EmsRefresh.queue_refresh(new_emses) unless new_emses.blank?
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
@@ -51,7 +51,8 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher::Stream
 
     ems.connect(:user => ems_auth.userid,
                 :pass => ems_auth.password,
-                :host => ems.endpoints.first.hostname)
+                :host => ems.endpoints.first.hostname,
+                :port => ems.endpoints.first.port)
   end
 
   def get_last_cnn_from_events(ems_id)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
@@ -35,7 +35,8 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
     endpoint = endpoints.first
     client = connect(:user => auth.userid,
                      :pass => auth.password,
-                     :host => endpoint.hostname)
+                     :host => endpoint.hostname,
+                     :port => endpoint.port)
 
     # Turn on the location LED using the xclarity_client API
     client.send(verb, args.ems_ref)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -28,7 +28,8 @@ module ManageIQ::Providers::Lenovo
       @ems               = ems
       @connection        = ems.connect(:user => ems_auth.userid,
                                        :pass => ems_auth.password,
-                                       :host => ems.endpoints.first.hostname)
+                                       :host => ems.endpoints.first.hostname,
+                                       :port => ems.endpoints.first.port)
       @options           = options || {}
       @data              = {}
       @data_index        = {}

--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "xclarity_client", "~> 0.4.1"
+  s.add_dependency "xclarity_client", "~> 0.5.2"
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream_spec.rb
@@ -2,7 +2,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher::Stream
   let(:ems) do
     FactoryGirl.create(:physical_infra_with_authentication,
                        :name     => "LXCA",
-                       :hostname => "https://10.243.9.123")
+                       :hostname => "https://10.243.9.123",
+                       :port     => "443")
   end
 
   let(:stream) { described_class.new(ems) }

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -3,7 +3,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
     pim = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "https://10.243.9.123",
-                             :ipaddress => "https://10.243.9.123")
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
     auth = FactoryGirl.create(:authentication,
                               :userid   => 'admin',
                               :password => 'password',

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -10,7 +10,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
     FactoryGirl.create(:physical_infra,
                        :name      => "LXCA",
                        :hostname  => "https://10.243.9.123",
-                       :ipaddress => "https://10.243.9.123")
+                       :port      => "443",
+                       :ipaddress => "https://10.243.9.123:443")
   end
 
   let(:targets) { [ems] }

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
@@ -2,7 +2,7 @@ require 'xclarity_client'
 
 describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
   before :all do
-    @auth = { :user => 'admin', :pass => 'smartvm', :host => 'localhost' }
+    @auth = { :user => 'admin', :pass => 'smartvm', :host => 'localhost', :port => '3000' }
   end
 
   it 'will turn on a location LED successfully' do
@@ -12,7 +12,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
     pim = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "https://10.243.9.123",
-                             :ipaddress => "https://10.243.9.123")
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
     auth = FactoryGirl.create(:authentication,
                               :userid   => 'admin',
                               :password => 'password',
@@ -31,7 +32,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
     pim = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "https://10.243.9.123",
-                             :ipaddress => "https://10.243.9.123")
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
     auth = FactoryGirl.create(:authentication,
                               :userid   => 'admin',
                               :password => 'password',
@@ -50,7 +52,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
     pim = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "https://10.243.9.123",
-                             :ipaddress => "https://10.243.9.123")
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
     auth = FactoryGirl.create(:authentication,
                               :userid   => 'admin',
                               :password => 'password',
@@ -69,7 +72,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
     pim = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "https://10.243.9.123",
-                             :ipaddress => "https://10.243.9.123")
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
     auth = FactoryGirl.create(:authentication,
                               :userid   => 'admin',
                               :password => 'password',
@@ -88,7 +92,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
     pim = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "https://10.243.9.123",
-                             :ipaddress => "https://10.243.9.123")
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
     auth = FactoryGirl.create(:authentication,
                               :userid   => 'admin',
                               :password => 'password',
@@ -107,7 +112,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
     pim = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "https://10.243.9.123",
-                             :ipaddress => "https://10.243.9.123")
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
     auth = FactoryGirl.create(:authentication,
                               :userid   => 'admin',
                               :password => 'password',
@@ -120,7 +126,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
   end
 
   it 'will execute discover successfully' do
-    result = described_class.new.class.discover(@auth[:user], @auth[:pass], @auth[:host])
+    result = described_class.new.class.discover(@auth[:user], @auth[:pass], @auth[:host], @auth[:port])
     expect(result).to eq([])
   end
 


### PR DESCRIPTION
This PR makes it possible use API Port passed in the interface form to the Client connection.
Depends on https://github.com/lenovo/xclarity_client/pull/32