### PR TITLE
Fix physical server cascading deletion on deleting a Physical provider

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -1,5 +1,5 @@
 class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::PhysicalInfraManager
-  has_many :physical_servers, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer"
+  has_many :physical_servers, :foreign_key => "ems_id", :class_name => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer", :dependent => :destroy
 
   include ManageIQ::Providers::Lenovo::ManagerMixin
   include_concern 'Operations'


### PR DESCRIPTION
Adds `:dependent => :destroy` in the Physical server relationship.

Fixes https://github.com/ManageIQ/manageiq/issues/15925