### PR TITLE
Pass port to refresh parser spec tests

### DIFF
--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -23,7 +23,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
     pim = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "https://10.243.9.123",
-                             :ipaddress => "https://10.243.9.123")
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
     auth = FactoryGirl.create(:authentication,
                               :userid   => 'admin',
                               :password => 'password',


### PR DESCRIPTION
This Pull Request fix the bug in the spec tests, where the API port is not passed in the second refresh parser test case.