### PR TITLE
Change device_type from 'ethernet port' to 'physical_port'

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -252,7 +252,7 @@ module ManageIQ::Providers::Lenovo
 
     def parse_physical_port(port)
       {
-        :device_type => "ethernet port",
+        :device_type => "physical_port",
         :device_name => "Physical Port #{port['physicalPortIndex']}"
       }
     end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -50,7 +50,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
     expect(guest_device[:location]).to eq("Bay 7")
 
     expect(guest_device[:child_devices][0][:address]).to eq("00:0A:F7:25:67:38")
-    expect(guest_device[:child_devices][0][:device_type]).to eq("ethernet port")
+    expect(guest_device[:child_devices][0][:device_type]).to eq("physical_port")
     expect(guest_device[:child_devices][0][:device_name]).to eq("Physical Port 1")
   end
 


### PR DESCRIPTION
Updated the device_type for ethernet ports to be 'physical_port' instead of 'ethernet port' due to pending changes in the model.