### PR TITLE
searches the hardware resource for a relationship

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/parser.rb
@@ -94,7 +94,8 @@ module ManageIQ::Providers::Lenovo
     # Assign a physicalserver and host if server already exists and
     # some host match with physical Server's serial number
     def get_host_relationship(serial_number)
-      Host.find_by(:service_tag => serial_number)
+      Host.find_by(:service_tag => serial_number) ||
+        Host.joins(:hardware).find_by('hardwares.serial_number' => serial_number)
     end
 
     # Find the identification led state

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -58,7 +58,119 @@ module ManageIQ::Providers::Lenovo
 
     def get_config_patterns
       config_patterns = @connection.discover_config_pattern
-      process_collection(config_patterns, :customization_scripts) { |config_pattern| @parser.parse_config_pattern(config_pattern) }
+      process_collection(config_patterns, :customization_scripts) { |config_pattern| parse_config_pattern(config_pattern) }
+    end
+
+    def parse_firmware(firmware)
+      {
+        :name         => "#{firmware["role"]} #{firmware["name"]}-#{firmware["status"]}",
+        :build        => firmware["build"],
+        :version      => firmware["version"],
+        :release_date => firmware["date"],
+      }
+    end
+
+    def parse_management_device(node)
+      {
+        :device_type => "management",
+        :network     => parse_management_network(node),
+        :address     => node.macAddress
+      }
+    end
+
+    def parse_management_network(node)
+      {
+        :ipaddress   => node.mgmtProcIPaddress,
+        :ipv6address => node.ipv6Addresses.nil? ? node.ipv6Addresses : node.ipv6Addresses.join(", ")
+      }
+    end
+
+    def parse_addin_cards(addin_card)
+      {
+        :device_name            => addin_card["productName"],
+        :device_type            => get_device_type(addin_card),
+        :firmwares              => get_guest_device_firmware(addin_card),
+        :manufacturer           => addin_card["manufacturer"],
+        :field_replaceable_unit => addin_card["FRU"],
+        :location               => "Bay #{addin_card['slotNumber']}",
+        :child_devices          => get_guest_device_ports(addin_card)
+      }
+    end
+
+    def parse_onboard_devices(onboard_device)
+      {
+        :device_name   => onboard_device["name"],
+        :device_type   => get_device_type(onboard_device),
+        :firmwares     => get_guest_device_firmware(onboard_device),
+        :location      => "Onboard",
+        :child_devices => get_guest_device_ports(onboard_device)
+      }
+    end
+
+    def parse_physical_port(port)
+      {
+        :device_type => "physical_port",
+        :device_name => "Physical Port #{port['physicalPortIndex']}"
+      }
+    end
+
+    def parse_logical_port(port)
+      {
+        :address => format_mac_address(port["addresses"])
+      }
+    end
+
+    def format_mac_address(mac_address)
+      mac_address.scan(/\w{2}/).join(":")
+    end
+
+    def parse_physical_server(node)
+      new_result = {
+        :type                   => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer",
+        :name                   => node.name,
+        :ems_ref                => node.uuid,
+        :uid_ems                => node.uuid,
+        :hostname               => node.hostname,
+        :product_name           => node.productName,
+        :manufacturer           => node.manufacturer,
+        :machine_type           => node.machineType,
+        :model                  => node.model,
+        :serial_number          => node.serialNumber,
+        :field_replaceable_unit => node.FRU,
+        :host                   => get_host_relationship(node),
+        :power_state            => POWER_STATE_MAP[node.powerStatus],
+        :health_state           => HEALTH_STATE_MAP[node.cmmHealthState.nil? ? node.cmmHealthState : node.cmmHealthState.downcase],
+        :vendor                 => "lenovo",
+        :computer_system        => {
+          :hardware => {
+            :guest_devices => [],
+            :firmwares     => [] # Filled in later conditionally on what's available
+          }
+        },
+        :asset_details          => parse_asset_details(node),
+        :location_led_state    	=> find_loc_led_state(node.leds)
+      }
+      new_result[:computer_system][:hardware] = get_hardwares(node)
+      return node.uuid, new_result
+    end
+
+    def parse_config_pattern(config_pattern)
+      new_result =
+        {
+          :manager_ref  => config_pattern.id,
+          :name         => config_pattern.name,
+          :description  => config_pattern.description,
+          :user_defined => config_pattern.userDefined,
+          :in_use       => config_pattern.inUse
+        }
+      return config_pattern.id, new_result
+    end
+
+    def get_host_relationship(node)
+      # Assign a physicalserver and host if server already exists and
+      # some host match with physical Server's serial number
+      Host.find_by(:service_tag => node.serialNumber) ||
+        Host.joins(:hardware).find_by('hardwares.serial_number' => node.serialNumber)
     end
 
     def all_server_resources


### PR DESCRIPTION
To address the bug:  https://bugzilla.redhat.com/show_bug.cgi?id=1505590

Host relationships are not created to the RHEV VM instances because the service_tag field in the host table is not set. This value is set in the hardwares table associated with the host.   Joining the two tables to find the hardwares.serial_number field that matches the physical server this host is sitting on.

@miq-bot add_label wip