### PR TITLE
Cleanup duplicate refresher methods

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
@@ -9,14 +9,5 @@ module ManageIQ::Providers::Lenovo
 
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
     end
-
-    def save_inventory(ems, target, hashes)
-      EmsRefresh.save_ems_inventory(ems, hashes)
-    end
-
-    def post_process_refresh_classes
-      []
-    end
-
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -30,7 +30,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
   it 'will save the inventory' do
     ems.authentications = [auth]
 
-    refresher.save_inventory(ems, {}, {})
+    refresher.save_inventory(ems, nil, {})
   end
 
   it 'will execute post_process_refresh_classes' do


### PR DESCRIPTION
These two methods are duplicates of what is in the refresher mixin so
they can be removed

cc @Ladas