### PR TITLE
Discover ip address and name server of the physical infra provider

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -17,4 +17,11 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   def self.description
     @description ||= "Lenovo XClarity"
   end
+
+  def hostname_ipaddress?(hostname)
+    IPAddr.new(hostname)
+    return true
+  rescue
+    return false
+  end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -42,6 +42,7 @@ module ManageIQ::Providers::Lenovo
       $log.info("#{log_header}...")
 
       get_physical_servers
+      discover_ip_physical_infra
 
       $log.info("#{log_header}...Complete")
 
@@ -335,6 +336,30 @@ module ManageIQ::Providers::Lenovo
       end
 
       loc_led_state
+    end
+
+    def discover_ip_physical_infra
+      hostname = URI.parse(@ems.hostname).host || URI.parse(@ems.hostname).path
+      if @ems.ipaddress.blank?
+        resolve_ip_address(hostname, @ems)
+      end
+      if @ems.hostname_ipaddress?(hostname)
+        resolve_hostname(hostname, @ems)
+      end
+    end
+
+    def resolve_hostname(ipaddress, ems)
+      ems.hostname = Resolv.getname(ipaddress)
+      $log.info("EMS ID: #{ems.id}" + " Resolved hostname successfully.")
+    rescue => err
+      $log.warn("EMS ID: #{ems.id}" + " It's not possible resolve hostname of the physical infra, #{err}.")
+    end
+
+    def resolve_ip_address(hostname, ems)
+      ems.ipaddress = Resolv.getaddress(hostname)
+      $log.info("EMS ID: #{ems.id}" + " Resolved ip address successfully.")
+    rescue => err
+      $log.warn("EMS ID: #{ems.id}" + " It's not possible resolve ip address of the physical infra, #{err}.")
     end
   end
 end


### PR DESCRIPTION
This PR is able to:
 - Discover the Ip address and name server of the physical infra provider Lenovo.
![provider_before](https://user-images.githubusercontent.com/12627705/28730477-bb798434-73a6-11e7-92dc-947fa79cae16.png)
After the refresh: 
![provider_after_discover](https://user-images.githubusercontent.com/12627705/28730476-bb770a42-73a6-11e7-9a69-33f67f4de36b.png)

