### PR TITLE
Remove old Lenovo provider objects

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/compute_node.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/compute_node.rb
@@ -1,7 +1,0 @@
-module ManageIQ::Providers
-  class Lenovo::PhysicalInfraManager::ComputeNode < ::ComputeNode
-    def name
-      "xclarity_compute_node"
-    end
-  end
-end


### PR DESCRIPTION
This PR remove computeNode object which was our old node object, and remove storegeNode object that was never used and will not be too.