### PR TITLE
Add port to new_ems in discover method

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -88,7 +88,8 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
         new_ems = create!(
           :name     => "Discovered Provider ##{count + 1}",
           :hostname => URI('https://' + ip_address),
-          :zone     => Zone.default_zone
+          :zone     => Zone.default_zone,
+          :port     => port
         )
 
         # Set empty authentications


### PR DESCRIPTION
This PR adds port to new_ems created in discover method. This was necessary because the port was not being included in the provider model, causing an error in the UI when trying to edit any discovered provider.