### PR TITLE
Fix refresh PhysicalServer subclass error

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -269,7 +269,7 @@ module ManageIQ::Providers::Lenovo
 
     def parse_physical_server(node)
       new_result = {
-        :type                   => ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer.name,
+        :type                   => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer",
         :name                   => node.name,
         :ems_ref                => node.uuid,
         :uid_ems                => @ems.uid_ems,


### PR DESCRIPTION
This change fixes the following error which occurs during refresh:

PhysicalServer is not a subclass of ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer

Apparently, the name method was removed from PhysicalServer some time ago, but the method was still being accessed by the refresh_parser.