### PR TITLE
Create provider discovery feature.

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -49,14 +49,17 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
     # Factory method to create EmsLenovo with instances
     #   or images for the given authentication.  Created EmsLenovo instances
     #   will automatically have EmsRefreshes queued up.
-    def discover(username, password, host, verify_ssl = 0)
-      new_emses = []
+    def discover(ipAddress, port)
+      require 'xclarity_client'
 
-      raw_connect(username, password, host, verify_ssl)
+      if XClarityClient::Discover.responds?(ipAddress, port)
+        new_ems = create!(
+            :name => "Discovered Provider #{ManageIQ::Providers::Lenovo::PhysicalInfraManager.count + 1}",
+            :hostname => ipAddress
+        )
+      end
 
-      EmsRefresh.queue_refresh(new_emses) unless new_emses.blank?
-
-      new_emses
+      EmsRefresh.queue_refresh(new_ems) unless new_ems.blank?
     end
 
     def discover_queue(username, password, zone = nil)

--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -71,19 +71,19 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
       EmsRefresh.queue_refresh(new_ems) unless new_ems.blank?
     end
 
-    def discover_queue(username, password, zone = nil)
+    def discover_queue(ip_address, port, zone = nil)
       MiqQueue.put(
         :class_name  => name,
         :method_name => "discover_from_queue",
-        :args        => [username, MiqPassword.encrypt(password)],
+        :args        => [ip_address, port],
         :zone        => zone
       )
     end
 
     private
 
-    def discover_from_queue(username, password)
-      discover(username, '')
+    def discover_from_queue(ip_address, port)
+      discover(ip_address, port)
     end
 
     def create_default_authentications(ems)

--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -15,5 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "xclarity_client", "~> 0.4.1"
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
+  s.add_development_dependency "webmock", "~> 2.1.0"
   s.add_development_dependency "simplecov"
+  s.add_dependency "faker", "~>1.8.3"
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
@@ -146,24 +146,24 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
   context 'valid discover' do
     before :each do
       EvmSpecHelper.local_miq_server(:zone => Zone.seed)
-      @port = Random.rand(10000).to_s
+      @port = Random.rand(10_000).to_s
       @address = URI('https://' + Faker::Internet.ip_v4_address + ':' + @port)
       WebMock.allow_net_connect!
       stub_request(:get, File.join(@address.to_s, '/aicc')).to_return(:status => [200, 'OK'])
     end
 
     it 'should create a new instance' do
-      expect{described_class.discover(@address.host, @port)}.to change{described_class.count}.by 1
+      expect { described_class.discover(@address.host, @port) }.to change { described_class.count }.by 1
     end
   end
 
   context 'invalid discover' do
     before :each do
-      @port = Random.rand(10000).to_s
+      @port = Random.rand(10_000).to_s
       @address = URI('https://' + Faker::Internet.ip_v4_address + ':' + @port)
     end
     it 'should not create a new instance' do
-      expect{described_class.discover(@address.host, @port)}.to change{described_class.count}.by 0
+      expect { described_class.discover(@address.host, @port) }.to change { described_class.count }.by 0
     end
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
@@ -1,4 +1,5 @@
 require 'xclarity_client'
+require 'faker'
 
 describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
   before :all do
@@ -119,11 +120,6 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
     end
   end
 
-  it 'will execute discover successfully' do
-    result = described_class.new.class.discover(@auth[:user], @auth[:pass], @auth[:host])
-    expect(result).to eq([])
-  end
-
   it 'will execute discover_queue successfully' do
     result = described_class.new.class.discover_queue(@auth[:user], @auth[:pass])
     expect(result).to_not eq(nil)
@@ -145,5 +141,29 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
   it 'connect should return a XClarityClient::Client object' do
     client = described_class.new.connect(@auth)
     expect(client).to be_a(XClarityClient::Client)
+  end
+
+  context 'valid discover' do
+    before :each do
+      EvmSpecHelper.local_miq_server(:zone => Zone.seed)
+      @port = Random.rand(10000).to_s
+      @address = URI('https://' + Faker::Internet.ip_v4_address + ':' + @port)
+      WebMock.allow_net_connect!
+      stub_request(:get, File.join(@address.to_s, '/aicc')).to_return(:status => [200, 'OK'])
+    end
+
+    it 'should create a new instance' do
+      expect{described_class.discover(@address.host, @port)}.to change{described_class.count}.by 1
+    end
+  end
+
+  context 'invalid discover' do
+    before :each do
+      @port = Random.rand(10000).to_s
+      @address = URI('https://' + Faker::Internet.ip_v4_address + ':' + @port)
+    end
+    it 'should not create a new instance' do
+      expect{described_class.discover(@address.host, @port)}.to change{described_class.count}.by 0
+    end
   end
 end


### PR DESCRIPTION
This Pull Request implement the discovery function for lenovo provider.

The idea is that, by receiving the ip + port, the function calls LXCA client in order to check if the params represents an appliance.

After that, it's created a new EMS instance and set all authentication with empty values. After the EMS in added, the user should update information via UI, then refreshing relationships.

Depends on: https://github.com/ManageIQ/manageiq-providers-lenovo/pull/66