### PR TITLE
remove descendant loader initializer

### DIFF
--- a/config/initializers/descendant_loader.rb
+++ b/config/initializers/descendant_loader.rb
@@ -1,2 +1,0 @@
-# make sure STI models are recognized
-DescendantLoader.instance.descendants_paths << ManageIQ::Providers::Lenovo::Engine.config.root.join('app/models')


### PR DESCRIPTION
because it is automatically done from the core