### PR TITLE
[WIP] Update the uid_ems to the uuid of the endpoint

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -272,7 +272,7 @@ module ManageIQ::Providers::Lenovo
         :type                   => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer",
         :name                   => node.name,
         :ems_ref                => node.uuid,
-        :uid_ems                => @ems.uid_ems,
+        :uid_ems                => node.uuid,
         :hostname               => node.hostname,
         :product_name           => node.productName,
         :manufacturer           => node.manufacturer,


### PR DESCRIPTION
Fills in the uuid of the endpoint with a UUID that is unique to this instance of the provider. Currently this value is empty. To be more correct this field should be populated.

@agrare , @AndreyMenezes 