### PR TITLE
Fix the lenovo's event_catcher

### DIFF
--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/stream_spec.rb
@@ -8,13 +8,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher::Stream
 
   let(:stream) { described_class.new(ems) }
 
-  it 'will start and stop without any exceptions occurring' do
-    stream.start
+  it 'will stop without any exceptions occurring' do
     stream.stop
-  end
-
-  it 'will return the event monitor handle' do
-    handle = stream.event_monitor_handle
-    expect(handle).not_to eq(nil)
   end
 end


### PR DESCRIPTION
This PR is able to:
- Fix the `monitor_events` problem that was being called twice at the same instant.
- Add support to `event_catcher` not be restarted after the `heartbeat_timeout` was reached.
- Refactor some things in the code.

