### PR TITLE
Supporting differents identify leds name of physical servers on refresh

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -372,16 +372,9 @@ module ManageIQ::Providers::Lenovo
     end
 
     def find_loc_led_state(leds)
-      loc_led_state = ""
-      unless leds.nil?
-        leds.each do |led|
-          if led["name"] == "Identify"
-            loc_led_state = led["state"]
-            break
-          end
-        end
-      end
-      loc_led_state
+      identification_led_names = %w(Identify Identification)
+      identification_led = leds.to_a.find { |led| identification_led_names.include?(led["name"]) }
+      identification_led.try(:[], "state")
     end
 
     def discover_ip_physical_infra


### PR DESCRIPTION
This PR is able to:
- Support identify leds with name "identification" on refresh

https://bugzilla.redhat.com/show_bug.cgi?id=1515453