### PR TITLE
Fixed the filter of the  event catcher

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
@@ -56,6 +56,6 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher::Stream
   end
 
   def get_last_cnn_from_events(ems_id)
-    EventStream.where(:ems_id => ems_id).select(:full_data).map { |event| event.full_data["cn"].to_i }.max
+    EventStream.where(:ems_id => ems_id).select(:full_data).map { |event| event.full_data["cn"].to_i }.max || 1
   end
 end


### PR DESCRIPTION
This PR is able to:
- Fix the filter of event catcher

The problem is when occurs the first refresh the method `get_last_cnn_from_events`  return `nil` and this break the filter make doing the REST API return all events.