### PR TITLE
Add support to the fix created in the client

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -28,7 +28,7 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
 
   def verify_credentials(auth_type = nil, options = {})
     raise MiqException::MiqHostError, "No credentials defined" if missing_credentials?(auth_type)
-    options[:auth_type] = auth_type
+    options[:auth_type] = auth_type.nil? ? 'default' : auth_type.to_s
 
     self.class.connection_rescue_block do
       with_provider_connection(options) do |lxca|


### PR DESCRIPTION
This pr is able to:
Fix the provider to support the new refactor created in the `xclarity_client`.


Depends on: [PR 58 Xclarity_client ](https://github.com/lenovo/xclarity_client/pull/58)