### PR TITLE
Fix exception handing for credential validation on raw_connect

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -50,7 +50,7 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
   end
 
   module ClassMethods
-    def raw_connect(username, password, host, port, auth_type, verify_ssl)
+    def raw_connect(username, password, host, port, auth_type, verify_ssl, validate = false)
       xclarity = XClarityClient::Configuration.new(
         :username   => username,
         :password   => password,
@@ -59,7 +59,11 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
         :auth_type  => auth_type,
         :verify_ssl => verify_ssl
       )
-      XClarityClient::Client.new(xclarity)
+      connection = XClarityClient::Client.new(xclarity)
+
+      connection_rescue_block { validate_connection(connection) } if validate
+
+      connection
     end
 
     def validate_connection(connection)


### PR DESCRIPTION
When provider is added the credentials validation is newly done via `raw_connect` (class method) instead of `verify_credentials` (needed EMS object). Further reading on this change can be found here: ManageIQ/manageiq-ui-classic#1580

This change ensures that exceptions are handled properly, because the `verify_credentials` is not called anymore.

Related: https://github.com/ManageIQ/manageiq-ui-classic/pull/2650
Similar PRs for other providers:
- https://github.com/ManageIQ/manageiq-providers-azure/pull/161
- https://github.com/ManageIQ/manageiq-providers-hawkular/pull/100
- https://github.com/ManageIQ/manageiq-providers-scvmm/pull/41
- https://github.com/ManageIQ/manageiq-providers-google/pull/28
- https://github.com/ManageIQ/manageiq-providers-nuage/pull/40