### PR TITLE
Change the way device type is determined

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -173,8 +173,8 @@ module ManageIQ::Providers::Lenovo
       # Look at the first port's portType to determine if we
       # are dealing with an Ethernet device
       port_info = device["portInfo"]
-      physical_ports = device["portInfo"]["physicalPorts"]
       unless port_info.nil?
+        physical_ports = port_info["physicalPorts"]
         unless physical_ports.nil?
           unless physical_ports.empty?
             port_type = physical_ports[0]["portType"]

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -170,10 +170,18 @@ module ManageIQ::Providers::Lenovo
     def get_device_type(device)
       device_type = ""
 
-      unless device["name"].nil?
-        device_name = device["name"].downcase
-        if device_name.include?("nic") || device_name.include?("ethernet")
-          device_type = "ethernet"
+      # Look at the first port's portType to determine if we
+      # are dealing with an Ethernet device
+      port_info = device["portInfo"]
+      physical_ports = device["portInfo"]["physicalPorts"]
+      unless port_info.nil?
+        unless physical_ports.nil?
+          unless physical_ports.empty?
+            port_type = physical_ports[0]["portType"]
+            if port_type == "ETHERNET"
+              device_type = "ethernet"
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Instead of using the product name to determine the device type, this PR updates the _get_device_type_ method to determine the device type by looking at the port type.