### PR TITLE
Add event_id to the event parser and change the query for refresh eve…

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream.rb
@@ -55,6 +55,6 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher::Stream
   end
 
   def get_last_cnn_from_events(ems_id)
-    EventStream.where(:ems_id => ems_id).select(:full_data).map { |event| event.full_data["cn"].to_i }.max
+    EventStream.where(:ems_id => ems_id).maximum('ems_ref') || 1
   end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
@@ -2,6 +2,7 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser
   def self.event_to_hash(event, ems_id)
     event_hash = {
       :event_type         => event.eventID,
+      :ems_ref            => event.cn,
       :source             => "LenovoXclarity",
       :physical_server_id => get_physical_server_id(event.componentID),
       :message            => event.msg,


### PR DESCRIPTION
This PR do:
- Add ems_ref to the event_parser and assign value of `cn`. This attribute is the unique sequential ID for the event for each LXCA. So the `ems_id + ems_ref` are unique for each event in the table `event_streams`.
![captura de tela 2017-09-22 as 15 44 10](https://user-images.githubusercontent.com/2501758/30759569-1de80334-9fad-11e7-93e6-08f8b8834bb6.png)

- Change the query for the refresh events to filter using the ems_ref.

Depends on:
https://github.com/ManageIQ/manageiq-schema/pull/70

This image show why we need to use `cn` attribute to differentiate between events with the same type.
The event from left of the print screen was added to `event_streams` and the right side event not, this occurs because of each identify until now for the event in the MIQ could be the same (ems_id, timestamp, event_type...)
![pasted image at 2017_09_22 03_39 pm](https://user-images.githubusercontent.com/2501758/30759376-5c0c57a6-9fac-11e7-9e2d-529b7f9929be.png)
