### PR TITLE
Fix to switch connection type

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
 
   AUTH_TYPES = {
     'default' => 'token',
-    nil       => 'token'
+    nil       => 'basic_auth'
   }.freeze
 
   def description

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -1,70 +1,60 @@
 describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
-  context 'refresh parser' do
-    host = 'https://10.243.9.123'
-    uri = '/sessions'
+  it 'will retrieve physical servers' do
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
+    rp = described_class.new(pim)
 
-    before do
-      WebMock.allow_net_connect!
-      stub_request(:post, File.join(host, uri)).to_return(:status => [200, 'OK'])
+    result = VCR.use_cassette("#{described_class.name.underscore}_ems_inv_to_hashes") do
+      rp.ems_inv_to_hashes
     end
 
-    it 'will retrieve physical servers' do
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123:443")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
-      rp = described_class.new(pim)
+    expect(result[:physical_servers].size).to eq(4)
+  end
 
-      result = VCR.use_cassette("#{described_class.name.underscore}_ems_inv_to_hashes") do
-        rp.ems_inv_to_hashes
-      end
+  it 'will retrieve addin cards on the physical servers' do
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123:443")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
+    rp = described_class.new(pim)
 
-      expect(result[:physical_servers].size).to eq(4)
+    result = VCR.use_cassette("#{described_class.name.underscore}_retrieve_addin_cards") do
+      rp.ems_inv_to_hashes
     end
 
-    it 'will retrieve addin cards on the physical servers' do
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123:443")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
-      rp = described_class.new(pim)
+    physical_server = result[:physical_servers][0]
+    computer_system = physical_server[:computer_system]
+    hardware = computer_system[:hardware]
+    guest_device = hardware[:guest_devices][0]
 
-      result = VCR.use_cassette("#{described_class.name.underscore}_retrieve_addin_cards") do
-        rp.ems_inv_to_hashes
-      end
+    expect(guest_device[:device_name]).to eq("Broadcom 2-port 1GbE NIC Card for IBM")
+    expect(guest_device[:device_type]).to eq("ethernet")
+    expect(guest_device[:firmwares][0][:name]).to eq("Primary 17.4.4.2a-Active")
+    expect(guest_device[:firmwares][0][:version]).to eq("17.4.4.2a")
+    expect(guest_device[:manufacturer]).to eq("IBM")
+    expect(guest_device[:field_replaceable_unit]).to eq("90Y9373")
+    expect(guest_device[:location]).to eq("Bay 7")
 
-      physical_server = result[:physical_servers][0]
-      computer_system = physical_server[:computer_system]
-      hardware = computer_system[:hardware]
-      guest_device = hardware[:guest_devices][0]
+    expect(guest_device[:child_devices][0][:address]).to eq("00:0A:F7:25:67:38")
+    expect(guest_device[:child_devices][0][:device_type]).to eq("physical_port")
+    expect(guest_device[:child_devices][0][:device_name]).to eq("Physical Port 1")
+  end
 
-      expect(guest_device[:device_name]).to eq("Broadcom 2-port 1GbE NIC Card for IBM")
-      expect(guest_device[:device_type]).to eq("ethernet")
-      expect(guest_device[:firmwares][0][:name]).to eq("Primary 17.4.4.2a-Active")
-      expect(guest_device[:firmwares][0][:version]).to eq("17.4.4.2a")
-      expect(guest_device[:manufacturer]).to eq("IBM")
-      expect(guest_device[:field_replaceable_unit]).to eq("90Y9373")
-      expect(guest_device[:location]).to eq("Bay 7")
-
-      expect(guest_device[:child_devices][0][:address]).to eq("00:0A:F7:25:67:38")
-      expect(guest_device[:child_devices][0][:device_type]).to eq("physical_port")
-      expect(guest_device[:child_devices][0][:device_name]).to eq("Physical Port 1")
-    end
-
-    it 'will return its miq_template_type' do
-      expect(described_class.miq_template_type).to eq("ManageIQ::Providers::Lenovo::PhysicalInfraManager::Template")
-    end
+  it 'will return its miq_template_type' do
+    expect(described_class.miq_template_type).to eq("ManageIQ::Providers::Lenovo::PhysicalInfraManager::Template")
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -1,49 +1,39 @@
 describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
-  context 'inventory' do
-    host = 'https://10.243.9.123'
-    uri = '/sessions'
+  let(:auth) do
+    FactoryGirl.create(:authentication,
+                       :userid   => 'admin',
+                       :password => 'password',
+                       :authtype => 'default')
+  end
 
-    before do
-      WebMock.allow_net_connect!
-      stub_request(:post, File.join(host, uri)).to_return(:status => [200, 'OK'])
+  let(:ems) do
+    FactoryGirl.create(:physical_infra,
+                       :name      => "LXCA",
+                       :hostname  => "https://10.243.9.123",
+                       :port      => "443",
+                       :ipaddress => "https://10.243.9.123:443")
+  end
+
+  let(:targets) { [ems] }
+  let(:refresher) { described_class.new(targets) }
+
+  it 'will parse the legacy inventory' do
+    ems.authentications = [auth]
+
+    result = VCR.use_cassette("#{described_class.name.underscore}_parse_legacy_inventory") do
+      refresher.parse_legacy_inventory(ems)
     end
 
-    let(:auth) do
-      FactoryGirl.create(:authentication,
-                         :userid   => 'admin',
-                         :password => 'password',
-                         :authtype => 'default')
-    end
+    expect(result[:physical_servers].size).to eq(3)
+  end
 
-    let(:ems) do
-      FactoryGirl.create(:physical_infra,
-                         :name      => "LXCA",
-                         :hostname  => "https://10.243.9.123",
-                         :port      => "443",
-                         :ipaddress => "https://10.243.9.123:443")
-    end
+  it 'will save the inventory' do
+    ems.authentications = [auth]
 
-    let(:targets) { [ems] }
-    let(:refresher) { described_class.new(targets) }
+    refresher.save_inventory(ems, {}, {})
+  end
 
-    it 'will parse the legacy inventory' do
-      ems.authentications = [auth]
-
-      result = VCR.use_cassette("#{described_class.name.underscore}_parse_legacy_inventory") do
-        refresher.parse_legacy_inventory(ems)
-      end
-
-      expect(result[:physical_servers].size).to eq(3)
-    end
-
-    it 'will save the inventory' do
-      ems.authentications = [auth]
-
-      refresher.save_inventory(ems, {}, {})
-    end
-
-    it 'will execute post_process_refresh_classes' do
-      expect(refresher.post_process_refresh_classes).to eq([])
-    end
+  it 'will execute post_process_refresh_classes' do
+    expect(refresher.post_process_refresh_classes).to eq([])
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
@@ -6,213 +6,203 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
     @auth = { :user => 'admin', :pass => 'smartvm', :host => 'localhost', :port => '3000' }
   end
 
-  context 'operations' do
-    host = 'https://10.243.9.123'
-    uri = '/sessions'
+  it 'will turn on a location LED successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "IMM2-e41f13ed5a1e",
+                            :ems_ref => "BD775D06821111E189A3E41F13ED5A1A")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default',)
+    pim.authentications = [auth]
 
-    before do
-      WebMock.allow_net_connect!
-      stub_request(:post, File.join(host, uri)).to_return(:status => [200, 'OK'])
+    VCR.use_cassette("#{described_class.name.underscore}_turn_on_loc_led") do
+      pim.turn_on_loc_led(ps, :uuid => "BD775D06821111E189A3E41F13ED5A1A")
     end
+  end
 
-    it 'will turn on a location LED successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "IMM2-e41f13ed5a1e",
-                              :ems_ref => "BD775D06821111E189A3E41F13ED5A1A")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default',)
-      pim.authentications = [auth]
+  it 'will turn off a location LED successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "IMM2-e41f13ed5a1e",
+                            :ems_ref => "BD775D06821111E189A3E41F13ED5A1A")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_turn_on_loc_led") do
-        pim.turn_on_loc_led(ps, :uuid => "BD775D06821111E189A3E41F13ED5A1A")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_turn_off_loc_led") do
+      pim.turn_off_loc_led(ps, :uuid => "BD775D06821111E189A3E41F13ED5A1A")
     end
+  end
 
-    it 'will turn off a location LED successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "IMM2-e41f13ed5a1e",
-                              :ems_ref => "BD775D06821111E189A3E41F13ED5A1A")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
+  it 'will blink a location LED successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "IMM2-e41f13ed5a1e",
+                            :ems_ref => "BD775D06821111E189A3E41F13ED5A1A")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_turn_off_loc_led") do
-        pim.turn_off_loc_led(ps, :uuid => "BD775D06821111E189A3E41F13ED5A1A")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_blink_loc_led") do
+      pim.blink_loc_led(ps, :uuid => "BD775D06821111E189A3E41F13ED5A1A")
     end
+  end
 
-    it 'will blink a location LED successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "IMM2-e41f13ed5a1e",
-                              :ems_ref => "BD775D06821111E189A3E41F13ED5A1A")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
+  it 'will power on a server successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "MimmNameDM",
+                            :ems_ref => "EADEBE8316174750A27FEC2E8226AC48")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_blink_loc_led") do
-        pim.blink_loc_led(ps, :uuid => "BD775D06821111E189A3E41F13ED5A1A")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_power_on") do
+      pim.power_on(ps, :uuid => "EADEBE8316174750A27FEC2E8226AC48")
     end
+  end
 
-    it 'will power on a server successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "MimmNameDM",
-                              :ems_ref => "EADEBE8316174750A27FEC2E8226AC48")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
+  it 'will power off a server successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "MimmNameDM",
+                            :ems_ref => "EADEBE8316174750A27FEC2E8226AC48")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_power_on") do
-        pim.power_on(ps, :uuid => "EADEBE8316174750A27FEC2E8226AC48")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_power_off") do
+      pim.power_off(ps, :uuid => "EADEBE8316174750A27FEC2E8226AC48")
     end
+  end
 
-    it 'will power off a server successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "MimmNameDM",
-                              :ems_ref => "EADEBE8316174750A27FEC2E8226AC48")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
+  it 'will immediately power off a server successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "17dspncsvdm",
+                            :ems_ref => "7936DD182C5311E3A8D6000AF7256738")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_power_off") do
-        pim.power_off(ps, :uuid => "EADEBE8316174750A27FEC2E8226AC48")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_power_off_now") do
+      pim.power_off_now(ps, :uuid => "7936DD182C5311E3A8D6000AF7256738")
     end
+  end
 
-    it 'will immediately power off a server successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "17dspncsvdm",
-                              :ems_ref => "7936DD182C5311E3A8D6000AF7256738")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
+  it 'will restart a server successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "MimmNameDM",
+                            :ems_ref => "EADEBE8316174750A27FEC2E8226AC48")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_power_off_now") do
-        pim.power_off_now(ps, :uuid => "7936DD182C5311E3A8D6000AF7256738")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_restart") do
+      pim.restart(ps, :uuid => "EADEBE8316174750A27FEC2E8226AC48")
     end
+  end
 
-    it 'will restart a server successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "MimmNameDM",
-                              :ems_ref => "EADEBE8316174750A27FEC2E8226AC48")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
+  it 'will immediately restart a server successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "17dspncsvdm",
+                            :ems_ref => "7936DD182C5311E3A8D6000AF7256738")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_restart") do
-        pim.restart(ps, :uuid => "EADEBE8316174750A27FEC2E8226AC48")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_restart_now") do
+      pim.restart_now(ps, :uuid => "7936DD182C5311E3A8D6000AF7256738")
     end
+  end
 
-    it 'will immediately restart a server successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "17dspncsvdm",
-                              :ems_ref => "7936DD182C5311E3A8D6000AF7256738")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
+  it 'will restart to system setup successfully' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "17dspncsvdm",
+                            :ems_ref => "7936DD182C5311E3A8D6000AF7256738")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_restart_now") do
-        pim.restart_now(ps, :uuid => "7936DD182C5311E3A8D6000AF7256738")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_restart_to_sys_setup") do
+      pim.restart_to_sys_setup(ps, :uuid => "7936DD182C5311E3A8D6000AF7256738")
     end
+  end
 
-    it 'will restart to system setup successfully' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "17dspncsvdm",
-                              :ems_ref => "7936DD182C5311E3A8D6000AF7256738")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
+  it 'will restart a server\'s management controller' do
+    ps = FactoryGirl.create(:physical_server,
+                            :name    => "17dspncsvdm",
+                            :ems_ref => "7936DD182C5311E3A8D6000AF7256738")
+    pim = FactoryGirl.create(:physical_infra,
+                             :name      => "LXCA",
+                             :hostname  => "https://10.243.9.123",
+                             :port      => "443",
+                             :ipaddress => "https://10.243.9.123")
+    auth = FactoryGirl.create(:authentication,
+                              :userid   => 'admin',
+                              :password => 'password',
+                              :authtype => 'default')
+    pim.authentications = [auth]
 
-      VCR.use_cassette("#{described_class.name.underscore}_restart_to_sys_setup") do
-        pim.restart_to_sys_setup(ps, :uuid => "7936DD182C5311E3A8D6000AF7256738")
-      end
-    end
-
-    it 'will restart a server\'s management controller' do
-      ps = FactoryGirl.create(:physical_server,
-                              :name    => "17dspncsvdm",
-                              :ems_ref => "7936DD182C5311E3A8D6000AF7256738")
-      pim = FactoryGirl.create(:physical_infra,
-                               :name      => "LXCA",
-                               :hostname  => "https://10.243.9.123",
-                               :port      => "443",
-                               :ipaddress => "https://10.243.9.123")
-      auth = FactoryGirl.create(:authentication,
-                                :userid   => 'admin',
-                                :password => 'password',
-                                :authtype => 'default')
-      pim.authentications = [auth]
-
-      VCR.use_cassette("#{described_class.name.underscore}_restart_mgmt_controller") do
-        pim.restart_mgmt_controller(ps, :uuid => "7936DD182C5311E3A8D6000AF7256738")
-      end
+    VCR.use_cassette("#{described_class.name.underscore}_restart_mgmt_controller") do
+      pim.restart_mgmt_controller(ps, :uuid => "7936DD182C5311E3A8D6000AF7256738")
     end
   end
 


### PR DESCRIPTION
This PR is necessary to:
- Change the type of connection depends on the action. 
- Token type should be in use only for the validate button and basic for the others.