### PR TITLE
Adds LXCA event groups for event handling

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser
   def self.event_to_hash(event, ems_id)
     event_hash = {
-      :event_type         => event.eventID,
+      :event_type         => event.msgID,
       :ems_ref            => event.cn,
       :source             => "LenovoXclarity",
       :physical_server_id => get_physical_server_id(event.componentID),

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,74 @@
     :blacklisted_event_names: []
     :event_handling:
       :event_groups:
+        :power:
+          :critical:
+          - 'CMM0157'
+          - 'IMM0015'
+          - 'FQXHMDM0125I'
+          - 'PLAT0106'
+          - 'PLAT0107'
+          - 'PLAT0108'
+          :detail: []
+          :name: Power Activity
+        :firmware:
+          :critical:
+          - '806F072B2201FFFF'
+          - '000AB001'
+          - '000AB002'
+          - '000AB003'
+          - '000AB004'
+          - '000AB005'
+          - '000AB006'
+          - '000AB007'
+          - '000AB008'
+          - '000AB009'
+          - '00015105'
+          - '0EA02101'
+          - '0EA02102'
+          - '0EA02103'
+          - '0EA02104'
+          - '00015101'
+          - 'FQXHMUP4007I'
+          - '00017310'
+          - '00017129'
+          - '00015103'
+          - '806F072B2101FFFF'
+          - '806F072B2201FFFF'
+          - 'FQXHMUP4006I'
+          - 'FQXHMUP4007I'
+          - 'FQXHMUP4008I'
+          :detail: []
+          :name: Firmware
+        :devices:
+          :critical:
+          - 'CMM0100'
+          - 'PLAT0162'
+          - 'PLAT0456'
+          - 'PLAT0084'
+          - 'CMM0101'
+          - 'PLAT0163'
+          - 'PLAT0457'
+          - 'PLAT0085'
+          - 'CMM0102'
+          - '806F000D0401FFFF'
+          - '806F000D0402FFFF'
+          - '806F000D0403FFFF'
+          - '806F000D0404FFFF'
+          - '806F000D0405FFFF'
+          - '806F000D0406FFFF'
+          - '806F000D0407FFFF'
+          - '816F000D0400FFFF'
+          - '816F000D0401FFFF'
+          - '816F000D0402FFFF'
+          - '816F000D0403FFFF'
+          - '816F000D0404FFFF'
+          - '816F000D0405FFFF'
+          - '816F000D0406FFFF'
+          - '816F000D0407FFFF'
+          - 'IMM0072'
+          :detail: []
+          :name: Devices
 :http_proxy:
   :lenovo:
     :host:

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_parser_spec.rb
@@ -3,7 +3,7 @@ require 'xclarity_client'
 describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser do
   let(:event_attrs1) do
     {
-      :eventID            => 1,
+      :msgID              => 1,
       :source             => "LenovoXclarity",
       :msg                => "This is a test event.",
       :timeStamp          => "2017-04-26T13:55:49.749552",


### PR DESCRIPTION
This PR adds the custom LXCA event groups for filtering on physical server timelines. 
[Physical Server Events Filtering.pdf](https://github.com/ManageIQ/manageiq-providers-lenovo/files/1371973/Physical.Server.Events.Filtering.pdf)

