### PR TITLE
Pinning faker gem to 1.8.3

### DIFF
--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "webmock", "~> 2.1.0"
   s.add_development_dependency "simplecov"
-  s.add_dependency "faker", "~>1.8.3"
+  s.add_dependency "faker", "=1.8.3"
 end


### PR DESCRIPTION
faker changed dependency of i18n which conflicts with our dependency from manageiq-consumption:
stympy/faker@9128945#diff-e79a60dc6b85309ae70a6ea8261eaf95R5