### PR TITLE
Add spec test for a full refresh

### DIFF
--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -49,4 +49,31 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
   it 'will execute post_process_refresh_classes' do
     expect(refresher.post_process_refresh_classes).to eq([])
   end
+
+  it 'will perform a full refresh' do
+    # Perform the refresh twice to verify that a second run with existing data
+    # does not change anything
+    2.times do
+      EmsRefresh.refresh(ems)
+      ems.reload
+
+      assert_table_counts
+      assert_guest_table_contents
+    end
+  end
+
+  def assert_table_counts
+    expect(PhysicalServer.count).to eq(2)
+    expect(GuestDevice.count).to eq(5)
+  end
+
+  def assert_guest_table_contents
+    nic = GuestDevice.where(:device_name => "Broadcom 2-port 1GbE NIC Card for IBM").first
+    ports = nic.child_devices
+
+    expect(ports[0].device_name).to eq("Physical Port 1")
+    expect(ports[0].address).to eq("00:0A:F7:25:67:38")
+    expect(ports[1].device_name).to eq("Physical Port 2")
+    expect(ports[1].address).to eq("00:0A:F7:25:67:39")
+  end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -68,12 +68,16 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
   end
 
   def assert_guest_table_contents
-    nic = GuestDevice.where(:device_name => "Broadcom 2-port 1GbE NIC Card for IBM").first
+    server = PhysicalServer.find_by(:ems_ref => "7936DD182C5311E3A8D6000AF7256738")
+    nic = server.hardware.nics.first
     ports = nic.child_devices
+    port1 = ports.find_by(:device_name => "Physical Port 1")
+    port2 = ports.find_by(:device_name => "Physical Port 2")
 
-    expect(ports[0].device_name).to eq("Physical Port 1")
-    expect(ports[0].address).to eq("00:0A:F7:25:67:38")
-    expect(ports[1].device_name).to eq("Physical Port 2")
-    expect(ports[1].address).to eq("00:0A:F7:25:67:39")
+    expect(nic.device_name).to eq("Broadcom 2-port 1GbE NIC Card for IBM")
+    expect(port1.device_name).to eq("Physical Port 1")
+    expect(port1.address).to eq("00:0A:F7:25:67:38")
+    expect(port2.device_name).to eq("Physical Port 2")
+    expect(port2.address).to eq("00:0A:F7:25:67:39")
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -6,6 +6,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
     VCR.insert_cassette("#{vcr_path}/mock_aicc", options)
     VCR.insert_cassette("#{vcr_path}/mock_cabinet", options)
     VCR.insert_cassette("#{vcr_path}/mock_config_patterns", options)
+    VCR.insert_cassette("#{vcr_path}/full_refresh", options)
   end
   after(:all) do
     while VCR.cassettes.last
@@ -28,6 +29,19 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
                              :ipaddress => "https://10.243.9.123:443")
     ems.authentications = [auth]
     ems
+  end
+
+  let(:ems2) do
+    # Note: The hostname below cannot be an IP address because it will
+    #       cause the full refresh test to fail when being executed
+    #       on the Travis CI site.
+    ems2 = FactoryGirl.create(:physical_infra,
+                              :name      => "LXCA2",
+                              :hostname  => "lxcahost",
+                              :port      => "443",
+                              :ipaddress => "https://10.243.9.123:443")
+    ems2.authentications = [auth]
+    ems2
   end
 
   let(:targets) { [ems] }
@@ -54,8 +68,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
     # Perform the refresh twice to verify that a second run with existing data
     # does not change anything
     2.times do
-      EmsRefresh.refresh(ems)
-      ems.reload
+      EmsRefresh.refresh(ems2)
+      ems2.reload
 
       assert_table_counts
       assert_guest_table_contents

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/full_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/full_refresh.yml
@@ -1,0 +1,1208 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://lxcahost/aicc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQQVNTVzByRA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:39:59 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=86400; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline'''
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '1'
+      Content-Type:
+      - application/com.lenovo.lxca-v1.2.2+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ntp":{"servers":[{"v3_key_type":"","authenticated":false,"v3_key":"","v3_key_index":0,"server":"us.pool.ntp.org","version":1}]},"services":[{"id":"core","initd":"xhmc-core","state":0,"pid":2256},{"id":"keydaemon","initd":"lxca-keydaemon","state":4,"pid":-1},{"id":"watchdog","initd":"sympl-watchdog","state":0,"pid":2584},{"id":"apache","initd":"httpd","state":3,"pid":-1},{"id":"network","initd":"network","state":0,"pid":-1},{"id":"ntp","initd":"ntpd","state":0,"pid":2304},{"id":"portreserve","initd":"portreserve","state":3,"pid":-1},{"id":"slp","initd":"slpd","state":0,"pid":1665},{"id":"sftp","initd":"sshd","state":0,"pid":2288},{"id":"xcat","initd":"xcatd","state":3,"pid":-1}],"subscriptions":[{"id":1,"monitor_uri":"/aicc/network/interfaces","uri":"/netchangenotsec","submonitor_uri":""},{"id":2,"monitor_uri":"/aicc","uri":"/ntpNotification","submonitor_uri":"/ntp"},{"id":3,"monitor_uri":"/aicc/network/interfaces","uri":"/osdeployment/rest/internal/event/aicc","submonitor_uri":""}],"service_states":[{"description":"Service
+        is running","state":0},{"description":"Service is dead but PID file exists","state":1},{"description":"Service
+        is dead but lock file exists","state":2},{"description":"Service is not running","state":3},{"description":"Service
+        state is unknown","state":4},{"description":"Special purpose state used to
+        trigger restart through REST","state":191}],"network_interfaces":[{"mac_address":"00:0C:29:85:AC:49","id":"eth0","role":["management"],"ip_addresses":[{"prefix_length":64,"assign_method":"static","ip_linklocal":"true","version":6,"ip":"fe80:0:0:0:20c:29ff:fe85:ac49%2"},{"prefix_length":20,"assign_method":"static","ip_linklocal":"false","version":4,"ip":"10.243.9.123"},{"prefix_length":64,"assign_method":"dhcp","ip_linklocal":"false","version":6,"ip":"0::0%0"}],"rpf":"RFC3704Strict"},{"mac_address":"00:0C:29:85:AC:53","id":"eth1","role":["none"],"ip_addresses":[{"prefix_length":64,"assign_method":"static","ip_linklocal":"true","version":6,"ip":"fe80:0:0:0:20c:29ff:fe85:ac53%3"}],"rpf":"RFC3704Strict"}],"appliance_states":[{"description":"Halt
+        the appliance","runlevel":0},{"description":"Normal operation","runlevel":3},{"description":"Reboot
+        the appliance","runlevel":6}],"date":{"utc_offset":-18000000,"timezones":[{"id":"Etc/GMT+12","display_name":"GMT-12:00","utc_offset_w_dst":-43200000,"daylight_saves":0,"uses_daylight":false,"offset":-43200000,"utc_offset_raw":-43200000},{"id":"Etc/GMT+11","display_name":"GMT-11:00","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"Pacific/Midway","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"Pacific/Niue","display_name":"Niue
+        Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"Pacific/Pago_Pago","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"Pacific/Samoa","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"US/Samoa","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"America/Adak","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"America/Atka","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Etc/GMT+10","display_name":"GMT-10:00","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"HST","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Honolulu","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Johnston","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Rarotonga","display_name":"Cook
+        Is. Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Tahiti","display_name":"Tahiti
+        Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"SystemV/HST10","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"US/Aleutian","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"US/Hawaii","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Marquesas","display_name":"Marquesas
+        Time","utc_offset_w_dst":-34200000,"daylight_saves":0,"uses_daylight":false,"offset":-34200000,"utc_offset_raw":-34200000},{"id":"AST","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Anchorage","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Juneau","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Metlakatla","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Nome","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Sitka","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Yakutat","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"Etc/GMT+9","display_name":"GMT-09:00","utc_offset_w_dst":-32400000,"daylight_saves":0,"uses_daylight":false,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"Pacific/Gambier","display_name":"Gambier
+        Time","utc_offset_w_dst":-32400000,"daylight_saves":0,"uses_daylight":false,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"SystemV/YST9","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":0,"uses_daylight":false,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"SystemV/YST9YDT","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"US/Alaska","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Dawson","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Ensenada","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Los_Angeles","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Santa_Isabel","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Tijuana","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Vancouver","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Whitehorse","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Canada/Pacific","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Canada/Yukon","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Etc/GMT+8","display_name":"GMT-08:00","utc_offset_w_dst":-28800000,"daylight_saves":0,"uses_daylight":false,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Mexico/BajaNorte","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"PST","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"PST8PDT","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Pacific/Pitcairn","display_name":"Pitcairn
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":0,"uses_daylight":false,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"SystemV/PST8","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":0,"uses_daylight":false,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"SystemV/PST8PDT","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"US/Pacific","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"US/Pacific-New","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Boise","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Cambridge_Bay","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Chihuahua","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Creston","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Dawson_Creek","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Denver","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Edmonton","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Fort_Nelson","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Hermosillo","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Inuvik","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Mazatlan","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Ojinaga","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Phoenix","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Shiprock","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Yellowknife","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"Canada/Mountain","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"Etc/GMT+7","display_name":"GMT-07:00","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"MST","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"MST7MDT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"Mexico/BajaSur","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"Navajo","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"PNT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"SystemV/MST7","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"SystemV/MST7MDT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"US/Arizona","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"US/Mountain","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Bahia_Banderas","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Belize","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Chicago","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Costa_Rica","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/El_Salvador","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Guatemala","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Indiana/Knox","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Indiana/Tell_City","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Knox_IN","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Managua","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Matamoros","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Menominee","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Merida","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Mexico_City","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Monterrey","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/North_Dakota/Beulah","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/North_Dakota/Center","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/North_Dakota/New_Salem","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Rainy_River","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Rankin_Inlet","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Regina","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Resolute","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Swift_Current","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Tegucigalpa","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Winnipeg","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"CST","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"CST6CDT","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Canada/Central","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Canada/East-Saskatchewan","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Canada/Saskatchewan","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Chile/EasterIsland","display_name":"Easter
+        Is. Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-21600000},{"id":"Etc/GMT+6","display_name":"GMT-06:00","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Mexico/General","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Pacific/Easter","display_name":"Easter
+        Is. Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-21600000},{"id":"Pacific/Galapagos","display_name":"Galapagos
+        Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"SystemV/CST6","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"SystemV/CST6CDT","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"US/Central","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"US/Indiana-Starke","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Atikokan","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Bogota","display_name":"Colombia
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Cancun","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Cayman","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Coral_Harbour","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Detroit","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Eirunepe","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Fort_Wayne","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Guayaquil","display_name":"Ecuador
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Havana","display_name":"Cuba
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Indianapolis","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Marengo","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Petersburg","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Vevay","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Vincennes","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Winamac","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indianapolis","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Iqaluit","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Jamaica","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Kentucky/Louisville","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Kentucky/Monticello","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Lima","display_name":"Peru
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Louisville","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Montreal","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Nassau","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/New_York","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Nipigon","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Panama","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Pangnirtung","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Port-au-Prince","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Porto_Acre","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Rio_Branco","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Thunder_Bay","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Toronto","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Brazil/Acre","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Canada/Eastern","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Cuba","display_name":"Cuba
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"EST","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"EST5EDT","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Etc/GMT+5","display_name":"GMT-05:00","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"IET","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Jamaica","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"SystemV/EST5","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"SystemV/EST5EDT","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"US/East-Indiana","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"US/Eastern","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"US/Michigan","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Anguilla","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Antigua","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Aruba","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Asuncion","display_name":"Paraguay
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-14400000},{"id":"America/Barbados","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Blanc-Sablon","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Boa_Vista","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Campo_Grande","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Caracas","display_name":"Venezuela
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Cuiaba","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Curacao","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Dominica","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Glace_Bay","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Goose_Bay","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Grand_Turk","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Grenada","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Guadeloupe","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Guyana","display_name":"Guyana
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Halifax","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Kralendijk","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/La_Paz","display_name":"Bolivia
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Lower_Princes","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Manaus","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Marigot","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Martinique","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Moncton","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Montserrat","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Port_of_Spain","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Porto_Velho","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Puerto_Rico","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Santiago","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-14400000},{"id":"America/Santo_Domingo","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Barthelemy","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Kitts","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Lucia","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Thomas","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Vincent","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Thule","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Tortola","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Virgin","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"Antarctica/Palmer","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-14400000},{"id":"Atlantic/Bermuda","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"Brazil/West","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"Canada/Atlantic","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"Chile/Continental","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-14400000},{"id":"Etc/GMT+4","display_name":"GMT-04:00","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"PRT","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"SystemV/AST4","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"SystemV/AST4ADT","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Johns","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-12600000,"utc_offset_raw":-12600000},{"id":"CNT","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-12600000,"utc_offset_raw":-12600000},{"id":"Canada/Newfoundland","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-12600000,"utc_offset_raw":-12600000},{"id":"AGT","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Araguaina","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Buenos_Aires","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Catamarca","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/ComodRivadavia","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Cordoba","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Jujuy","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/La_Rioja","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Mendoza","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Rio_Gallegos","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Salta","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/San_Juan","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/San_Luis","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Tucuman","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Ushuaia","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Bahia","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Belem","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Buenos_Aires","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Catamarca","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Cayenne","display_name":"French
+        Guiana Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Cordoba","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Fortaleza","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Godthab","display_name":"Western
+        Greenland Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Jujuy","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Maceio","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Mendoza","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Miquelon","display_name":"Pierre
+        & Miquelon Standard Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Montevideo","display_name":"Uruguay
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Paramaribo","display_name":"Suriname
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Recife","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Rosario","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Santarem","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Sao_Paulo","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"Antarctica/Rothera","display_name":"Rothera
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"Atlantic/Stanley","display_name":"Falkland
+        Is. Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"BET","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"Brazil/East","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"Etc/GMT+3","display_name":"GMT-03:00","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Noronha","display_name":"Fernando
+        de Noronha Time","utc_offset_w_dst":-7200000,"daylight_saves":0,"uses_daylight":false,"offset":-7200000,"utc_offset_raw":-7200000},{"id":"Atlantic/South_Georgia","display_name":"South
+        Georgia Standard Time","utc_offset_w_dst":-7200000,"daylight_saves":0,"uses_daylight":false,"offset":-7200000,"utc_offset_raw":-7200000},{"id":"Brazil/DeNoronha","display_name":"Fernando
+        de Noronha Time","utc_offset_w_dst":-7200000,"daylight_saves":0,"uses_daylight":false,"offset":-7200000,"utc_offset_raw":-7200000},{"id":"Etc/GMT+2","display_name":"GMT-02:00","utc_offset_w_dst":-7200000,"daylight_saves":0,"uses_daylight":false,"offset":-7200000,"utc_offset_raw":-7200000},{"id":"America/Scoresbysund","display_name":"Eastern
+        Greenland Time","utc_offset_w_dst":-3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-3600000,"utc_offset_raw":-3600000},{"id":"Atlantic/Azores","display_name":"Azores
+        Time","utc_offset_w_dst":-3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-3600000,"utc_offset_raw":-3600000},{"id":"Atlantic/Cape_Verde","display_name":"Cape
+        Verde Time","utc_offset_w_dst":-3600000,"daylight_saves":0,"uses_daylight":false,"offset":-3600000,"utc_offset_raw":-3600000},{"id":"Etc/GMT+1","display_name":"GMT-01:00","utc_offset_w_dst":-3600000,"daylight_saves":0,"uses_daylight":false,"offset":-3600000,"utc_offset_raw":-3600000},{"id":"Africa/Abidjan","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Accra","display_name":"Ghana
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Bamako","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Banjul","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Bissau","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Casablanca","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Africa/Conakry","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Dakar","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/El_Aaiun","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Africa/Freetown","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Lome","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Monrovia","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Nouakchott","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Ouagadougou","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Sao_Tome","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Timbuktu","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"America/Danmarkshavn","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Antarctica/Troll","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":7200000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Canary","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Faeroe","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Faroe","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Madeira","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Reykjavik","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/St_Helena","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Eire","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Etc/GMT","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/GMT+0","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/GMT-0","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/GMT0","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/Greenwich","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/UCT","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/UTC","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/Universal","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/Zulu","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Europe/Belfast","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Dublin","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Guernsey","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Isle_of_Man","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Jersey","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Lisbon","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/London","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"GB","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"GB-Eire","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"GMT","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"GMT0","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Greenwich","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Iceland","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Portugal","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"UCT","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"UTC","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Universal","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"WET","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Zulu","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Algiers","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Bangui","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Brazzaville","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Ceuta","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Douala","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Kinshasa","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Lagos","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Libreville","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Luanda","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Malabo","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Ndjamena","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Niamey","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Porto-Novo","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Tunis","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Windhoek","display_name":"Western
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":3600000},{"id":"Arctic/Longyearbyen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Atlantic/Jan_Mayen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"CET","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"ECT","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Etc/GMT-1","display_name":"GMT+01:00","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Amsterdam","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Andorra","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Belgrade","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Berlin","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Bratislava","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Brussels","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Budapest","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Busingen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Copenhagen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Gibraltar","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Ljubljana","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Luxembourg","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Madrid","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Malta","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Monaco","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Oslo","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Paris","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Podgorica","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Prague","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Rome","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/San_Marino","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Sarajevo","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Skopje","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Stockholm","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Tirane","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Vaduz","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Vatican","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Vienna","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Warsaw","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Zagreb","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Zurich","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"MET","display_name":"Middle
+        Europe Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Poland","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"ART","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Blantyre","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Bujumbura","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Cairo","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Gaborone","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Harare","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Johannesburg","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Kigali","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Lubumbashi","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Lusaka","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Maputo","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Maseru","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Mbabane","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Tripoli","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Amman","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Beirut","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Damascus","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Gaza","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Hebron","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Jerusalem","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Nicosia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Tel_Aviv","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"CAT","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"EET","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Egypt","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Etc/GMT-2","display_name":"GMT+02:00","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Athens","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Bucharest","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Chisinau","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Helsinki","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Kaliningrad","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Kiev","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Mariehamn","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Nicosia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Riga","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Sofia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Tallinn","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Tiraspol","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Uzhgorod","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Vilnius","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Zaporozhye","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Israel","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Libya","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Addis_Ababa","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Asmara","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Asmera","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Dar_es_Salaam","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Djibouti","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Juba","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Kampala","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Khartoum","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Mogadishu","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Nairobi","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Antarctica/Syowa","display_name":"Syowa
+        Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Aden","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Baghdad","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Bahrain","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Istanbul","display_name":"Eastern
+        European Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Kuwait","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Qatar","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Riyadh","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"EAT","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Etc/GMT-3","display_name":"GMT+03:00","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Istanbul","display_name":"Eastern
+        European Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Kirov","display_name":"GMT+03:00","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Minsk","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Moscow","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Simferopol","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Volgograd","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Indian/Antananarivo","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Indian/Comoro","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Indian/Mayotte","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Turkey","display_name":"Eastern
+        European Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"W-SU","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Tehran","display_name":"Iran
+        Standard Time","utc_offset_w_dst":12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":12600000,"utc_offset_raw":12600000},{"id":"Iran","display_name":"Iran
+        Standard Time","utc_offset_w_dst":12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":12600000,"utc_offset_raw":12600000},{"id":"Asia/Baku","display_name":"Azerbaijan
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Dubai","display_name":"Gulf
+        Standard Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Muscat","display_name":"Gulf
+        Standard Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Tbilisi","display_name":"Georgia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Yerevan","display_name":"Armenia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Etc/GMT-4","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Europe/Astrakhan","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Europe/Samara","display_name":"Samara
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Europe/Ulyanovsk","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Indian/Mahe","display_name":"Seychelles
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Indian/Mauritius","display_name":"Mauritius
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Indian/Reunion","display_name":"Reunion
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"NET","display_name":"Armenia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Kabul","display_name":"Afghanistan
+        Time","utc_offset_w_dst":16200000,"daylight_saves":0,"uses_daylight":false,"offset":16200000,"utc_offset_raw":16200000},{"id":"Antarctica/Mawson","display_name":"Mawson
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Aqtau","display_name":"Aqtau
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Aqtobe","display_name":"Aqtobe
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Ashgabat","display_name":"Turkmenistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Ashkhabad","display_name":"Turkmenistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Dushanbe","display_name":"Tajikistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Karachi","display_name":"Pakistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Oral","display_name":"Oral
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Samarkand","display_name":"Uzbekistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Tashkent","display_name":"Uzbekistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Yekaterinburg","display_name":"Yekaterinburg
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Etc/GMT-5","display_name":"GMT+05:00","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Indian/Kerguelen","display_name":"French
+        Southern & Antarctic Lands Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Indian/Maldives","display_name":"Maldives
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"PLT","display_name":"Pakistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Calcutta","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0,"uses_daylight":false,"offset":19800000,"utc_offset_raw":19800000},{"id":"Asia/Colombo","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0,"uses_daylight":false,"offset":19800000,"utc_offset_raw":19800000},{"id":"Asia/Kolkata","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0,"uses_daylight":false,"offset":19800000,"utc_offset_raw":19800000},{"id":"IST","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0,"uses_daylight":false,"offset":19800000,"utc_offset_raw":19800000},{"id":"Asia/Kathmandu","display_name":"Nepal
+        Time","utc_offset_w_dst":20700000,"daylight_saves":0,"uses_daylight":false,"offset":20700000,"utc_offset_raw":20700000},{"id":"Asia/Katmandu","display_name":"Nepal
+        Time","utc_offset_w_dst":20700000,"daylight_saves":0,"uses_daylight":false,"offset":20700000,"utc_offset_raw":20700000},{"id":"Antarctica/Vostok","display_name":"Vostok
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Almaty","display_name":"Alma-Ata
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Bishkek","display_name":"Kirgizstan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Dacca","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Dhaka","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Kashgar","display_name":"Xinjiang
+        Standard Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Omsk","display_name":"Omsk
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Qyzylorda","display_name":"Qyzylorda
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Thimbu","display_name":"Bhutan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Thimphu","display_name":"Bhutan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Urumqi","display_name":"Xinjiang
+        Standard Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"BST","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Etc/GMT-6","display_name":"GMT+06:00","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Indian/Chagos","display_name":"Indian
+        Ocean Territory Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Rangoon","display_name":"Myanmar
+        Time","utc_offset_w_dst":23400000,"daylight_saves":0,"uses_daylight":false,"offset":23400000,"utc_offset_raw":23400000},{"id":"Asia/Yangon","display_name":"Myanmar
+        Time","utc_offset_w_dst":23400000,"daylight_saves":0,"uses_daylight":false,"offset":23400000,"utc_offset_raw":23400000},{"id":"Indian/Cocos","display_name":"Cocos
+        Islands Time","utc_offset_w_dst":23400000,"daylight_saves":0,"uses_daylight":false,"offset":23400000,"utc_offset_raw":23400000},{"id":"Antarctica/Davis","display_name":"Davis
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Bangkok","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Barnaul","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Ho_Chi_Minh","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Hovd","display_name":"Hovd
+        Time","utc_offset_w_dst":25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Jakarta","display_name":"West
+        Indonesia Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Krasnoyarsk","display_name":"Krasnoyarsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Novokuznetsk","display_name":"Krasnoyarsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Novosibirsk","display_name":"Novosibirsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Phnom_Penh","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Pontianak","display_name":"West
+        Indonesia Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Saigon","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Tomsk","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Vientiane","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Etc/GMT-7","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Indian/Christmas","display_name":"Christmas
+        Island Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"VST","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Antarctica/Casey","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Brunei","display_name":"Brunei
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Choibalsan","display_name":"Choibalsan
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Chongqing","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Chungking","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Harbin","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Hong_Kong","display_name":"Hong
+        Kong Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Irkutsk","display_name":"Irkutsk
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Kuala_Lumpur","display_name":"Malaysia
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Kuching","display_name":"Malaysia
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Macao","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Macau","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Makassar","display_name":"Central
+        Indonesia Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Manila","display_name":"Philippines
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Shanghai","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Singapore","display_name":"Singapore
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Taipei","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Ujung_Pandang","display_name":"Central
+        Indonesia Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Ulaanbaatar","display_name":"Ulaanbaatar
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Ulan_Bator","display_name":"Ulaanbaatar
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":28800000,"utc_offset_raw":28800000},{"id":"Australia/Perth","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Australia/West","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"CTT","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Etc/GMT-8","display_name":"GMT+08:00","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Hongkong","display_name":"Hong
+        Kong Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"PRC","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Singapore","display_name":"Singapore
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Pyongyang","display_name":"Korea
+        Standard Time","utc_offset_w_dst":30600000,"daylight_saves":0,"uses_daylight":false,"offset":30600000,"utc_offset_raw":30600000},{"id":"Australia/Eucla","display_name":"Australian
+        Central Western Standard Time","utc_offset_w_dst":31500000,"daylight_saves":0,"uses_daylight":false,"offset":31500000,"utc_offset_raw":31500000},{"id":"Asia/Chita","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Dili","display_name":"Timor-Leste
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Jayapura","display_name":"East
+        Indonesia Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Khandyga","display_name":"Khandyga
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Seoul","display_name":"Korea
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Tokyo","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Yakutsk","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Etc/GMT-9","display_name":"GMT+09:00","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"JST","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Japan","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Pacific/Palau","display_name":"Palau
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"ROK","display_name":"Korea
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"ACT","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0,"uses_daylight":false,"offset":34200000,"utc_offset_raw":34200000},{"id":"Australia/Adelaide","display_name":"Australian
+        Central Standard Time (South Australia)","utc_offset_w_dst":37800000,"daylight_saves":3600000,"uses_daylight":true,"offset":37800000,"utc_offset_raw":34200000},{"id":"Australia/Broken_Hill","display_name":"Australian
+        Central Standard Time (South Australia/New South Wales)","utc_offset_w_dst":37800000,"daylight_saves":3600000,"uses_daylight":true,"offset":37800000,"utc_offset_raw":34200000},{"id":"Australia/Darwin","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0,"uses_daylight":false,"offset":34200000,"utc_offset_raw":34200000},{"id":"Australia/North","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0,"uses_daylight":false,"offset":34200000,"utc_offset_raw":34200000},{"id":"Australia/South","display_name":"Australian
+        Central Standard Time (South Australia)","utc_offset_w_dst":37800000,"daylight_saves":3600000,"uses_daylight":true,"offset":37800000,"utc_offset_raw":34200000},{"id":"Australia/Yancowinna","display_name":"Australian
+        Central Standard Time (South Australia/New South Wales)","utc_offset_w_dst":37800000,"daylight_saves":3600000,"uses_daylight":true,"offset":37800000,"utc_offset_raw":34200000},{"id":"AET","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Antarctica/DumontDUrville","display_name":"Dumont-d''Urville
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Asia/Ust-Nera","display_name":"Ust-Nera
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Asia/Vladivostok","display_name":"Vladivostok
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/ACT","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Brisbane","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/Canberra","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Currie","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Hobart","display_name":"Australian
+        Eastern Standard Time (Tasmania)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Lindeman","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/Melbourne","display_name":"Australian
+        Eastern Standard Time (Victoria)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/NSW","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Queensland","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/Sydney","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Tasmania","display_name":"Australian
+        Eastern Standard Time (Tasmania)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Victoria","display_name":"Australian
+        Eastern Standard Time (Victoria)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Etc/GMT-10","display_name":"GMT+10:00","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Chuuk","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Guam","display_name":"Chamorro
+        Standard Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Port_Moresby","display_name":"Papua
+        New Guinea Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Saipan","display_name":"Chamorro
+        Standard Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Truk","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Yap","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/LHI","display_name":"Lord
+        Howe Standard Time","utc_offset_w_dst":39600000,"daylight_saves":1800000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":37800000},{"id":"Australia/Lord_Howe","display_name":"Lord
+        Howe Standard Time","utc_offset_w_dst":39600000,"daylight_saves":1800000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":37800000},{"id":"Antarctica/Macquarie","display_name":"Macquarie
+        Island Standard Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Asia/Magadan","display_name":"Magadan
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Asia/Sakhalin","display_name":"Sakhalin
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Asia/Srednekolymsk","display_name":"Srednekolymsk
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Etc/GMT-11","display_name":"GMT+11:00","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Bougainville","display_name":"Bougainville
+        Standard Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Efate","display_name":"Vanuatu
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Guadalcanal","display_name":"Solomon
+        Is. Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Kosrae","display_name":"Kosrae
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Norfolk","display_name":"Norfolk
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Noumea","display_name":"New
+        Caledonia Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Pohnpei","display_name":"Pohnpei
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Ponape","display_name":"Pohnpei
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"SST","display_name":"Solomon
+        Is. Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Antarctica/McMurdo","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"Antarctica/South_Pole","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"Asia/Anadyr","display_name":"Anadyr
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Asia/Kamchatka","display_name":"Petropavlovsk-Kamchatski
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Etc/GMT-12","display_name":"GMT+12:00","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Kwajalein","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"NST","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"NZ","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"Pacific/Auckland","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"Pacific/Fiji","display_name":"Fiji
+        Time","utc_offset_w_dst":43200000,"daylight_saves":3600000,"uses_daylight":true,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Funafuti","display_name":"Tuvalu
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Kwajalein","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Majuro","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Nauru","display_name":"Nauru
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Tarawa","display_name":"Gilbert
+        Is. Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Wake","display_name":"Wake
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Wallis","display_name":"Wallis
+        & Futuna Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"NZ-CHAT","display_name":"Chatham
+        Standard Time","utc_offset_w_dst":49500000,"daylight_saves":3600000,"uses_daylight":true,"offset":49500000,"utc_offset_raw":45900000},{"id":"Pacific/Chatham","display_name":"Chatham
+        Standard Time","utc_offset_w_dst":49500000,"daylight_saves":3600000,"uses_daylight":true,"offset":49500000,"utc_offset_raw":45900000},{"id":"Etc/GMT-13","display_name":"GMT+13:00","utc_offset_w_dst":46800000,"daylight_saves":0,"uses_daylight":false,"offset":46800000,"utc_offset_raw":46800000},{"id":"MIT","display_name":"West
+        Samoa Standard Time","utc_offset_w_dst":50400000,"daylight_saves":3600000,"uses_daylight":true,"offset":50400000,"utc_offset_raw":46800000},{"id":"Pacific/Apia","display_name":"West
+        Samoa Standard Time","utc_offset_w_dst":50400000,"daylight_saves":3600000,"uses_daylight":true,"offset":50400000,"utc_offset_raw":46800000},{"id":"Pacific/Enderbury","display_name":"Phoenix
+        Is. Time","utc_offset_w_dst":46800000,"daylight_saves":0,"uses_daylight":false,"offset":46800000,"utc_offset_raw":46800000},{"id":"Pacific/Fakaofo","display_name":"Tokelau
+        Time","utc_offset_w_dst":46800000,"daylight_saves":0,"uses_daylight":false,"offset":46800000,"utc_offset_raw":46800000},{"id":"Pacific/Tongatapu","display_name":"Tonga
+        Time","utc_offset_w_dst":46800000,"daylight_saves":0,"uses_daylight":false,"offset":46800000,"utc_offset_raw":46800000},{"id":"Etc/GMT-14","display_name":"GMT+14:00","utc_offset_w_dst":50400000,"daylight_saves":0,"uses_daylight":false,"offset":50400000,"utc_offset_raw":50400000},{"id":"Pacific/Kiritimati","display_name":"Line
+        Is. Time","utc_offset_w_dst":50400000,"daylight_saves":0,"uses_daylight":false,"offset":50400000,"utc_offset_raw":50400000}],"timezone":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"timezone_id":"America/New_York","parts":{"dd":8,"mm":3,"secs":59,"hours":15,"yyyy":2018,"mins":39},"uses_daylight":true,"date_time":"March
+        8, 2018 3:39:59 PM EST","utc_offset_raw":-18000000},"appliance":{"status":"Normal","name":"LXCA
+        - fe80:0:0:0:20c:29ff:fe85:ac49%2","uuid":"20fede5f-721f-4a73-b507-e06d823d677e","build":"162","date":"2016-11-22_06-49-00","runlevel":3,"version":"1.2.2"}}'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:39:59 GMT
+- request:
+    method: get
+    uri: https://lxcahost/cabinet?status=includestandalone
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQQVNTVzByRA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:39:59 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=86400; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline'''
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '1'
+      Content-Type:
+      - application/com.lenovo.lxca-v1.2.2+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"cabinetList":[{"storageList":[],"cabinetName":"cabinet71","height":42,"complexList":[],"chassisList":[],"location":"","UUID":"096F8C92-08D4-4A24-ABD8-FE56D482F8C4","nodeList":[{"itemParentUUID":null,"itemName":"IMM2-e41f13ed5a1e","itemLowerUnit":42,"itemType":"SERVER","itemLocationRack":"cabinet71","itemSubType":"LegacyServer","itemUUID":"BD775D06821111E189A3E41F13ED5A1A","itemInventory":{"accessState":"Online","arch":"x86_64","manufacturerId":"","location":{"lowestRackUnit":42,"location":"","rack":"cabinet71","room":""},"addinCardSlots":0,"serialNumber":"06AREZ9","driveBays":0,"macAddress":"e4:1f:13:ed:5a:1f","type":"Rack-Tower
+        Server","lanOverUsb":"disabled","height":1,"leds":[{"conditions":"Warning","color":"Yellow","location":"Front
+        Panel","name":"Check Log","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Front
+        Panel","name":"Fault","state":"Off"},{"conditions":"Attention","color":"Blue","location":"Front
+        Panel","name":"Identify","state":"Off"},{"conditions":"Health","color":"Green","location":"Front
+        Panel","name":"Power","state":"On"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"BOARD","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"Battery","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"CONFIG","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"CPU","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"CPU 1","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"CPU 2","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 1","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 10","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 11","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 12","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 13","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 14","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 15","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 16","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 17","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 18","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 19","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 2","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 20","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 21","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 22","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 23","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 24","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 3","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 4","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 5","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 6","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 7","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 8","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 9","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"FAN","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 1","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 2","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 3","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 4","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 5","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 6","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"HDD","state":"Off"},{"conditions":"Health","color":"Green","location":"System
+        Board","name":"IMM2 Heartbeat","state":"Blink"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"Internal RAID","state":"Off"},{"conditions":"Health","color":"Green","location":"Lightpath
+        Card","name":"LINK","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"MEM","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"Mezz Card Error","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"NMI","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"OVER SPEC","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"PCI","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"FRU","name":"PCI
+        1","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"FRU","name":"PCI
+        2","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"PS","state":"Off"},{"conditions":"Status","color":"Green","location":"FRU","name":"Power","state":"On"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"SysBrd Fault","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"TEMP","state":"Off"}],"description":"chassis System x3550 M4","mgmtProcIPaddress":"10.243.9.112","expansionCards":[],"errorFields":[],"FQDN":"ratchetimm2.labs.lenovo.com","ipInterfaces":[],"firmware":[{"status":"ACTIVE","name":"IMM","role":"","date":"","type":"IMM","build":"","version":"1AOO72H-5.60"},{"status":"ACTIVE","name":"Preboot
+        DSA","role":"","date":"","type":"Preboot DSA","build":"","version":"DSYTD8G-9.54"},{"status":"ACTIVE","name":"UEFI","role":"","date":"","type":"UEFI","build":"","version":"D7E152CUS-2.11"}],"bladeState":0,"activationKeys":[],"status":{"message":"managed","name":"MANAGED"},"powerCappingPolicy":{"cappingACorDCMode":"UNKNOWN","minimumHardCapLevel":-1,"cappingPolicy":"UNKNOWN","maxPowerCap":-1,"minimumPowerCappingHotPlugLevel":-1,"powerCappingAllocUnit":"watts","maximumPowerCappingHotPlugLevel":-1,"currentPowerCap":0,"minPowerCap":-1},"parent":{"uuid":"096F8C92-08D4-4A24-ABD8-FE56D482F8C4","uri":"cabinet/096F8C92-08D4-4A24-ABD8-FE56D482F8C4"},"hostname":"IMM2-e41f13ed5a1e","powerSupplies":[{"model":"43X3313","manufacturerId":"EMER","serialNumber":"
+        K118122706D","inputVoltageIsAC":false,"inputVoltageMin":0,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":null,"leds":[{"color":"Green","location":"FRU","name":"IN","state":"On"},{"color":"Green","location":"FRU","name":"OUT","state":"On"},{"color":"Amber","location":"FRU","name":"FAULT","state":"Off"}],"description":"Power
+        Supply 1","name":" K118122706D","userDescription":null,"manufactureDate":"2011-12-02","partNumber":null,"firmware":[],"healthState":"GOOD","machineType":null,"hardwareRevision":null,"FRU":null,"uri":"powerSupply/null","productId":null,"powerAllocation":{"totalInputPower":0,"totalOutputPower":0},"powerState":null,"posID":null,"slots":[0],"manufacturer":null,"vpdID":null,"uuid":null,"productName":null,"fruSerialNumber":null,"inputVoltageMax":0}],"FRU":"","thinkServerFru":[],"uri":"node/BD775D06821111E189A3E41F13ED5A1A","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":0,"minimumAllocatedPower":0},"expansionProductType":"","powerStatus":8,"bootOrder":{"uri":"node/BD775D06821111E189A3E41F13ED5A1A/bootOrder","bootOrderList":[{"currentBootOrderDevices":["default"],"bootType":"SingleUse","possibleBootOrderDevices":["setup","network","hd","cd","default"]}]},"expansionProducts":[],"ipv6Addresses":["fe80::e61f:13ff:feed:5a1f"],"slots":[1],"manufacturer":"
+        IBM","raidSettings":[],"vpdID":"","uuid":"BD775D06821111E189A3E41F13ED5A1A","isConnectionTrusted":"true","memoryModules":[{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"d95bfb8c","displayName":"DIMM 1","slot":1,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"1a8c3c7d","displayName":"DIMM 2","slot":2,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540750c","displayName":"DIMM 4","slot":4,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"1a8c3c8e","displayName":"DIMM 5","slot":5,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"35407521","displayName":"DIMM 8","slot":8,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"d67318ee","displayName":"DIMM 9","slot":9,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540751c","displayName":"DIMM 11","slot":11,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540753b","displayName":"DIMM 12","slot":12,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540751e","displayName":"DIMM 13","slot":13,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"1a8c3c39","displayName":"DIMM 14","slot":14,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540750b","displayName":"DIMM 16","slot":16,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"1a8c3c4c","displayName":"DIMM 17","slot":17,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540753d","displayName":"DIMM 20","slot":20,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Hyundai
+        Electronics","capacity":8,"serialNumber":"44c11b68","displayName":"DIMM 21","slot":21,"type":"DDR3
+        SDRAM","partNumber":"HMT31GR7CFR4C-PB  "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"354074be","displayName":"DIMM 23","slot":23,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"354074c0","displayName":"DIMM 24","slot":24,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "}],"fruSerialNumber":"Y015UN23X13P","secureBootMode":{"possibleValues":[],"currentValue":""},"tlsVersion":{"possibleValues":["TLS_10","TLS_11","TLS_12","unsupported"],"currentValue":"unsupported"},"model":"AC1","isScalable":false,"expansionCardSlots":0,"fans":[],"isITME":false,"hostMacAddresses":"","contact":"","dataHandle":0,"ipv4Addresses":["10.243.9.112"],"cmmDisplayName":"","backedBy":"real","complexID":-1,"name":"IMM2-e41f13ed5a1e","memorySlots":0,"drives":[],"cmmHealthState":"Normal","userDescription":"","subSlots":[],"partNumber":null,"excludedHealthState":"Normal","machineType":"7914","isRemotePresenceEnabled":false,"pciDevices":[],"domainName":"","processors":[{"speed":2.7,"manufacturer":"Intel(R)
+        Corporation","family":"Intel(R) Xeon(R) processor","displayName":"","slot":1,"productVersion":"Intel(R)
+        Xeon(R) CPU E5-2680 0 @ 2.70GHz","cores":8},{"speed":2.7,"manufacturer":"Intel(R)
+        Corporation","family":"Intel(R) Xeon(R) processor","displayName":"","slot":2,"productVersion":"Intel(R)
+        Xeon(R) CPU E5-2680 0 @ 2.70GHz","cores":8}],"processorSlots":0,"pciCapabilities":[],"productId":"","hasOS":false,"bootMode":{"possibleValues":["uefi","bios"],"currentValue":"unspecified"},"ports":[],"embeddedHypervisorPresence":false,"posID":"","nist":{"possibleValues":["Compatibility","Nist_800_131A_Strict","Nist_800_131A_Custom","unsupported"],"currentValue":"unsupported"},"overallHealthState":"Normal","subType":"LegacyServer","partitionID":-1,"flashStorage":[],"productName":"System
+        x3550 M4"},"itemLocation":"","itemHeight":1,"itemLocationRoom":""}],"placeholderList":[],"switchList":[],"room":""},{"storageList":[],"cabinetName":"STANDALONE_OBJECT_NAME","height":42,"complexList":[{"partition":[],"orphanNodes":[{"accessState":"Offline","arch":"x86","manufacturerId":"
+        IBM(CLCN)","location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"addinCardSlots":0,"serialNumber":"23Y6458","driveBays":17,"macAddress":"6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16","type":"Rack-Tower
+        Server","lanOverUsb":"enabled","onboardPciDevices":[{"pciSubID":"0","firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","softwareID":"0:0","type":"","build":"0","date":"","version":""}],"fodUniqueID":"","pciRevision":"0","isAgentless":false,"pciBusNumber":"27","pciSubVendorID":"0","isAddOnCard":false,"pciDeviceNumber":"0","posID":"534","pciFunctionNumber":"0","name":"","portInfo":{},"vpdID":"102b"}],"height":4,"leds":[{"color":"Yellow","location":"FrontRearPanel","name":"Fault","state":"Off"},{"color":"Blue","location":"FrontRearPanel","name":"Identify","state":"Off"},{"color":"Yellow","location":"FrontPanel","name":"Check
+        Log","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"CNFG","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"CPU","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"PS","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"DASD","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"FAN","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"MEM","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"NMI","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"OVER
+        SPEC","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"TEMP","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"PCI","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"LINK","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        5","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        9","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 10PEC","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 10Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 11Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 12Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 13Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 14Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 15Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        5","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        9","state":"Off"},{"color":"Yellow","location":"FRU","name":"ML2","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        11DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        12DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"Planar","name":"SysBrd","state":"Off"},{"color":"Yellow","location":"Planar","name":"CMOS
+        Batt Error","state":"Off"},{"color":"Green","location":"FrontRearPanel","name":"Power","state":"On"},{"color":"Green","location":"Planar","name":"BMC
+        Heartbeat","state":"Blinking"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book
+        1 Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book 2
+        Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book 3 Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book
+        4 Board4","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 1
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 2
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 3
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 4
+        Attention","state":"Off"}],"description":"Chassis","mgmtProcIPaddress":"10.243.6.17","expansionCards":[],"errorFields":[],"FQDN":"cmm-dt1.labs.lenovo.com","ipInterfaces":[{"IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.17","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"},{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"}],"name":"eth0","IPv6statelessEnabled":true,"label":"unknown","IPv6staticEnabled":false}],"firmware":[{"status":"Active","name":"UEFI
+        Firmware/BIOS","role":"Primary","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"A9E143HUS","version":"4.30"},{"status":"Inactive","name":"UEFI
+        Backup Firmware/BIOS","role":"Backup","date":"2017-02-21T00:00:00Z","type":"UEFI-Backup","build":"A9E139GUS","version":"4.10"},{"status":"Active","name":"DSA
+        Diagnostic Software","role":"Primary","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2"},{"status":"Active","name":"IMM2
+        Firmware","role":"Primary","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70"},{"status":"Inactive","name":"IMM2
+        Backup Firmware","role":"Backup","date":"2016-12-05T00:00:00Z","type":"IMM2-Backup","build":"TCOO59G","version":"9.00"}],"bladeState":0,"activationKeys":[],"status":{"message":"managed","name":"MANAGED"},"powerCappingPolicy":{"cappingACorDCMode":"DC","minimumHardCapLevel":434300,"cappingPolicy":"OFF","maxPowerCap":535000,"minimumPowerCappingHotPlugLevel":754000,"powerCappingAllocUnit":"watts*10^-3","maximumPowerCappingHotPlugLevel":856000,"currentPowerCap":0,"minPowerCap":130000},"hostname":"IMM2-6cae8b4b4f15","powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K115136V11E","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","FRU":"","uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[2],"manufacturer":"DELT","vpdID":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1},{"model":"","manufacturerId":"","serialNumber":"K115136V11L","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 2","leds":[],"description":"","name":"Power Supply 2","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","FRU":"","uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[3],"manufacturer":"DELT","vpdID":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1}],"parentComplexID":"7936DD182C5311E3A8D6000AF7256738","FRU":"None","uri":"node/7936DD182C5311E3A8D6000AF7256738","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":1710,"minimumAllocatedPower":26},"expansionProductType":"","powerStatus":8,"bootOrder":{"uri":"node/7936DD182C5311E3A8D6000AF7256738/bootOrder","bootOrderList":[{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]},{"currentBootOrderDevices":["Hard Disk 0","CentOS Linux","Windows
+        Boot Manager","PXE Network","CD/DVD Rom"],"bootType":"Permanent","possibleBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS Linux","Windows Boot Manager","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]}]},"expansionProducts":[],"ipv6Addresses":["fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","fe80:0:0:0:6eae:8bff:fe4b:4f15"],"slots":[1],"manufacturer":"
+        IBM(CLCN)","addinCards":[{"pciSubID":"454","firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Software
+        Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"slotSupportsHotPlug":"false","fodUniqueID":"N/A","pciRevision":"2","isAgentless":true,"pciBusNumber":"7","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","pciDeviceNumber":"0","slotNumber":"12","posID":"5d","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"vpdID":"1000","productName":"ServeRAID M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"}],"parentPartitionUUID":"","raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Firmware","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"description":"ServeRAID
+        M5210","name":"ServeRAID M5210","uuid":"0000000000000000500605B006E6ED5B","storagePools":[{"raidLevel":0,"description":"0000000000000000500605B006E6ED5B_Storage
+        Pool_M5210_0000000000000000500605B006E6ED5B_c:Pool:0","storageVolumes":[{"bootable":true,"volumeUID":"0","primaryPartition":0,"volumeID":"6","numberOfBlocks":583983104,"volumeStatus":"Dynamic
+        Reconfig","description":"Volume 0 0000000000000000500605B006E6ED5B_0","stripeSize":65536,"name":"GenericR0_0","blockSize":512,"health":"Unknown"}],"name":"Pool_0","totalManagedSpace":298999349248,"remainingSpace":0,"arrayUid":"0","arrayStatus":"Offline","diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"FRU":"42D0628","mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631"}]}],"diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"FRU":"42D0628","mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631"}]}],"vpdID":"","uuid":"7936DD182C5311E3A8D6000AF7256738","isConnectionTrusted":"false","memoryModules":[{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65F9","displayName":"CPU 1 DIMM
+        9,12800 MB/s","slot":9,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FA","displayName":"CPU 1 DIMM
+        15,12800 MB/s","slot":15,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FE","displayName":"CPU 2 DIMM
+        9,12800 MB/s","slot":9,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF6603","displayName":"CPU 2 DIMM
+        15,12800 MB/s","slot":15,"type":"DDR3","partNumber":"Unknown"}],"partitionEnabled":false,"fruSerialNumber":"None","secureBootMode":{"possibleValues":["Disabled","Enabled"],"currentValue":"Disabled"},"encapsulation":{"encapsulationMode":"normal"},"tlsVersion":{"possibleValues":["TLS_10","TLS_11","TLS_12","unsupported"],"currentValue":"TLS_12"},"model":"AC1","isScalable":true,"expansionCardSlots":0,"fans":[{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 1","slots":1,"name":"Fan 1"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 2","slots":2,"name":"Fan 2"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 3","slots":3,"name":"Fan 3"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 4","slots":4,"name":"Fan 4"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 5","slots":5,"name":"Fan 5"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 6","slots":6,"name":"Fan 6"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 7","slots":7,"name":"Fan 7"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 8","slots":8,"name":"Fan 8"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 9","slots":9,"name":"Fan 9"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 10","slots":10,"name":"Fan 10"}],"isITME":false,"hostMacAddresses":"00:0A:F7:25:67:38,00:0A:F7:25:67:39","contact":"","dataHandle":1518063984527,"ipv4Addresses":["10.243.6.17","169.254.95.118"],"cmmDisplayName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","backedBy":"real","complexID":1,"name":"cmm-dt1.labs.lenovo.com","memorySlots":0,"drives":[],"cmmHealthState":"Normal","userDescription":"","subSlots":[],"partNumber":"00D0188     ","excludedHealthState":"Warning","machineType":"6241","isRemotePresenceEnabled":true,"pciDevices":[{"pciSubID":"454","firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Software
+        Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"slotSupportsHotPlug":"false","fodUniqueID":"N/A","pciRevision":"2","isAgentless":true,"pciBusNumber":"7","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","pciDeviceNumber":"0","slotNumber":"12","posID":"5d","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"vpdID":"1000","productName":"ServeRAID M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)"},{"pciSubID":"0","firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","softwareID":"0:0","type":"","build":"0","date":"","version":""}],"fodUniqueID":"","pciRevision":"0","isAgentless":false,"pciBusNumber":"27","pciSubVendorID":"0","isAddOnCard":false,"pciDeviceNumber":"0","posID":"534","pciFunctionNumber":"0","name":"","portInfo":{},"vpdID":"102b"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"}],"domainName":"mm-dt1.labs.lenovo.com","processors":[{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15},{"speed":2.2,"manufacturer":"Intel(R) Corporation","family":"PENTIUM_R_4","displayName":"Intel(R)
+        Xeon(R) CPU E7-8880L v2 @ 2.20GHz","slot":2,"productVersion":"Intel(R) Xeon(R)
+        CPU E7-8880L v2 @ 2.20GHz","cores":15}],"processorSlots":0,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config"],"productId":"4D4F00","hasOS":false,"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"ports":[{"ioModuleBay":0,"portNumber":49},{"ioModuleBay":0,"portNumber":50}],"embeddedHypervisorPresence":false,"posID":"","nist":{"possibleValues":["Compatibility","Nist_800_131A_Strict","unsupported"],"currentValue":"Compatibility"},"overallHealthState":"Warning","subType":"","partitionID":-1,"physicalID":0,"flashStorage":[],"productName":"Lenovo
+        System x3850 X6"}],"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"complexID":"7936DD182C5311E3A8D6000AF7256738","partitionCount":0,"uuid":"7936DD182C5311E3A8D6000AF7256738","nodeCount":1}],"chassisList":[],"location":"","UUID":"STANDALONE_OBJECT_UUID","nodeList":[{"itemParentUUID":null,"itemName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","complexNodeCount":1,"itemLowerUnit":0,"itemType":"SERVER","itemUUID":"7936DD182C5311E3A8D6000AF7256738","itemSubType":"","itemHeight":4,"itemInventory":{"accessState":"Offline","arch":"x86","manufacturerId":"
+        IBM(CLCN)","location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"addinCardSlots":0,"serialNumber":"23Y6458","driveBays":17,"macAddress":"6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16","type":"Rack-Tower
+        Server","lanOverUsb":"enabled","onboardPciDevices":[{"pciSubID":"0","firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","softwareID":"0:0","type":"","build":"0","date":"","version":""}],"fodUniqueID":"","pciRevision":"0","isAgentless":false,"pciBusNumber":"27","pciSubVendorID":"0","isAddOnCard":false,"pciDeviceNumber":"0","posID":"534","pciFunctionNumber":"0","name":"","portInfo":{},"vpdID":"102b"}],"height":4,"leds":[{"color":"Yellow","location":"FrontRearPanel","name":"Fault","state":"Off"},{"color":"Blue","location":"FrontRearPanel","name":"Identify","state":"Off"},{"color":"Yellow","location":"FrontPanel","name":"Check
+        Log","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"CNFG","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"CPU","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"PS","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"DASD","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"FAN","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"MEM","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"NMI","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"OVER
+        SPEC","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"TEMP","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"PCI","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"LINK","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        5","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        9","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 10PEC","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 10Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 11Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 12Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 13Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 14Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 15Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        5","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        9","state":"Off"},{"color":"Yellow","location":"FRU","name":"ML2","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        11DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        12DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"Planar","name":"SysBrd","state":"Off"},{"color":"Yellow","location":"Planar","name":"CMOS
+        Batt Error","state":"Off"},{"color":"Green","location":"FrontRearPanel","name":"Power","state":"On"},{"color":"Green","location":"Planar","name":"BMC
+        Heartbeat","state":"Blinking"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book
+        1 Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book 2
+        Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book 3 Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book
+        4 Board4","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 1
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 2
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 3
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 4
+        Attention","state":"Off"}],"description":"Chassis","mgmtProcIPaddress":"10.243.6.17","expansionCards":[],"errorFields":[],"FQDN":"cmm-dt1.labs.lenovo.com","ipInterfaces":[{"IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.17","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"},{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"}],"name":"eth0","IPv6statelessEnabled":true,"label":"unknown","IPv6staticEnabled":false}],"firmware":[{"status":"Active","name":"UEFI
+        Firmware/BIOS","role":"Primary","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"A9E143HUS","version":"4.30"},{"status":"Inactive","name":"UEFI
+        Backup Firmware/BIOS","role":"Backup","date":"2017-02-21T00:00:00Z","type":"UEFI-Backup","build":"A9E139GUS","version":"4.10"},{"status":"Active","name":"DSA
+        Diagnostic Software","role":"Primary","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2"},{"status":"Active","name":"IMM2
+        Firmware","role":"Primary","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70"},{"status":"Inactive","name":"IMM2
+        Backup Firmware","role":"Backup","date":"2016-12-05T00:00:00Z","type":"IMM2-Backup","build":"TCOO59G","version":"9.00"}],"bladeState":0,"activationKeys":[],"status":{"message":"managed","name":"MANAGED"},"powerCappingPolicy":{"cappingACorDCMode":"DC","minimumHardCapLevel":434300,"cappingPolicy":"OFF","maxPowerCap":535000,"minimumPowerCappingHotPlugLevel":754000,"powerCappingAllocUnit":"watts*10^-3","maximumPowerCappingHotPlugLevel":856000,"currentPowerCap":0,"minPowerCap":130000},"hostname":"IMM2-6cae8b4b4f15","powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K115136V11E","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","FRU":"","uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[2],"manufacturer":"DELT","vpdID":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1},{"model":"","manufacturerId":"","serialNumber":"K115136V11L","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 2","leds":[],"description":"","name":"Power Supply 2","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","FRU":"","uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[3],"manufacturer":"DELT","vpdID":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1}],"parentComplexID":"7936DD182C5311E3A8D6000AF7256738","FRU":"None","uri":"node/7936DD182C5311E3A8D6000AF7256738","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":1710,"minimumAllocatedPower":26},"expansionProductType":"","powerStatus":8,"bootOrder":{"uri":"node/7936DD182C5311E3A8D6000AF7256738/bootOrder","bootOrderList":[{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]},{"currentBootOrderDevices":["Hard Disk 0","CentOS Linux","Windows
+        Boot Manager","PXE Network","CD/DVD Rom"],"bootType":"Permanent","possibleBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS Linux","Windows Boot Manager","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]}]},"expansionProducts":[],"ipv6Addresses":["fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","fe80:0:0:0:6eae:8bff:fe4b:4f15"],"slots":[1],"manufacturer":"
+        IBM(CLCN)","addinCards":[{"pciSubID":"454","firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Software
+        Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"slotSupportsHotPlug":"false","fodUniqueID":"N/A","pciRevision":"2","isAgentless":true,"pciBusNumber":"7","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","pciDeviceNumber":"0","slotNumber":"12","posID":"5d","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"vpdID":"1000","productName":"ServeRAID M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"}],"parentPartitionUUID":"","raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Firmware","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"description":"ServeRAID
+        M5210","name":"ServeRAID M5210","uuid":"0000000000000000500605B006E6ED5B","storagePools":[{"raidLevel":0,"description":"0000000000000000500605B006E6ED5B_Storage
+        Pool_M5210_0000000000000000500605B006E6ED5B_c:Pool:0","storageVolumes":[{"bootable":true,"volumeUID":"0","primaryPartition":0,"volumeID":"6","numberOfBlocks":583983104,"volumeStatus":"Dynamic
+        Reconfig","description":"Volume 0 0000000000000000500605B006E6ED5B_0","stripeSize":65536,"name":"GenericR0_0","blockSize":512,"health":"Unknown"}],"name":"Pool_0","totalManagedSpace":298999349248,"remainingSpace":0,"arrayUid":"0","arrayStatus":"Offline","diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"FRU":"42D0628","mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631"}]}],"diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"FRU":"42D0628","mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631"}]}],"vpdID":"","uuid":"7936DD182C5311E3A8D6000AF7256738","isConnectionTrusted":"false","memoryModules":[{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65F9","displayName":"CPU 1 DIMM
+        9,12800 MB/s","slot":9,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FA","displayName":"CPU 1 DIMM
+        15,12800 MB/s","slot":15,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FE","displayName":"CPU 2 DIMM
+        9,12800 MB/s","slot":9,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF6603","displayName":"CPU 2 DIMM
+        15,12800 MB/s","slot":15,"type":"DDR3","partNumber":"Unknown"}],"partitionEnabled":false,"fruSerialNumber":"None","secureBootMode":{"possibleValues":["Disabled","Enabled"],"currentValue":"Disabled"},"encapsulation":{"encapsulationMode":"normal"},"tlsVersion":{"possibleValues":["TLS_10","TLS_11","TLS_12","unsupported"],"currentValue":"TLS_12"},"model":"AC1","isScalable":true,"expansionCardSlots":0,"fans":[{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 1","slots":1,"name":"Fan 1"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 2","slots":2,"name":"Fan 2"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 3","slots":3,"name":"Fan 3"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 4","slots":4,"name":"Fan 4"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 5","slots":5,"name":"Fan 5"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 6","slots":6,"name":"Fan 6"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 7","slots":7,"name":"Fan 7"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 8","slots":8,"name":"Fan 8"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 9","slots":9,"name":"Fan 9"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 10","slots":10,"name":"Fan 10"}],"isITME":false,"hostMacAddresses":"00:0A:F7:25:67:38,00:0A:F7:25:67:39","contact":"","dataHandle":1518063984527,"ipv4Addresses":["10.243.6.17","169.254.95.118"],"cmmDisplayName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","backedBy":"real","complexID":1,"name":"cmm-dt1.labs.lenovo.com","memorySlots":0,"drives":[],"cmmHealthState":"Normal","userDescription":"","subSlots":[],"partNumber":"00D0188     ","excludedHealthState":"Warning","machineType":"6241","isRemotePresenceEnabled":true,"pciDevices":[{"pciSubID":"454","firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Software
+        Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"slotSupportsHotPlug":"false","fodUniqueID":"N/A","pciRevision":"2","isAgentless":true,"pciBusNumber":"7","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","pciDeviceNumber":"0","slotNumber":"12","posID":"5d","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"vpdID":"1000","productName":"ServeRAID M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)"},{"pciSubID":"0","firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","softwareID":"0:0","type":"","build":"0","date":"","version":""}],"fodUniqueID":"","pciRevision":"0","isAgentless":false,"pciBusNumber":"27","pciSubVendorID":"0","isAddOnCard":false,"pciDeviceNumber":"0","posID":"534","pciFunctionNumber":"0","name":"","portInfo":{},"vpdID":"102b"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"}],"domainName":"mm-dt1.labs.lenovo.com","processors":[{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15},{"speed":2.2,"manufacturer":"Intel(R) Corporation","family":"PENTIUM_R_4","displayName":"Intel(R)
+        Xeon(R) CPU E7-8880L v2 @ 2.20GHz","slot":2,"productVersion":"Intel(R) Xeon(R)
+        CPU E7-8880L v2 @ 2.20GHz","cores":15}],"processorSlots":0,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config"],"productId":"4D4F00","hasOS":false,"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"ports":[{"ioModuleBay":0,"portNumber":49},{"ioModuleBay":0,"portNumber":50}],"embeddedHypervisorPresence":false,"posID":"","nist":{"possibleValues":["Compatibility","Nist_800_131A_Strict","unsupported"],"currentValue":"Compatibility"},"overallHealthState":"Warning","subType":"","partitionID":-1,"physicalID":0,"flashStorage":[],"productName":"Lenovo
+        System x3850 X6"},"complexNodeUUIDs":["7936DD182C5311E3A8D6000AF7256738"],"complexID":"7936DD182C5311E3A8D6000AF7256738","itemLocationRack":"","physicalID":0,"nodeCount":1,"itemLocation":"","itemLocationRoom":""}],"placeholderList":[],"switchList":[],"room":""},{"storageList":[],"cabinetName":"solution-1","height":42,"complexList":[],"chassisList":[],"location":"","UUID":"FCD07E7C-F69F-4469-A57B-3FAF4D064C49","nodeList":[],"placeholderList":[],"switchList":[],"room":""},{"storageList":[],"cabinetName":"rack-2","height":42,"complexList":[],"chassisList":[],"location":"","UUID":"43D47624-E655-45B6-A0A7-D914BBC1D2D7","nodeList":[],"placeholderList":[],"switchList":[],"room":""}]}'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:39:59 GMT
+- request:
+    method: get
+    uri: https://lxcahost/patterns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQQVNTVzByRA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:00 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=86400; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline'''
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '1'
+      Content-Type:
+      - application/com.lenovo.lxca-v1.2.2+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1162'
+    body:
+      encoding: UTF-8
+      string: '{"identifier":"id","label":"name","items":[{"id":"77","referencedBy":[],"userDefined":true,"formFactor":"r","inUse":false,"description":"Pattern
+        generated from 10.243.6.71\nPattern created from server: XinYi-71\nLearned
+        on: Oct 19, 2017 2:38:29 PM","name":"XinYi-71-config","nodeType":"sysx","type":"Server","uri":"/config/template/77"},{"id":"96","referencedBy":[],"userDefined":true,"formFactor":"r","inUse":true,"description":"Pattern
+        created from server: DaAn-68-gui\nLearned on: Oct 25, 2017 8:28:52 PM","name":"DaAn-68-gui-config","nodeType":"sysx","type":"Server","uri":"/config/template/96"},{"id":"65","referencedBy":[],"userDefined":true,"formFactor":"rc","inUse":false,"description":"Copy
+        of the 17dspncsvdm server''s settings\nPattern created from server: 17dspncsvdm\nLearned
+        on: Sep 19, 2017 10:58:18 AM","name":"17dspncsvdm-config","nodeType":"sysx","type":"Server","uri":"/config/template/65"},{"id":"54","referencedBy":[],"userDefined":true,"formFactor":"r","inUse":false,"description":"Pattern
+        created from server: DaAn-68-gui\nLearned on: Aug 28, 2017 12:47:37 PM","name":"DaAn","nodeType":"sysx","type":"Server","uri":"/config/template/54"}]}
+
+'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:00 GMT

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/full_refresh_second_lxca.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/full_refresh_second_lxca.yml
@@ -1,0 +1,3905 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://10.243.6.103/aicc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQYXNzdzByZA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:00 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=15550200; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - default-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src
+        'self' 'unsafe-inline'; worker-src 'self' blob:; child-src 'self' blob:; img-src
+        'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.0.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"date":{"utc_offset":-18000000,"utc_offset_raw":-18000000,"uses_daylight":true,"timezones":[{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Abidjan","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Accra","display_name":"Ghana
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Addis_Ababa","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Algiers","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Asmara","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Asmera","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Bamako","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Bangui","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Banjul","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Bissau","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Blantyre","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Brazzaville","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Bujumbura","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Cairo","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Africa/Casablanca","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Africa/Ceuta","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Conakry","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Dakar","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Dar_es_Salaam","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Djibouti","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Douala","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Africa/El_Aaiun","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Freetown","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Gaborone","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Harare","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Johannesburg","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Juba","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Kampala","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Khartoum","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Kigali","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Kinshasa","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Lagos","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Libreville","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Lome","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Luanda","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Lubumbashi","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Lusaka","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Malabo","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Maputo","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Maseru","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Mbabane","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Mogadishu","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Monrovia","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Nairobi","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Ndjamena","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Niamey","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Nouakchott","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Ouagadougou","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Porto-Novo","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Sao_Tome","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Timbuktu","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Tripoli","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Tunis","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":7200000,"id":"Africa/Windhoek","display_name":"Western
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":-36000000,"uses_daylight":true,"offset":-36000000,"id":"America/Adak","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Anchorage","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Anguilla","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Antigua","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Araguaina","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Buenos_Aires","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Catamarca","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/ComodRivadavia","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Cordoba","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Jujuy","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/La_Rioja","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Mendoza","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Rio_Gallegos","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Salta","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/San_Juan","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/San_Luis","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Tucuman","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Ushuaia","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Aruba","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-10800000,"id":"America/Asuncion","display_name":"Paraguay
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Atikokan","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":true,"offset":-36000000,"id":"America/Atka","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Bahia","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Bahia_Banderas","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Barbados","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Belem","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Belize","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Blanc-Sablon","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Boa_Vista","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Bogota","display_name":"Colombia
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Boise","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Buenos_Aires","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Cambridge_Bay","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Campo_Grande","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Cancun","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Caracas","display_name":"Venezuela
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Catamarca","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Cayenne","display_name":"French
+        Guiana Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Cayman","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Chicago","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Chihuahua","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Coral_Harbour","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Cordoba","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Costa_Rica","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Creston","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Cuiaba","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Curacao","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"America/Danmarkshavn","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Dawson","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Dawson_Creek","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Denver","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Detroit","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Dominica","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Edmonton","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Eirunepe","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/El_Salvador","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Ensenada","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Fort_Nelson","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Fort_Wayne","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Fortaleza","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Glace_Bay","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":true,"offset":-10800000,"id":"America/Godthab","display_name":"Western
+        Greenland Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Goose_Bay","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Grand_Turk","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Grenada","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Guadeloupe","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Guatemala","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Guayaquil","display_name":"Ecuador
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Guyana","display_name":"Guyana
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Halifax","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Havana","display_name":"Cuba
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Hermosillo","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Indianapolis","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Indiana/Knox","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Marengo","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Petersburg","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Indiana/Tell_City","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Vevay","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Vincennes","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Winamac","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indianapolis","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Inuvik","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Iqaluit","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Jamaica","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Jujuy","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Juneau","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Kentucky/Louisville","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Kentucky/Monticello","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Knox_IN","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Kralendijk","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/La_Paz","display_name":"Bolivia
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Lima","display_name":"Peru
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Los_Angeles","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Louisville","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Lower_Princes","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Maceio","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Managua","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Manaus","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Marigot","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Martinique","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Matamoros","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Mazatlan","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Mendoza","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Menominee","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Merida","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Metlakatla","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Mexico_City","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":true,"offset":-10800000,"id":"America/Miquelon","display_name":"Pierre
+        & Miquelon Standard Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Moncton","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Monterrey","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Montevideo","display_name":"Uruguay
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Montreal","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Montserrat","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Nassau","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/New_York","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Nipigon","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Nome","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-7200000,"uses_daylight":false,"offset":-7200000,"id":"America/Noronha","display_name":"Fernando
+        de Noronha Time","utc_offset_w_dst":-7200000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/North_Dakota/Beulah","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/North_Dakota/Center","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/North_Dakota/New_Salem","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Ojinaga","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Panama","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Pangnirtung","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Paramaribo","display_name":"Suriname
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Phoenix","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Port-au-Prince","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Port_of_Spain","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Porto_Acre","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Porto_Velho","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Puerto_Rico","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Rainy_River","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Rankin_Inlet","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Recife","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Regina","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Resolute","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Rio_Branco","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Rosario","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Santa_Isabel","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Santarem","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-10800000,"id":"America/Santiago","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Santo_Domingo","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":true,"offset":-10800000,"id":"America/Sao_Paulo","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-3600000,"uses_daylight":true,"offset":-3600000,"id":"America/Scoresbysund","display_name":"Eastern
+        Greenland Time","utc_offset_w_dst":-3600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Shiprock","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Sitka","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Barthelemy","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-12600000,"uses_daylight":true,"offset":-12600000,"id":"America/St_Johns","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Kitts","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Lucia","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Thomas","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Vincent","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Swift_Current","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Tegucigalpa","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Thule","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Thunder_Bay","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Tijuana","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Toronto","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Tortola","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Vancouver","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Virgin","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Whitehorse","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Winnipeg","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Yakutat","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Yellowknife","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Antarctica/Casey","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Antarctica/Davis","display_name":"Davis
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Antarctica/DumontDUrville","display_name":"Dumont-d''Urville
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Antarctica/Macquarie","display_name":"Macquarie
+        Island Standard Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Antarctica/Mawson","display_name":"Mawson
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":46800000,"id":"Antarctica/McMurdo","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-10800000,"id":"Antarctica/Palmer","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"Antarctica/Rothera","display_name":"Rothera
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":46800000,"id":"Antarctica/South_Pole","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Antarctica/Syowa","display_name":"Syowa
+        Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Antarctica/Troll","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":7200000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Antarctica/Vostok","display_name":"Vostok
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Arctic/Longyearbyen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Aden","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Almaty","display_name":"Alma-Ata
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Amman","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Asia/Anadyr","display_name":"Anadyr
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Aqtau","display_name":"Aqtau
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Aqtobe","display_name":"Aqtobe
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Ashgabat","display_name":"Turkmenistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Ashkhabad","display_name":"Turkmenistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Baghdad","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Bahrain","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Baku","display_name":"Azerbaijan
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Bangkok","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Barnaul","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Beirut","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Bishkek","display_name":"Kirgizstan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Brunei","display_name":"Brunei
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":19800000,"uses_daylight":false,"offset":19800000,"id":"Asia/Calcutta","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Chita","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":true,"offset":28800000,"id":"Asia/Choibalsan","display_name":"Choibalsan
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Chongqing","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Chungking","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":19800000,"uses_daylight":false,"offset":19800000,"id":"Asia/Colombo","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Dacca","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Damascus","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Dhaka","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Dili","display_name":"Timor-Leste
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Dubai","display_name":"Gulf
+        Standard Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Dushanbe","display_name":"Tajikistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Gaza","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Harbin","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Hebron","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Ho_Chi_Minh","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Hong_Kong","display_name":"Hong
+        Kong Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":true,"offset":25200000,"id":"Asia/Hovd","display_name":"Hovd
+        Time","utc_offset_w_dst":25200000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Irkutsk","display_name":"Irkutsk
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Istanbul","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Jakarta","display_name":"West
+        Indonesia Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Jayapura","display_name":"East
+        Indonesia Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Jerusalem","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":16200000,"uses_daylight":false,"offset":16200000,"id":"Asia/Kabul","display_name":"Afghanistan
+        Time","utc_offset_w_dst":16200000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Asia/Kamchatka","display_name":"Petropavlovsk-Kamchatski
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Karachi","display_name":"Pakistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Kashgar","display_name":"Xinjiang
+        Standard Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":20700000,"uses_daylight":false,"offset":20700000,"id":"Asia/Kathmandu","display_name":"Nepal
+        Time","utc_offset_w_dst":20700000,"daylight_saves":0},{"utc_offset_raw":20700000,"uses_daylight":false,"offset":20700000,"id":"Asia/Katmandu","display_name":"Nepal
+        Time","utc_offset_w_dst":20700000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Khandyga","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":19800000,"uses_daylight":false,"offset":19800000,"id":"Asia/Kolkata","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Krasnoyarsk","display_name":"Krasnoyarsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Kuala_Lumpur","display_name":"Malaysia
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Kuching","display_name":"Malaysia
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Kuwait","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Macao","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Macau","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Asia/Magadan","display_name":"Magadan
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Makassar","display_name":"Central
+        Indonesia Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Manila","display_name":"Philippines
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Muscat","display_name":"Gulf
+        Standard Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Nicosia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Novokuznetsk","display_name":"Krasnoyarsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Novosibirsk","display_name":"Novosibirsk
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Omsk","display_name":"Omsk
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Oral","display_name":"Oral
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Phnom_Penh","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Pontianak","display_name":"West
+        Indonesia Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":30600000,"uses_daylight":false,"offset":30600000,"id":"Asia/Pyongyang","display_name":"Korea
+        Standard Time","utc_offset_w_dst":30600000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Qatar","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Qyzylorda","display_name":"Qyzylorda
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":23400000,"uses_daylight":false,"offset":23400000,"id":"Asia/Rangoon","display_name":"Myanmar
+        Time","utc_offset_w_dst":23400000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Riyadh","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Saigon","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Asia/Sakhalin","display_name":"Sakhalin
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Samarkand","display_name":"Uzbekistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Seoul","display_name":"Korea
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Shanghai","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Singapore","display_name":"Singapore
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Asia/Srednekolymsk","display_name":"Srednekolymsk
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Taipei","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Tashkent","display_name":"Uzbekistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Tbilisi","display_name":"Georgia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":12600000,"uses_daylight":true,"offset":12600000,"id":"Asia/Tehran","display_name":"Iran
+        Standard Time","utc_offset_w_dst":12600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Tel_Aviv","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Thimbu","display_name":"Bhutan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Thimphu","display_name":"Bhutan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Tokyo","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Tomsk","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Ujung_Pandang","display_name":"Central
+        Indonesia Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":true,"offset":28800000,"id":"Asia/Ulaanbaatar","display_name":"Ulaanbaatar
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":true,"offset":28800000,"id":"Asia/Ulan_Bator","display_name":"Ulaanbaatar
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Urumqi","display_name":"Xinjiang
+        Standard Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Asia/Ust-Nera","display_name":"Ust-Nera
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Vientiane","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Asia/Vladivostok","display_name":"Vladivostok
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Yakutsk","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Yekaterinburg","display_name":"Yekaterinburg
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Yerevan","display_name":"Armenia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":-3600000,"uses_daylight":true,"offset":-3600000,"id":"Atlantic/Azores","display_name":"Azores
+        Time","utc_offset_w_dst":-3600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"Atlantic/Bermuda","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Atlantic/Canary","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":-3600000,"uses_daylight":false,"offset":-3600000,"id":"Atlantic/Cape_Verde","display_name":"Cape
+        Verde Time","utc_offset_w_dst":-3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Atlantic/Faeroe","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Atlantic/Faroe","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Atlantic/Jan_Mayen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Atlantic/Madeira","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Atlantic/Reykjavik","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-7200000,"uses_daylight":false,"offset":-7200000,"id":"Atlantic/South_Georgia","display_name":"South
+        Georgia Standard Time","utc_offset_w_dst":-7200000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Atlantic/St_Helena","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"Atlantic/Stanley","display_name":"Falkland
+        Is. Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/ACT","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":34200000,"uses_daylight":true,"offset":37800000,"id":"Australia/Adelaide","display_name":"Australian
+        Central Standard Time (South Australia)","utc_offset_w_dst":37800000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Australia/Brisbane","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":34200000,"uses_daylight":true,"offset":37800000,"id":"Australia/Broken_Hill","display_name":"Australian
+        Central Standard Time (South Australia/New South Wales)","utc_offset_w_dst":37800000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Canberra","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Currie","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":34200000,"uses_daylight":false,"offset":34200000,"id":"Australia/Darwin","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0},{"utc_offset_raw":31500000,"uses_daylight":false,"offset":31500000,"id":"Australia/Eucla","display_name":"Australian
+        Central Western Standard Time","utc_offset_w_dst":31500000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Hobart","display_name":"Australian
+        Eastern Standard Time (Tasmania)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":37800000,"uses_daylight":true,"offset":39600000,"id":"Australia/LHI","display_name":"Lord
+        Howe Standard Time","utc_offset_w_dst":39600000,"daylight_saves":1800000},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Australia/Lindeman","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":37800000,"uses_daylight":true,"offset":39600000,"id":"Australia/Lord_Howe","display_name":"Lord
+        Howe Standard Time","utc_offset_w_dst":39600000,"daylight_saves":1800000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Melbourne","display_name":"Australian
+        Eastern Standard Time (Victoria)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/NSW","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":34200000,"uses_daylight":false,"offset":34200000,"id":"Australia/North","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Australia/Perth","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Australia/Queensland","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":34200000,"uses_daylight":true,"offset":37800000,"id":"Australia/South","display_name":"Australian
+        Central Standard Time (South Australia)","utc_offset_w_dst":37800000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Sydney","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Tasmania","display_name":"Australian
+        Eastern Standard Time (Tasmania)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Victoria","display_name":"Australian
+        Eastern Standard Time (Victoria)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Australia/West","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":34200000,"uses_daylight":true,"offset":37800000,"id":"Australia/Yancowinna","display_name":"Australian
+        Central Standard Time (South Australia/New South Wales)","utc_offset_w_dst":37800000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"Brazil/Acre","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-7200000,"uses_daylight":false,"offset":-7200000,"id":"Brazil/DeNoronha","display_name":"Fernando
+        de Noronha Time","utc_offset_w_dst":-7200000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":true,"offset":-10800000,"id":"Brazil/East","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"Brazil/West","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"CET","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"CST6CDT","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"Canada/Atlantic","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"Canada/Central","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"Canada/East-Saskatchewan","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"Canada/Eastern","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"Canada/Mountain","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-12600000,"uses_daylight":true,"offset":-12600000,"id":"Canada/Newfoundland","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"Canada/Pacific","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"Canada/Saskatchewan","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"Canada/Yukon","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-10800000,"id":"Chile/Continental","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-18000000,"id":"Chile/EasterIsland","display_name":"Easter
+        Is. Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"Cuba","display_name":"Cuba
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"EET","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"EST5EDT","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Egypt","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Eire","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/GMT","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/GMT+0","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-3600000,"uses_daylight":false,"offset":-3600000,"id":"Etc/GMT+1","display_name":"GMT-01:00","utc_offset_w_dst":-3600000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Etc/GMT+10","display_name":"GMT-10:00","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Etc/GMT+11","display_name":"GMT-11:00","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":-43200000,"uses_daylight":false,"offset":-43200000,"id":"Etc/GMT+12","display_name":"GMT-12:00","utc_offset_w_dst":-43200000,"daylight_saves":0},{"utc_offset_raw":-7200000,"uses_daylight":false,"offset":-7200000,"id":"Etc/GMT+2","display_name":"GMT-02:00","utc_offset_w_dst":-7200000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"Etc/GMT+3","display_name":"GMT-03:00","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"Etc/GMT+4","display_name":"GMT-04:00","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"Etc/GMT+5","display_name":"GMT-05:00","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"Etc/GMT+6","display_name":"GMT-06:00","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"Etc/GMT+7","display_name":"GMT-07:00","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":false,"offset":-28800000,"id":"Etc/GMT+8","display_name":"GMT-08:00","utc_offset_w_dst":-28800000,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":false,"offset":-32400000,"id":"Etc/GMT+9","display_name":"GMT-09:00","utc_offset_w_dst":-32400000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/GMT-0","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Etc/GMT-1","display_name":"GMT+01:00","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Etc/GMT-10","display_name":"GMT+10:00","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Etc/GMT-11","display_name":"GMT+11:00","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Etc/GMT-12","display_name":"GMT+12:00","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":46800000,"uses_daylight":false,"offset":46800000,"id":"Etc/GMT-13","display_name":"GMT+13:00","utc_offset_w_dst":46800000,"daylight_saves":0},{"utc_offset_raw":50400000,"uses_daylight":false,"offset":50400000,"id":"Etc/GMT-14","display_name":"GMT+14:00","utc_offset_w_dst":50400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Etc/GMT-2","display_name":"GMT+02:00","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Etc/GMT-3","display_name":"GMT+03:00","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Etc/GMT-4","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Etc/GMT-5","display_name":"GMT+05:00","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Etc/GMT-6","display_name":"GMT+06:00","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Etc/GMT-7","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Etc/GMT-8","display_name":"GMT+08:00","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Etc/GMT-9","display_name":"GMT+09:00","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/GMT0","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/Greenwich","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/UCT","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/UTC","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/Universal","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/Zulu","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Amsterdam","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Andorra","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Europe/Astrakhan","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Athens","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Belfast","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Belgrade","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Berlin","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Bratislava","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Brussels","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Bucharest","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Budapest","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Busingen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Chisinau","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Copenhagen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Dublin","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Gibraltar","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Guernsey","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Helsinki","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Isle_of_Man","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Istanbul","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Jersey","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Europe/Kaliningrad","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Kiev","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Kirov","display_name":"GMT+03:00","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Lisbon","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Ljubljana","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/London","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Luxembourg","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Madrid","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Malta","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Mariehamn","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Minsk","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Monaco","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Moscow","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Nicosia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Oslo","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Paris","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Podgorica","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Prague","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Riga","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Rome","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Europe/Samara","display_name":"Samara
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/San_Marino","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Sarajevo","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Simferopol","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Skopje","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Sofia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Stockholm","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Tallinn","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Tirane","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Tiraspol","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Europe/Ulyanovsk","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Uzhgorod","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Vaduz","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Vatican","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Vienna","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Vilnius","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Volgograd","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Warsaw","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Zagreb","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Zaporozhye","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Zurich","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"GB","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"GB-Eire","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"GMT","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"GMT0","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Greenwich","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Hongkong","display_name":"Hong
+        Kong Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Iceland","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Indian/Antananarivo","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Indian/Chagos","display_name":"Indian
+        Ocean Territory Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Indian/Christmas","display_name":"Christmas
+        Island Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":23400000,"uses_daylight":false,"offset":23400000,"id":"Indian/Cocos","display_name":"Cocos
+        Islands Time","utc_offset_w_dst":23400000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Indian/Comoro","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Indian/Kerguelen","display_name":"French
+        Southern & Antarctic Lands Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Indian/Mahe","display_name":"Seychelles
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Indian/Maldives","display_name":"Maldives
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Indian/Mauritius","display_name":"Mauritius
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Indian/Mayotte","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Indian/Reunion","display_name":"Reunion
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":12600000,"uses_daylight":true,"offset":12600000,"id":"Iran","display_name":"Iran
+        Standard Time","utc_offset_w_dst":12600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Israel","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"Jamaica","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Japan","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Kwajalein","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Libya","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"MET","display_name":"Middle
+        Europe Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"MST7MDT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"Mexico/BajaNorte","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"Mexico/BajaSur","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"Mexico/General","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":46800000,"id":"NZ","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000},{"utc_offset_raw":45900000,"uses_daylight":true,"offset":49500000,"id":"NZ-CHAT","display_name":"Chatham
+        Standard Time","utc_offset_w_dst":49500000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"Navajo","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"PRC","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"PST8PDT","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":46800000,"uses_daylight":true,"offset":50400000,"id":"Pacific/Apia","display_name":"West
+        Samoa Standard Time","utc_offset_w_dst":50400000,"daylight_saves":3600000},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":46800000,"id":"Pacific/Auckland","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Bougainville","display_name":"Bougainville
+        Standard Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":45900000,"uses_daylight":true,"offset":49500000,"id":"Pacific/Chatham","display_name":"Chatham
+        Standard Time","utc_offset_w_dst":49500000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Chuuk","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-18000000,"id":"Pacific/Easter","display_name":"Easter
+        Is. Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Efate","display_name":"Vanuatu
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":46800000,"uses_daylight":false,"offset":46800000,"id":"Pacific/Enderbury","display_name":"Phoenix
+        Is. Time","utc_offset_w_dst":46800000,"daylight_saves":0},{"utc_offset_raw":46800000,"uses_daylight":false,"offset":46800000,"id":"Pacific/Fakaofo","display_name":"Tokelau
+        Time","utc_offset_w_dst":46800000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":43200000,"id":"Pacific/Fiji","display_name":"Fiji
+        Time","utc_offset_w_dst":43200000,"daylight_saves":3600000},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Funafuti","display_name":"Tuvalu
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"Pacific/Galapagos","display_name":"Galapagos
+        Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":false,"offset":-32400000,"id":"Pacific/Gambier","display_name":"Gambier
+        Time","utc_offset_w_dst":-32400000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Guadalcanal","display_name":"Solomon
+        Is. Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Guam","display_name":"Chamorro
+        Standard Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Pacific/Honolulu","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Pacific/Johnston","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":50400000,"uses_daylight":false,"offset":50400000,"id":"Pacific/Kiritimati","display_name":"Line
+        Is. Time","utc_offset_w_dst":50400000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Kosrae","display_name":"Kosrae
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Kwajalein","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Majuro","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":-34200000,"uses_daylight":false,"offset":-34200000,"id":"Pacific/Marquesas","display_name":"Marquesas
+        Time","utc_offset_w_dst":-34200000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Pacific/Midway","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Nauru","display_name":"Nauru
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Pacific/Niue","display_name":"Niue
+        Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Norfolk","display_name":"Norfolk
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Noumea","display_name":"New
+        Caledonia Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Pacific/Pago_Pago","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Pacific/Palau","display_name":"Palau
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":false,"offset":-28800000,"id":"Pacific/Pitcairn","display_name":"Pitcairn
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Pohnpei","display_name":"Pohnpei
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Ponape","display_name":"Pohnpei
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Port_Moresby","display_name":"Papua
+        New Guinea Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Pacific/Rarotonga","display_name":"Cook
+        Is. Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Saipan","display_name":"Chamorro
+        Standard Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Pacific/Samoa","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Pacific/Tahiti","display_name":"Tahiti
+        Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Tarawa","display_name":"Gilbert
+        Is. Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":46800000,"uses_daylight":false,"offset":46800000,"id":"Pacific/Tongatapu","display_name":"Tonga
+        Time","utc_offset_w_dst":46800000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Truk","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Wake","display_name":"Wake
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Wallis","display_name":"Wallis
+        & Futuna Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Yap","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Poland","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Portugal","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"ROK","display_name":"Korea
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Singapore","display_name":"Singapore
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"SystemV/AST4","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"SystemV/AST4ADT","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"SystemV/CST6","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"SystemV/CST6CDT","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"SystemV/EST5","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"SystemV/EST5EDT","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"SystemV/HST10","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"SystemV/MST7","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"SystemV/MST7MDT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":false,"offset":-28800000,"id":"SystemV/PST8","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"SystemV/PST8PDT","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":false,"offset":-32400000,"id":"SystemV/YST9","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"SystemV/YST9YDT","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Turkey","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"UCT","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"US/Alaska","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-36000000,"uses_daylight":true,"offset":-36000000,"id":"US/Aleutian","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"US/Arizona","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"US/Central","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"US/East-Indiana","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"US/Eastern","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"US/Hawaii","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"US/Indiana-Starke","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"US/Michigan","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"US/Mountain","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"US/Pacific","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"US/Pacific-New","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"US/Samoa","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"UTC","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Universal","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"W-SU","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"WET","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Zulu","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"EST","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"HST","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"MST","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0}],"date_time":"March
+        8, 2018 3:40:01 PM EST","timezone":"Eastern Standard Time","timezone_id":"EST5EDT","parts":{"mm":3,"dd":8,"hours":15,"mins":40,"secs":1,"yyyy":2018},"utc_offset_w_dst":-18000000},"appliance":{"date":"2018-02-09_13-37-27","build":"423","name":"LXCA
+        - 10.243.6.103","runlevel":3,"version":"2.0.0","uuid":"85acba9f-9ddf-4a62-91e6-9a1c4f1beda5","status":"Normal"},"subscriptions":[{"submonitor_uri":"","id":1,"monitor_uri":"/aicc/network/interfaces","uri":"/osdeployment/rest/internal/event/aicc"},{"submonitor_uri":"","id":2,"monitor_uri":"/aicc/network/interfaces","uri":"/netchangenotsec"},{"submonitor_uri":"/ntp","id":3,"monitor_uri":"/aicc","uri":"/ntpNotification"}],"appliance_states":[{"description":"Halt
+        the appliance","runlevel":0},{"description":"Normal operation","runlevel":3},{"description":"Reboot
+        the appliance","runlevel":6}],"preferredDisplayName":"byDefault","services":[{"pid":26614,"id":"core","state":0,"initd":"xhmc-core"},{"pid":1428,"id":"keydaemon","state":0,"initd":"sympl-keydaemon"},{"pid":1577,"id":"watchdog","state":0,"initd":"sympl-watchdog"},{"pid":-1,"id":"apache","state":1,"initd":"httpd"},{"pid":-1,"id":"network","state":0,"initd":"network"},{"pid":23849,"id":"ntp","state":0,"initd":"ntpd"},{"pid":1764,"id":"sftp","state":0,"initd":"sshd"},{"pid":22528,"id":"xcat","state":0,"initd":"xcatd"}],"ntp":{"servers":[{"server":"us.pool.ntp.org","authenticated":false,"v3_key_type":"","v3_key":"","v3_key_index":0,"version":1},{"server":"","authenticated":false,"v3_key_type":"","v3_key":"","v3_key_index":0,"version":0}]},"network_interfaces":[{"role":["management","osdeployment"],"mac_address":"52:54:00:C2:BF:23","ip_addresses":[{"ip":"fe80:0:0:0:5054:ff:fec2:bf23%eth0","ip_linklocal":"true","prefix_length":64,"version":6,"assign_method":"static"},{"ip":"10.243.6.103","ip_linklocal":"false","prefix_length":20,"version":4,"assign_method":"static"},{"ip":"0::0%0","ip_linklocal":"false","prefix_length":64,"version":6,"assign_method":"dhcp"}],"rpf":"RFC3704Strict","id":"eth0"}],"service_states":[{"description":"Service
+        is running","state":0},{"description":"Service is dead but PID file exists","state":1},{"description":"Service
+        is dead but lock file exists","state":2},{"description":"Service is not running","state":3},{"description":"Service
+        state is unknown","state":4},{"description":"Special purpose state used to
+        trigger restart through REST","state":191}]}'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:01 GMT
+- request:
+    method: get
+    uri: https://10.243.6.103/cabinet?status=includestandalone
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQYXNzdzByZA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:01 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=15550200; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - default-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src
+        'self' 'unsafe-inline'; worker-src 'self' blob:; child-src 'self' blob:; img-src
+        'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.0.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"cabinetList":[{"cabinetName":"solution-1","height":42,"room":"","location":"","chassisList":[],"complexList":[],"nodeList":[{"itemName":"Management
+        Controller UUID-F812491A398611E4B45040F2E9A61078","itemUUID":"F812491A398611E4B45040F2E9A61078","itemLocationRoom":"","itemLocationRack":"solution-1","itemLocation":"","itemLowerUnit":1,"itemType":"SERVER","itemHeight":5,"itemSubType":"","complexNodeCount":-1,"nodeCount":-1,"physicalID":-1,"itemInventory":{"name":"cmm-ys21","uuid":"F812491A398611E4B45040F2E9A61078","status":{"message":"managed","name":"MANAGED"},"hostname":"IMM2-40f2e9a6107d","overallHealthState":"Warning","productName":"Lenovo
+        System x3500 M5","type":"Rack-Tower Server","manufacturer":"LNVO(WIST)","machineType":"5464","model":"AC1","mgmtProcIPaddress":"10.243.6.150","arch":"x86","serialNumber":"06CHKBV","partNumber":"00KC305     ","FRU":"None","fruSerialNumber":"None","domainName":"labs.lenovo.com","FQDN":"RodneySystem.labs.lenovo.com","powerStatus":8,"userDescription":"","macAddress":"40:F2:E9:A6:10:7D,40:F2:E9:A6:10:7E","hostMacAddresses":"40:F2:E9:A6:10:78,40:F2:E9:A6:10:79,40:F2:E9:A6:10:7A,40:F2:E9:A6:10:7B","tlsVersion":{"possibleValues":["unsupported","TLS_12","TLS_11","TLS_10"],"currentValue":"TLS_10"},"nist":{"possibleValues":["Nist_800_131A_Strict","unsupported","Compatibility"],"currentValue":"Compatibility"},"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"location":{"lowestRackUnit":0,"location":"","rack":"solution-1","room":""},"lanOverUsb":"enabled","description":"Chassis","mgmtProcType":"IMM2","isRemotePresenceEnabled":true,"height":5,"leds":[{"name":"DIMM
+        13","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 2","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CONFIG","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        4","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM 23","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        18","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 7","state":"Off","color":"Yellow","location":"Planar"},{"name":"Power","state":"On","color":"Green","location":"FrontRearPanel"},{"name":"Fan
+        2","state":"Off","color":"Yellow","location":"Planar"},{"name":"PS","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"Check
+        Log","state":"Off","color":"Yellow","location":"FrontPanel"},{"name":"PCI
+        7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU MISMATCH","state":"Off","color":"Yellow","location":"FRU"},{"name":"HYP
+        SKT2","state":"Off","color":"Yellow","location":"FRU"},{"name":"SD ERR","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM
+        22","state":"Off","color":"Yellow","location":"Planar"},{"name":"MEM","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"DIMM
+        12","state":"Off","color":"Yellow","location":"Planar"},{"name":"NMI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"SysBrd
+        Fault","state":"Off","color":"Yellow","location":"Planar"},{"name":"HYP SKT1","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM
+        5","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 19","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"Fan 4","state":"Off","color":"Yellow","location":"Planar"},{"name":"Fan
+        1","state":"Off","color":"Yellow","location":"Planar"},{"name":"IMM2 Heartbeat","state":"Blinking","color":"Green","location":"Planar"},{"name":"DIMM
+        8","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 1","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        15","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM
+        21","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 9","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        4","state":"Off","color":"Yellow","location":"Planar"},{"name":"Fan 3","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU
+        2","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 16","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        11","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Identify","state":"Off","color":"Blue","location":"FrontRearPanel"},{"name":"FAN","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"Battery","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        14","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 3","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU
+        1","state":"Off","color":"Yellow","location":"Planar"},{"name":"SP ERR","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"DIMM
+        24","state":"Off","color":"Yellow","location":"Planar"},{"name":"TEMP","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        5","state":"Off","color":"Yellow","location":"FRU"},{"name":"HDD","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"DIMM
+        17","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"Fault","state":"Off","color":"Yellow","location":"FrontRearPanel"},{"name":"DIMM
+        6","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"BOARD","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"DIMM
+        20","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 10","state":"Off","color":"Yellow","location":"Planar"}],"expansionCards":[],"firmware":[{"name":"DSA
+        Diagnostic Software","date":"2016-07-08T00:00:00Z","type":"DSA","build":"DSALA7K","version":"10.2","role":"Primary","status":"Active"},{"name":"IMM2
+        Firmware","date":"2016-08-29T00:00:00Z","type":"IMM2","build":"TCOO23A","version":"3.50","role":"Primary","status":"Active"},{"name":"UEFI
+        Backup Firmware/BIOS","date":"2016-09-07T00:00:00Z","type":"UEFI-Backup","build":"TAE125O","version":"2.20","role":"Backup","status":"Inactive"},{"name":"UEFI
+        Firmware/BIOS","date":"2016-09-07T00:00:00Z","type":"UEFI","build":"TAE125O","version":"2.20","role":"Primary","status":"Active"},{"name":"IMM2
+        Backup Firmware","date":"2016-08-29T00:00:00Z","type":"IMM2-Backup","build":"TCOO23A","version":"3.50","role":"Backup","status":"Inactive"}],"powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K12814750M2","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8136","firmware":[],"healthState":"CRITICAL","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":550},"powerState":"Unknown","posID":"","slots":[1],"manufacturer":"EMER","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""}],"ipv4Addresses":["10.243.6.150","169.254.95.118"],"ipv6Addresses":["fd55:faaf:e1ab:2021:42f2:e9ff:fea6:107d","fe80:0:0:0:42f2:e9ff:fea6:107d"],"raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Firmware","build":"0","date":"2016-07-20T00:00:00Z","version":"24.12.0-0033","softwareID":"10140456"}],"description":"ServeRAID
+        M1215","name":"ServeRAID M1215","uuid":"0000000000000000500605B00915C470","diskDrives":[{"model":"ST91000640SS","healthState":"Normal","numberOfBlocks":1953525168,"interfaceType":"SAS","serialNumber":"9XG0JVL3","blockSize":512,"mediaType":"Rotational","diskState":"JBOD","bay":7,"description":"ST91000640SS","manufacturer":"IBM-ESXS","name":"Disk
+        0_9","uuid":"","partNumber":"81Y3818","largestAvailableSize":512,"capacity":1000204886000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"BD23","softwareID":"ST91000640SS"}],"FRU":"81Y9687"}],"storagePools":[],"batteryData":[]}],"drives":[],"memoryModules":[{"model":"DDR4","speed":2133,"manufacturer":"Hynix
+        Semiconductor","capacity":16,"serialNumber":"9032D73E","displayName":"DIMM
+        1","slot":1,"type":"DDR4","partNumber":"HMA42GR7MFR4N-TF","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992CF59","displayName":"DIMM
+        2","slot":2,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992D4EB","displayName":"DIMM
+        3","slot":3,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0E41381F","displayName":"DIMM 4","slot":4,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992DC3D","displayName":"DIMM
+        5","slot":5,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992DBE2","displayName":"DIMM
+        6","slot":6,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0E413681","displayName":"DIMM 7","slot":7,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0E413825","displayName":"DIMM 8","slot":8,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0E4136DF","displayName":"DIMM 9","slot":9,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0D855B12","displayName":"DIMM 10","slot":10,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992D294","displayName":"DIMM
+        11","slot":11,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Hynix
+        Semiconductor","capacity":16,"serialNumber":"9032D73F","displayName":"DIMM
+        12","slot":12,"type":"DDR4","partNumber":"HMA42GR7MFR4N-TF","speedMBs":0}],"processors":[{"speed":2.3,"manufacturer":"Intel(R)
+        Corporation","family":"INTEL_R_XEON_TM","displayName":"Intel(R) Xeon(R) CPU
+        E5-2650 v3 @ 2.30GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E5-2650
+        v3 @ 2.30GHz","cores":10,"socket":""}],"pciDevices":[{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2016-07-20T00:00:00Z","version":"24.12.0-0033","softwareID":"10140456"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"11","pciDeviceNumber":"0","slotNumber":"1","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M1215","portInfo":{},"uuid":"0000000000000000500605B00915C470","productName":"ServeRAID
+        M1215","partNumber":"N/A","fruSerialNumber":"SV42831792","slotName":"SlotDesig7_Slot
+        1","pciSubID":"456","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5f","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A61078","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"1d49:a01"}],"pciRevision":"1","pciBusNumber":"25","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"a01","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"1d49","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"3","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":4,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A6107B","vnicMode":false}],"peerBay":0,"physicalPortIndex":4}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"1","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":2,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A61079","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"2","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":3,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A6107A","vnicMode":false}],"peerBay":0,"physicalPortIndex":3}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"}],"accessState":"Online","manufacturerId":"LNVO(WIST)","addinCardSlots":0,"driveBays":33,"errorFields":[{"FirmwareData":"NO_CONNECTOR"},{"ChassisMounted":"NO_CONNECTOR"},{"RackPowerCappingPolicy":"FETCH_FAILED"}],"bladeState":0,"activationKeys":[{"keyFeatureType":1,"keyStatus":"VALID","description":"Integrated
+        Management Module Advanced Upgrade","keyUseLimit":0,"keyExpirationDate":"","keyUseCount":0,"uuid":"cc1911fd3eefbf6d","keyIdentiferList":[{"keyIdentifierType":"MT","keyIdentifier":"546406CHKBV"}]}],"uri":"nodes/F812491A398611E4B45040F2E9A61078","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":550,"minimumAllocatedPower":26},"expansionProductType":"","bootOrder":{"uri":"nodes/F812491A398611E4B45040F2E9A61078/bootOrder","bootOrderList":[{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS","Floppy Disk","Hard Disk 1","Hard
+        Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB1","USB2","USB3","USB4","USB5","USB6","USB10","USB11","USB12","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","NIC1","NIC2","NIC3","NIC4","SATA","DSA"]},{"currentBootOrderDevices":["CentOS","CD/DVD
+        Rom","Hard Disk 0","PXE Network"],"bootType":"Permanent","possibleBootOrderDevices":["CentOS","CD/DVD
+        Rom","Hard Disk 0","PXE Network","Floppy Disk","Hard Disk 1","Hard Disk 2","Hard
+        Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI Critical","Embedded
+        Hypervisor","Legacy Only","USB1","USB2","USB3","USB4","USB5","USB6","USB10","USB11","USB12","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","NIC1","NIC2","NIC3","NIC4","SATA","DSA"]},{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]}]},"expansionProducts":[],"slots":[1],"vpdID":"","encapsulation":{"encapsulationMode":"normal"},"secureBootMode":{"possibleValues":["Enabled","Disabled"],"currentValue":"Disabled"},"expansionCardSlots":0,"contact":"","dataHandle":1520517060293,"cmmDisplayName":"Management
+        Controller UUID-F812491A398611E4B45040F2E9A61078","backedBy":"real","complexID":-1,"memorySlots":12,"cmmHealthState":"Normal","subSlots":[],"excludedHealthState":"Warning","processorSlots":1,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config","OOB
+        Option Firmware Update"],"productId":"4D4F00","hasOS":false,"ports":[{"ioModuleBay":0,"portNumber":1},{"ioModuleBay":0,"portNumber":2},{"ioModuleBay":0,"portNumber":3},{"ioModuleBay":0,"portNumber":4}],"embeddedHypervisorPresence":false,"posID":"","subType":"","partitionID":-1,"flashStorage":[],"userDefinedName":"cmm-ys21","securityDescriptor":{"managedAuthSupported":true,"publicAccess":false,"uri":"nodes/f812491a398611e4b45040f2e9a61078","roleGroups":[],"managedAuthEnabled":true,"storedCredentials":{"description":"Credentials
+        for cmm-ys21","id":"352","userName":"USERID"}},"logicalID":-1,"primary":false,"fans":[{"name":"Fan
+        1","healthState":"Normal","status":"OK","description":"Logical Device for
+        fan / cooling device 1","speed":3807,"slots":1},{"name":"Fan 2","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 2","speed":3807,"slots":2}],"addinCards":[{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2016-07-20T00:00:00Z","version":"24.12.0-0033","softwareID":"10140456"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"11","pciDeviceNumber":"0","slotNumber":"1","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M1215","portInfo":{},"uuid":"0000000000000000500605B00915C470","productName":"ServeRAID
+        M1215","partNumber":"N/A","fruSerialNumber":"SV42831792","slotName":"SlotDesig7_Slot
+        1","pciSubID":"456","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5f","vpdID":"1000","class":"Mass
+        storage controller"}],"physicalID":0,"faceplateIDs":[{"name":"front panel
+        board 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0},{"name":"drive
+        backplane 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0},{"name":"system
+        board 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0}],"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"m2Presence":false,"onboardPciDevices":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A61078","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"3","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":4,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A6107B","vnicMode":false}],"peerBay":0,"physicalPortIndex":4}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"1d49:a01"}],"pciRevision":"1","pciBusNumber":"25","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"a01","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"1d49","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"1","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":2,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A61079","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"2","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":3,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A6107A","vnicMode":false}],"peerBay":0,"physicalPortIndex":3}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"}],"ipInterfaces":[{"name":"eth0","label":"unknown","IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.150","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:42f2:e9ff:fea6:107d","prefix":64,"type":"INUSE"},{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:42f2:e9ff:fea6:107d","prefix":64,"type":"INUSE"}],"IPv6statelessEnabled":true,"IPv6staticEnabled":false}],"isConnectionTrusted":"true","isScalable":false,"isITME":false}}],"switchList":[],"storageList":[],"placeholderList":[],"UUID":"B5C61140-DDA1-4102-8838-A32C89372826"},{"cabinetName":"SueThinkAgile
+        Solution","height":42,"room":"basement","location":"Rochester","chassisList":[],"complexList":[],"nodeList":[],"switchList":[{"itemName":"NE2572","itemUUID":"00000000000010008000542AA2D3CB00","itemLocationRoom":"basement","itemLocationRack":"SueThinkAgile
+        Solution","itemLocation":"Rochester","itemLowerUnit":41,"itemType":"SWITCH","itemHeight":1,"itemSubType":"","itemInventory":{"name":"NE2572","uuid":"00000000000010008000542AA2D3CB00","accessState":"Offline","overallHealthState":"Critical","type":"Rackswitch","hostname":"NE2572","description":"48*25
+        GbE SFP+, 6*100 GbE QSFP+","dnsHostnames":[],"domainName":"","FRU":"","fruSerialNumber":"","ipv4Addresses":["10.241.107.248"],"ipv6Addresses":["fe80:0:0:0:562a:a2ff:fed3:cb"],"macAddresses":["2A:A2:D3:CB:00:00"],"machineType":"7159","manufacturer":"LNVO","manufacturerId":"","model":"xxx","partNumber":"SC57A24361","posID":"","powerState":"Unknown","productId":"","productName":"Lenovo
+        ThinkSystem NE2572 RackSwitch","protectedMode":"Unknown","serialNumber":"ABCDEFGHUJKL","stackMode":"none","vpdID":"","backedBy":"real","cmmDisplayName":"NE2572","cmmHealthState":"Critical","dataHandle":1519674286005,"elapsedTimeMillisecs":"867296622","errorFields":[],"firmware":[{"name":"Uboot","date":"","type":"Boot
+        ROM","build":"","version":"0.0.0.0","role":"","status":"N/A"},{"name":"Active
+        Image","date":"","type":"Main Image","build":"","version":"10.4.2.0","role":"","status":"Active"},{"name":"Standby
+        Image","date":"","type":"Main Image","build":"","version":"0.0.0.0","role":"","status":"Non-Active"}],"ipInterfaces":[{"name":"unknown","label":"unknown","IPv4enabled":false,"IPv4DHCPmode":"UNKNOWN","IPv6enabled":false,"IPv6DHCPenabled":false,"IPv4assignments":[{"id":0,"subnet":"127.0.0.1","gateway":"0.0.0.0","address":"10.241.107.248","type":"UNKNOWN"}],"IPv6assignments":[],"IPv6statelessEnabled":false,"IPv6staticEnabled":false}],"leds":[],"ntpPushEnabled":false,"ntpPushFrequency":0,"parent":{"uuid":"D9E74889-5929-45EC-83EC-60038EEA23C3","uri":"chassis/D9E74889-5929-45EC-83EC-60038EEA23C3"},"portDataSetTimestamp":"02:44:41","uri":"switches/00000000000010008000542AA2D3CB00","userDescription":"","userDefinedName":"NE2572","securityDescriptor":{"managedAuthSupported":false,"publicAccess":false,"uri":"switches/00000000000010008000542aa2d3cb00","roleGroups":[],"managedAuthEnabled":false},"applyPending":"No","contact":"","cpuUtilization":"N/A","entitleSerialNumber":"<EMPTY>","fans":[{"fanName":"Fan
+        1","fanSpeed":"4800 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        2","fanSpeed":"5250 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        3","fanSpeed":"4800 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        4","fanSpeed":"5250 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        5","fanSpeed":"4800 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        6","fanSpeed":"5400 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        7","fanSpeed":"4950 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        8","fanSpeed":"5250 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        10","fanSpeed":"5400 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        9","fanSpeed":"4950 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        11","fanSpeed":"4800 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        12","fanSpeed":"5250 RPM (23 PWM)","fanState":"Front-to-Back"}],"height":1,"location":{"lowestRackUnit":41,"location":"Rochester","rack":"SueThinkAgile
+        Solution","room":"basement"},"manufacturingDate":"0308 (WWYY)","memoryUtilization":"","mgmtProcIPaddress":"10.241.107.248","panicDump":"Yes","ports":[{"configuredStatus":"up","interfaceIndex":"410001","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/1","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410002","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/2","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410003","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/3","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410004","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/4","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410005","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/5","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410006","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/6","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410007","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/7","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410008","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/8","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410009","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/9","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410010","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/10","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410011","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/11","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410012","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/12","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410013","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/13","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410014","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/14","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410015","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/15","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410016","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/16","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410017","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/17","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410018","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/18","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410019","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/19","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410020","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/20","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410021","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/21","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410022","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/22","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410023","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/23","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410024","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/24","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410025","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/25","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410026","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/26","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410027","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/27","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410028","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/28","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410029","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/29","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410030","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/30","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410031","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/31","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410032","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/32","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410033","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/33","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410034","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/34","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410035","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/35","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410036","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/36","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410037","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/37","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410038","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/38","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410039","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/39","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410040","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/40","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410041","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/41","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410042","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/42","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410043","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/43","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410044","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/44","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410045","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/45","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410046","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/46","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410047","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/47","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410048","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/48","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410049","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/49","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410053","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/50","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410057","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/51","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410061","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/52","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410065","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/53","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410069","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/54","PVID":"default"}],"powerSupply":"Power
+        Supply 1: Off;Power Supply 2: on.","resetReason":"1","savePending":"No","stackRole":"none","sysObjectID":"1.3.6.1.4.1.19046.1.7.41","temperatureSensors":[{"sensorName":"
+        Ambient","sensorState":" 34 C"},{"sensorName":" CPU","sensorState":" 38 C"},{"sensorName":"Hot
+        Spot","sensorState":" 42 C"}],"upTime":"9 days, 03:10:35","isConnectionTrusted":"true","OS":"CNOS"}}],"storageList":[],"placeholderList":[],"UUID":"D9E74889-5929-45EC-83EC-60038EEA23C3"},{"cabinetName":"STANDALONE_OBJECT_NAME","height":42,"room":"","location":"","chassisList":[],"complexList":[{"slots":[1,1],"complexID":"7936DD182C5311E3A8D6000AF7256738","partitionCount":0,"uuid":"7936DD182C5311E3A8D6000AF7256738","nodeCount":1,"orphanNodes":[{"name":"cmm-dt1.labs.lenovo.com","uuid":"7936DD182C5311E3A8D6000AF7256738","status":{"message":"managed","name":"MANAGED"},"hostname":"IMM2-6cae8b4b4f15","overallHealthState":"Normal","productName":"Lenovo
+        System x3850 X6","type":"Rack-Tower Server","manufacturer":" IBM(CLCN)","machineType":"6241","model":"AC1","mgmtProcIPaddress":"10.243.6.17","arch":"x86","serialNumber":"23Y6458","partNumber":"00D0188     ","FRU":"None","fruSerialNumber":"None","domainName":"labs.lenovo.com","FQDN":"cmm-dt1.labs.lenovo.com","powerStatus":8,"userDescription":"","macAddress":"6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16","hostMacAddresses":"00:0A:F7:25:67:38,00:0A:F7:25:67:39","tlsVersion":{"possibleValues":["unsupported","TLS_12","TLS_11","TLS_10"],"currentValue":"TLS_12"},"nist":{"possibleValues":["Nist_800_131A_Strict","unsupported","Compatibility"],"currentValue":"Compatibility"},"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"lanOverUsb":"enabled","description":"Chassis","mgmtProcType":"IMM2","isRemotePresenceEnabled":true,"height":4,"leds":[{"name":"CPU
+        3 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM
+        10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 10Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CMOS Batt
+        Error","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU 3
+        DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        15","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"PS","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        12DIMM 16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"Check
+        Log","state":"Off","color":"Yellow","location":"FrontPanel"},{"name":"CPU
+        3 DIMM 24","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 14Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 20","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"OVER
+        SPEC","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        3 DIMM 11","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"DASD","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        1 DIMM 16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        4 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"ML2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 12","state":"Off","color":"Yellow","location":"FRU"},{"name":"BMC Heartbeat","state":"Blinking","color":"Green","location":"Planar"},{"name":"PCI
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"SysBrd","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN
+        2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        11","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        24","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book 4 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        2 DIMM 12","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"TEMP","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        5","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        20","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        2 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"Book
+        1 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 12Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"Fault","state":"Off","color":"Yellow","location":"FrontRearPanel"},{"name":"CPU
+        2 DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4
+        DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI
+        8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 20","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book 2 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        3 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        4 DIMM 11","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 13Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"Power","state":"On","color":"Green","location":"FrontRearPanel"},{"name":"CPU
+        4 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        12","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"MEM","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"NMI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CNFG","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        3 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 15","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        10PEC","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        11Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        24","state":"Off","color":"Yellow","location":"FRU"},{"name":"LINK","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        2 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        20","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 15","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Identify","state":"Off","color":"Blue","location":"FrontRearPanel"},{"name":"CPU
+        1 DIMM 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        1 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        4 DIMM 10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        15Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 11DIMM
+        16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        4 DIMM 24","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 9","state":"Off","color":"Yellow","location":"FRU"}],"expansionCards":[],"firmware":[{"name":"UEFI
+        Backup Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI-Backup","build":"A9E143HUS","version":"4.30","role":"Backup","status":"Inactive"},{"name":"IMM2
+        Backup Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2-Backup","build":"TCOO39A","version":"4.70","role":"Backup","status":"Inactive"},{"name":"DSA
+        Diagnostic Software","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2","role":"Primary","status":"Active"},{"name":"UEFI
+        Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"A9E143HUS","version":"4.30","role":"Primary","status":"Active"},{"name":"IMM2
+        Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70","role":"Primary","status":"Active"}],"powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K115136V11L","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 2","leds":[],"description":"","name":"Power Supply 2","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[3],"manufacturer":"DELT","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""},{"model":"","manufacturerId":"","serialNumber":"K115136V11E","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[2],"manufacturer":"DELT","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""}],"ipv4Addresses":["10.243.6.17","169.254.95.118"],"ipv6Addresses":["fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","fe80:0:0:0:6eae:8bff:fe4b:4f15"],"raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Firmware","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"description":"ServeRAID
+        M5210","name":"ServeRAID M5210","uuid":"0000000000000000500605B006E6ED5B","diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631","largestAvailableSize":512,"capacity":300000000000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"B56T","softwareID":"ST300MM0006"}],"FRU":"42D0628"}],"storagePools":[{"name":"Pool_0","arrayUid":"0","description":"0000000000000000500605B006E6ED5B_Storage
+        Pool_M5210_0000000000000000500605B006E6ED5B_c:Pool:0","arrayStatus":"Offline","totalManagedSpace":298999349248,"remainingSpace":0,"raidLevel":0,"storageVolumes":[{"name":"GenericR0_0","bootable":true,"description":"Volume
+        0 0000000000000000500605B006E6ED5B_0","blockSize":512,"numberOfBlocks":583983104,"primaryPartition":0,"stripeSize":65536,"volumeStatus":"Dynamic
+        Reconfig","volumeID":"6","volumeUID":"0","driveIndex":0,"removable":false,"health":"Unknown","LUN":-1}],"diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631","largestAvailableSize":512,"capacity":300000000000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"B56T","softwareID":"ST300MM0006"}],"FRU":"42D0628"}]}],"batteryData":[]}],"drives":[],"memoryModules":[{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65F9","displayName":"CPU 1 DIMM
+        9","slot":9,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FA","displayName":"CPU 1 DIMM
+        15","slot":15,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FE","displayName":"CPU 2 DIMM
+        9","slot":9,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF6603","displayName":"CPU 2 DIMM
+        15","slot":15,"type":"DDR3","partNumber":"Unknown","speedMBs":12800}],"processors":[{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15,"socket":"Socket 1"},{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":2,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15,"socket":"Socket 2"}],"pciDevices":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"7","pciDeviceNumber":"0","slotNumber":"12","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B006E6ED5B","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"0:0"}],"pciRevision":"0","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"0","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"0","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"}],"accessState":"Offline","manufacturerId":" IBM(CLCN)","addinCardSlots":0,"driveBays":17,"errorFields":[{"FirmwareData":"NO_CONNECTOR"},{"ChassisMounted":"NO_CONNECTOR"}],"bladeState":255,"activationKeys":[],"uri":"nodes/7936DD182C5311E3A8D6000AF7256738","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":1710,"minimumAllocatedPower":26},"expansionProductType":"","bootOrder":{"uri":"nodes/7936DD182C5311E3A8D6000AF7256738/bootOrder","bootOrderList":[{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS Linux","Windows Boot Manager","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom"],"bootType":"Permanent","possibleBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]}]},"expansionProducts":[],"slots":[1],"vpdID":"","encapsulation":{"encapsulationMode":"normal"},"secureBootMode":{"possibleValues":["Enabled","Disabled"],"currentValue":"Disabled"},"expansionCardSlots":0,"contact":"","dataHandle":1520459083510,"cmmDisplayName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","backedBy":"real","complexID":1,"memorySlots":4,"cmmHealthState":"Normal","subSlots":[],"excludedHealthState":"Normal","processorSlots":2,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config"],"productId":"4D4F00","hasOS":false,"ports":[{"ioModuleBay":0,"portNumber":49},{"ioModuleBay":0,"portNumber":50}],"embeddedHypervisorPresence":false,"posID":"","subType":"","partitionID":-1,"flashStorage":[],"userDefinedName":"","securityDescriptor":{"managedAuthSupported":true,"publicAccess":false,"uri":"nodes/7936dd182c5311e3a8d6000af7256738","roleGroups":[],"managedAuthEnabled":true,"storedCredentials":{"description":"Credentials
+        for null","id":"353","userName":"USERID"}},"logicalID":0,"primary":false,"powerCappingPolicy":{"cappingACorDCMode":"DC","minimumHardCapLevel":434100,"cappingPolicy":"OFF","maxPowerCap":533000,"minimumPowerCappingHotPlugLevel":754000,"powerCappingAllocUnit":"watts*10^-3","maximumPowerCappingHotPlugLevel":854000,"currentPowerCap":0,"minPowerCap":-1},"fans":[{"name":"Fan
+        1","healthState":"Normal","status":"OK","description":"Logical Device for
+        fan / cooling device 1","speed":3440,"slots":1},{"name":"Fan 4","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 4","speed":3440,"slots":4},{"name":"Fan 2","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 2","speed":3440,"slots":2},{"name":"Fan 9","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 9","speed":3440,"slots":9},{"name":"Fan 7","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 7","speed":3440,"slots":7},{"name":"Fan 6","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 6","speed":3440,"slots":6},{"name":"Fan 10","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 10","speed":3440,"slots":10},{"name":"Fan
+        8","healthState":"Warning","status":"Degraded","description":"Logical Device
+        for fan / cooling device 8","speed":3440,"slots":8},{"name":"Fan 3","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 3","speed":3440,"slots":3},{"name":"Fan 5","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 5","speed":3440,"slots":5}],"addinCards":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"7","pciDeviceNumber":"0","slotNumber":"12","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B006E6ED5B","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"}],"physicalID":0,"faceplateIDs":[{"name":"drive backplane 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0},{"name":"I/O
+        module 5","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0}],"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"m2Presence":false,"onboardPciDevices":[{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"0:0"}],"pciRevision":"0","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"0","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"0","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"}],"ipInterfaces":[{"name":"eth0","label":"unknown","IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.17","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"},{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"}],"IPv6statelessEnabled":true,"IPv6staticEnabled":false}],"parentComplexID":"7936DD182C5311E3A8D6000AF7256738","isConnectionTrusted":"true","isScalable":true,"isITME":false}],"partition":[],"location":{"lowestRackUnit":0,"location":"","rack":"","room":""}}],"nodeList":[{"itemName":"Management
+        Controller UUID-FC3058CADF8B11D48C9B9B1B1B1B1B57","itemUUID":"FC3058CADF8B11D48C9B9B1B1B1B1B57","itemLocationRoom":"","itemLocationRack":"","itemLocation":"","itemLowerUnit":0,"itemType":"SERVER","itemHeight":1,"itemSubType":"","complexNodeCount":-1,"nodeCount":-1,"physicalID":-1,"itemInventory":{"name":"DaAn1.labs.lenovo.com","uuid":"FC3058CADF8B11D48C9B9B1B1B1B1B57","status":{"message":"managed","name":"MANAGED"},"hostname":"IMM2-40f2e9b8163d","overallHealthState":"Normal","productName":"IBM
+        System x3550 M5","type":"Rack-Tower Server","manufacturer":" IBM(WIST)","machineType":"5463","model":"45Z","mgmtProcIPaddress":"10.243.6.68","arch":"x86","serialNumber":"KVD0152","partNumber":"00KC903     ","FRU":"None","fruSerialNumber":"None","domainName":"labs.lenovo.com","FQDN":"DaAn1.labs.lenovo.com","powerStatus":8,"userDescription":"","macAddress":"40:F2:E9:B8:16:3D,40:F2:E9:B8:16:3E","hostMacAddresses":"40:F2:E9:B8:16:38,40:F2:E9:B8:16:39,40:F2:E9:B8:16:3A,40:F2:E9:B8:16:3B","tlsVersion":{"possibleValues":["unsupported","TLS_12","TLS_11","TLS_10"],"currentValue":"TLS_12"},"nist":{"possibleValues":["Nist_800_131A_Strict","unsupported","Compatibility"],"currentValue":"Compatibility"},"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"lanOverUsb":"enabled","description":"Chassis","mgmtProcType":"IMM2","isRemotePresenceEnabled":true,"height":1,"leds":[{"name":"DIMM
+        13","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 2","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        21","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 15","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        9","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN 3","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        4","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 23","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU
+        2","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 18","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        7","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN 5","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        16","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN 2","state":"Off","color":"Yellow","location":"Planar"},{"name":"Check
+        Log","state":"Off","color":"Yellow","location":"FrontPanel"},{"name":"DIMM
+        11","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        7","state":"Off","color":"Yellow","location":"Planar"},{"name":"Identify","state":"Off","color":"Blue","location":"FrontRearPanel"},{"name":"Battery","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        22","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 14","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        3","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 12","state":"Off","color":"Yellow","location":"Planar"},{"name":"Power","state":"Blinking","color":"Green","location":"FrontRearPanel"},{"name":"SysBrd
+        Fault","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU 1","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        24","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 5","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN
+        4","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 19","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU
+        Mismatch Ctlr","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM 17","state":"Off","color":"Yellow","location":"Planar"},{"name":"Fault","state":"Off","color":"Yellow","location":"FrontRearPanel"},{"name":"FAN
+        6","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 6","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI
+        1","state":"Off","color":"Yellow","location":"FRU"},{"name":"Internal RAID","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN
+        8","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 8","state":"Off","color":"Yellow","location":"Planar"},{"name":"IMM2
+        Heartbeat","state":"Blinking","color":"Green","location":"Planar"},{"name":"DIMM
+        1","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 20","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        10","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN 1","state":"Off","color":"Yellow","location":"Planar"},{"name":"SDRAID
+        Error","state":"Off","color":"Yellow","location":"Planar"}],"expansionCards":[],"firmware":[{"name":"UEFI
+        Backup Firmware/BIOS","date":"2017-04-10T00:00:00Z","type":"UEFI-Backup","build":"TBE129J","version":"2.40","role":"Backup","status":"Inactive"},{"name":"UEFI
+        Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"TBE133J","version":"2.60","role":"Primary","status":"Active"},{"name":"IMM2
+        Backup Firmware","date":"2017-10-26T00:00:00Z","type":"IMM2-Backup","build":"TCOO61T","version":"9.00","role":"Backup","status":"Inactive"},{"name":"DSA
+        Diagnostic Software","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2","role":"Primary","status":"Active"},{"name":"IMM2
+        Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70","role":"Primary","status":"Active"}],"powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":0},"powerState":"Unknown","posID":"","slots":[1],"manufacturer":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""}],"ipv4Addresses":["10.243.6.68","169.254.95.118"],"ipv6Addresses":["fd55:faaf:e1ab:2021:42f2:e9ff:feb8:163d","fe80:0:0:0:42f2:e9ff:feb8:163d"],"raidSettings":[],"drives":[],"memoryModules":[{"model":"DDR4","speed":2133,"manufacturer":"Hynix
+        Semiconductor","capacity":4,"serialNumber":"103D4F3B","displayName":"DIMM
+        4","slot":4,"type":"DDR4","partNumber":"HMA451R7MFR8N-TFTD","speedMBs":16000}],"processors":[{"speed":2.3,"manufacturer":"Intel(R)
+        Corporation","family":"INTEL_R_XEON_TM","displayName":"Intel(R) Xeon(R) CPU
+        E5-2650 v3 @ 2.30GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E5-2650
+        v3 @ 2.30GHz","cores":10,"socket":"Socket 1"}],"pciDevices":[{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"1d49:a01"}],"pciRevision":"1","pciBusNumber":"20","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"a01","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"1d49","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B81638","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"2","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":3,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B8163A","vnicMode":false}],"peerBay":0,"physicalPortIndex":3}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"3","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":4,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B8163B","vnicMode":false}],"peerBay":0,"physicalPortIndex":4}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"1","pciDeviceNumber":"0","slotNumber":"4","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B008E547C0","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV42103710","slotName":"SlotDesig4_Slot
+        4","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"1","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":2,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B81639","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"}],"accessState":"Online","manufacturerId":" IBM(WIST)","addinCardSlots":0,"driveBays":0,"errorFields":[{"HealthState":"FATAL_EXCEPTION"},{"HealthSummary":"FATAL_EXCEPTION"},{"FirmwareData":"NO_CONNECTOR"},{"NetworkInterfaceData":"FATAL_EXCEPTION"},{"ChassisMounted":"NO_CONNECTOR"},{"PhysicalAndLocation":"FETCH_FAILED"},{"ServerSlots":"FATAL_EXCEPTION"},{"ServerExpansionHardware":"FATAL_EXCEPTION"},{"RackCPU":"FETCH_FAILED"},{"BootOrder":"FETCH_FAILED"},{"FlashDimm":"FETCH_FAILED"},{"ServerFirmwareData":"FETCH_FAILED"},{"RackPowerCappingPolicy":"FETCH_FAILED"}],"bladeState":0,"activationKeys":[{"keyFeatureType":1,"keyStatus":"VALID","description":"IBM
+        Integrated Management Module Advanced Upgrade","keyUseLimit":0,"keyExpirationDate":"","keyUseCount":0,"uuid":"bcf7e81e99c7b67f","keyIdentiferList":[{"keyIdentifierType":"MT","keyIdentifier":"5463KVD0152"}]}],"uri":"nodes/FC3058CADF8B11D48C9B9B1B1B1B1B57","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":0,"minimumAllocatedPower":0},"expansionProductType":"","bootOrder":{"uri":"nodes/FC3058CADF8B11D48C9B9B1B1B1B1B57/bootOrder","bootOrderList":[{"currentBootOrderDevices":["CentOS
+        Linux","Hard Disk 0","CentOS","CD/DVD Rom","PXE Network"],"bootType":"Permanent","possibleBootOrderDevices":["CentOS
+        Linux","Hard Disk 0","CentOS","CD/DVD Rom","PXE Network","Floppy Disk","Hard
+        Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","IMM1","IMM2","USB1","USB2","USB3","USB4","USB5","USB6","SdRaid","USB8","Slot4","Slot1","Slot2","Slot2","Slot3","NIC1","NIC2","NIC3","NIC4","CD/DVD","SATA
+        Port 0","SATA Port 1","SATA Port 2","SATA Port 3","sSATA Port 0","sSATA Port
+        1","sSATA Port 2","sSATA Port 3","DSA"]},{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]},{"currentBootOrderDevices":["PXE Network","CD/DVD Rom","Hard Disk
+        0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE Network","CD/DVD
+        Rom","Hard Disk 0","CentOS Linux","CentOS","Floppy Disk","Hard Disk 1","Hard
+        Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","IMM1","IMM2","USB1","USB2","USB3","USB4","USB5","USB6","SdRaid","USB8","Slot4","Slot1","Slot2","Slot2","Slot3","NIC1","NIC2","NIC3","NIC4","CD/DVD","SATA
+        Port 0","SATA Port 1","SATA Port 2","SATA Port 3","sSATA Port 0","sSATA Port
+        1","sSATA Port 2","sSATA Port 3","DSA"]}]},"expansionProducts":[],"slots":[1],"vpdID":"","encapsulation":{"encapsulationMode":"normal"},"secureBootMode":{"possibleValues":["Enabled","Disabled"],"currentValue":"Disabled"},"expansionCardSlots":0,"contact":"","dataHandle":1520530055801,"cmmDisplayName":"Management
+        Controller UUID-FC3058CADF8B11D48C9B9B1B1B1B1B57","backedBy":"real","complexID":-1,"memorySlots":0,"cmmHealthState":"Normal","subSlots":[],"excludedHealthState":"Normal","processorSlots":0,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config","OOB
+        Option Firmware Update"],"productId":"4D4F00","hasOS":false,"ports":[{"ioModuleBay":0,"portNumber":1},{"ioModuleBay":0,"portNumber":2},{"ioModuleBay":0,"portNumber":3},{"ioModuleBay":0,"portNumber":4}],"embeddedHypervisorPresence":false,"posID":"","subType":"","partitionID":-1,"flashStorage":[],"userDefinedName":"","securityDescriptor":{"managedAuthSupported":true,"publicAccess":false,"uri":"nodes/fc3058cadf8b11d48c9b9b1b1b1b1b57","roleGroups":[],"managedAuthEnabled":true,"storedCredentials":{"description":"Credentials
+        for SN#KVD0152","id":"360","userName":"USERID"}},"logicalID":-1,"primary":false,"fans":[{"name":"Fan
+        5","healthState":"Normal","status":"OK","description":"Logical Device for
+        fan / cooling device 5","speed":6966,"slots":5},{"name":"Fan 7","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 7","speed":6966,"slots":7},{"name":"Fan 2","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 2","speed":6966,"slots":2},{"name":"Fan 3","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 3","speed":6966,"slots":3},{"name":"Fan 6","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 6","speed":6966,"slots":6},{"name":"Fan 1","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 1","speed":6966,"slots":1},{"name":"Fan 4","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 4","speed":6966,"slots":4},{"name":"Fan 8","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 8","speed":6966,"slots":8}],"addinCards":[{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"1","pciDeviceNumber":"0","slotNumber":"4","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B008E547C0","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV42103710","slotName":"SlotDesig4_Slot
+        4","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"}],"physicalID":0,"faceplateIDs":[],"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"m2Presence":false,"onboardPciDevices":[{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"1d49:a01"}],"pciRevision":"1","pciBusNumber":"20","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"a01","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"1d49","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"2","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":3,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B8163A","vnicMode":false}],"peerBay":0,"physicalPortIndex":3}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B81638","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"3","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":4,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B8163B","vnicMode":false}],"peerBay":0,"physicalPortIndex":4}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"1","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":2,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B81639","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"}],"ipInterfaces":[{"name":"eth0","label":"unknown","IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.68","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:42f2:e9ff:feb8:163d","prefix":64,"type":"INUSE"},{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:42f2:e9ff:feb8:163d","prefix":64,"type":"INUSE"}],"IPv6statelessEnabled":true,"IPv6staticEnabled":false}],"isConnectionTrusted":"true","isScalable":false,"isITME":false}},{"itemName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","itemUUID":"7936DD182C5311E3A8D6000AF7256738","itemLocationRoom":"","itemLocationRack":"","itemLocation":"","itemLowerUnit":0,"itemType":"SERVER","itemHeight":4,"itemSubType":"","complexID":"7936DD182C5311E3A8D6000AF7256738","complexNodeCount":1,"complexNodeUUIDs":["7936DD182C5311E3A8D6000AF7256738"],"nodeCount":1,"physicalID":0,"itemInventory":{"name":"cmm-dt1.labs.lenovo.com","uuid":"7936DD182C5311E3A8D6000AF7256738","status":{"message":"managed","name":"MANAGED"},"hostname":"IMM2-6cae8b4b4f15","overallHealthState":"Normal","productName":"Lenovo
+        System x3850 X6","type":"Rack-Tower Server","manufacturer":" IBM(CLCN)","machineType":"6241","model":"AC1","mgmtProcIPaddress":"10.243.6.17","arch":"x86","serialNumber":"23Y6458","partNumber":"00D0188     ","FRU":"None","fruSerialNumber":"None","domainName":"labs.lenovo.com","FQDN":"cmm-dt1.labs.lenovo.com","powerStatus":8,"userDescription":"","macAddress":"6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16","hostMacAddresses":"00:0A:F7:25:67:38,00:0A:F7:25:67:39","tlsVersion":{"possibleValues":["unsupported","TLS_12","TLS_11","TLS_10"],"currentValue":"TLS_12"},"nist":{"possibleValues":["Nist_800_131A_Strict","unsupported","Compatibility"],"currentValue":"Compatibility"},"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"lanOverUsb":"enabled","description":"Chassis","mgmtProcType":"IMM2","isRemotePresenceEnabled":true,"height":4,"leds":[{"name":"CPU
+        3 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM
+        10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 10Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CMOS Batt
+        Error","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU 3
+        DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        15","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"PS","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        12DIMM 16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"Check
+        Log","state":"Off","color":"Yellow","location":"FrontPanel"},{"name":"CPU
+        3 DIMM 24","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 14Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 20","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"OVER
+        SPEC","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        3 DIMM 11","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"DASD","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        1 DIMM 16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        4 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"ML2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 12","state":"Off","color":"Yellow","location":"FRU"},{"name":"BMC Heartbeat","state":"Blinking","color":"Green","location":"Planar"},{"name":"PCI
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"SysBrd","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN
+        2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        11","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        24","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book 4 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        2 DIMM 12","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"TEMP","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        5","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        20","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        2 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"Book
+        1 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 12Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"Fault","state":"Off","color":"Yellow","location":"FrontRearPanel"},{"name":"CPU
+        2 DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4
+        DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI
+        8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 20","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book 2 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        3 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        4 DIMM 11","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 13Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"Power","state":"On","color":"Green","location":"FrontRearPanel"},{"name":"CPU
+        4 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        12","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"MEM","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"NMI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CNFG","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        3 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 15","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        10PEC","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        11Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        24","state":"Off","color":"Yellow","location":"FRU"},{"name":"LINK","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        2 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        20","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 15","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Identify","state":"Off","color":"Blue","location":"FrontRearPanel"},{"name":"CPU
+        1 DIMM 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        1 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        4 DIMM 10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        15Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 11DIMM
+        16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        4 DIMM 24","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 9","state":"Off","color":"Yellow","location":"FRU"}],"expansionCards":[],"firmware":[{"name":"UEFI
+        Backup Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI-Backup","build":"A9E143HUS","version":"4.30","role":"Backup","status":"Inactive"},{"name":"IMM2
+        Backup Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2-Backup","build":"TCOO39A","version":"4.70","role":"Backup","status":"Inactive"},{"name":"DSA
+        Diagnostic Software","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2","role":"Primary","status":"Active"},{"name":"UEFI
+        Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"A9E143HUS","version":"4.30","role":"Primary","status":"Active"},{"name":"IMM2
+        Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70","role":"Primary","status":"Active"}],"powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K115136V11L","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 2","leds":[],"description":"","name":"Power Supply 2","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[3],"manufacturer":"DELT","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""},{"model":"","manufacturerId":"","serialNumber":"K115136V11E","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[2],"manufacturer":"DELT","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""}],"ipv4Addresses":["10.243.6.17","169.254.95.118"],"ipv6Addresses":["fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","fe80:0:0:0:6eae:8bff:fe4b:4f15"],"raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Firmware","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"description":"ServeRAID
+        M5210","name":"ServeRAID M5210","uuid":"0000000000000000500605B006E6ED5B","diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631","largestAvailableSize":512,"capacity":300000000000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"B56T","softwareID":"ST300MM0006"}],"FRU":"42D0628"}],"storagePools":[{"name":"Pool_0","arrayUid":"0","description":"0000000000000000500605B006E6ED5B_Storage
+        Pool_M5210_0000000000000000500605B006E6ED5B_c:Pool:0","arrayStatus":"Offline","totalManagedSpace":298999349248,"remainingSpace":0,"raidLevel":0,"storageVolumes":[{"name":"GenericR0_0","bootable":true,"description":"Volume
+        0 0000000000000000500605B006E6ED5B_0","blockSize":512,"numberOfBlocks":583983104,"primaryPartition":0,"stripeSize":65536,"volumeStatus":"Dynamic
+        Reconfig","volumeID":"6","volumeUID":"0","driveIndex":0,"removable":false,"health":"Unknown","LUN":-1}],"diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631","largestAvailableSize":512,"capacity":300000000000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"B56T","softwareID":"ST300MM0006"}],"FRU":"42D0628"}]}],"batteryData":[]}],"drives":[],"memoryModules":[{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65F9","displayName":"CPU 1 DIMM
+        9","slot":9,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FA","displayName":"CPU 1 DIMM
+        15","slot":15,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FE","displayName":"CPU 2 DIMM
+        9","slot":9,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF6603","displayName":"CPU 2 DIMM
+        15","slot":15,"type":"DDR3","partNumber":"Unknown","speedMBs":12800}],"processors":[{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15,"socket":"Socket 1"},{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":2,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15,"socket":"Socket 2"}],"pciDevices":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"7","pciDeviceNumber":"0","slotNumber":"12","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B006E6ED5B","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"0:0"}],"pciRevision":"0","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"0","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"0","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"}],"accessState":"Offline","manufacturerId":" IBM(CLCN)","addinCardSlots":0,"driveBays":17,"errorFields":[{"FirmwareData":"NO_CONNECTOR"},{"ChassisMounted":"NO_CONNECTOR"}],"bladeState":255,"activationKeys":[],"uri":"nodes/7936DD182C5311E3A8D6000AF7256738","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":1710,"minimumAllocatedPower":26},"expansionProductType":"","bootOrder":{"uri":"nodes/7936DD182C5311E3A8D6000AF7256738/bootOrder","bootOrderList":[{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS Linux","Windows Boot Manager","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom"],"bootType":"Permanent","possibleBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]}]},"expansionProducts":[],"slots":[1],"vpdID":"","encapsulation":{"encapsulationMode":"normal"},"secureBootMode":{"possibleValues":["Enabled","Disabled"],"currentValue":"Disabled"},"expansionCardSlots":0,"contact":"","dataHandle":1520459083510,"cmmDisplayName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","backedBy":"real","complexID":1,"memorySlots":4,"cmmHealthState":"Normal","subSlots":[],"excludedHealthState":"Normal","processorSlots":2,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config"],"productId":"4D4F00","hasOS":false,"ports":[{"ioModuleBay":0,"portNumber":49},{"ioModuleBay":0,"portNumber":50}],"embeddedHypervisorPresence":false,"posID":"","subType":"","partitionID":-1,"flashStorage":[],"userDefinedName":"","securityDescriptor":{"managedAuthSupported":true,"publicAccess":false,"uri":"nodes/7936dd182c5311e3a8d6000af7256738","roleGroups":[],"managedAuthEnabled":true,"storedCredentials":{"description":"Credentials
+        for null","id":"353","userName":"USERID"}},"logicalID":0,"primary":false,"powerCappingPolicy":{"cappingACorDCMode":"DC","minimumHardCapLevel":434100,"cappingPolicy":"OFF","maxPowerCap":533000,"minimumPowerCappingHotPlugLevel":754000,"powerCappingAllocUnit":"watts*10^-3","maximumPowerCappingHotPlugLevel":854000,"currentPowerCap":0,"minPowerCap":-1},"fans":[{"name":"Fan
+        1","healthState":"Normal","status":"OK","description":"Logical Device for
+        fan / cooling device 1","speed":3440,"slots":1},{"name":"Fan 4","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 4","speed":3440,"slots":4},{"name":"Fan 2","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 2","speed":3440,"slots":2},{"name":"Fan 9","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 9","speed":3440,"slots":9},{"name":"Fan 7","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 7","speed":3440,"slots":7},{"name":"Fan 6","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 6","speed":3440,"slots":6},{"name":"Fan 10","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 10","speed":3440,"slots":10},{"name":"Fan
+        8","healthState":"Warning","status":"Degraded","description":"Logical Device
+        for fan / cooling device 8","speed":3440,"slots":8},{"name":"Fan 3","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 3","speed":3440,"slots":3},{"name":"Fan 5","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 5","speed":3440,"slots":5}],"addinCards":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"7","pciDeviceNumber":"0","slotNumber":"12","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B006E6ED5B","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"}],"physicalID":0,"faceplateIDs":[{"name":"drive backplane 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0},{"name":"I/O
+        module 5","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0}],"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"m2Presence":false,"onboardPciDevices":[{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"0:0"}],"pciRevision":"0","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"0","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"0","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"}],"ipInterfaces":[{"name":"eth0","label":"unknown","IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.17","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"},{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"}],"IPv6statelessEnabled":true,"IPv6staticEnabled":false}],"parentComplexID":"7936DD182C5311E3A8D6000AF7256738","isConnectionTrusted":"true","isScalable":true,"isITME":false}}],"switchList":[{"itemName":"ThinkAgile-VX-NE1032-SW02","itemUUID":"00000000000010008000A48CDB984C00","itemLocationRoom":"","itemLocationRack":"","itemLocation":"","itemLowerUnit":0,"itemType":"SWITCH","itemHeight":1,"itemSubType":"","itemInventory":{"name":"ThinkAgile-VX-NE1032-SW02","uuid":"00000000000010008000A48CDB984C00","accessState":"Online","overallHealthState":"Non-Critical","type":"Rackswitch","hostname":"ThinkAgile-VX-NE1032-SW02","description":"32*10
+        GbE SFP+","dnsHostnames":[],"domainName":"","FRU":"","fruSerialNumber":"","ipv4Addresses":["10.243.4.78"],"ipv6Addresses":[],"macAddresses":["A4:8C:DB:98:4C:00"],"machineType":"7159","manufacturer":"LNVO","manufacturerId":"","model":"HD1","partNumber":"00YL949     ","posID":"","powerState":"On","productId":"","productName":"Lenovo
+        ThinkSystem NE1032 RackSwitch","protectedMode":"Unknown","serialNumber":"Y056DH79E047","stackMode":"none","vpdID":"","backedBy":"real","cmmDisplayName":"ThinkAgile-VX-NE1032-SW02","cmmHealthState":"Non-Critical","dataHandle":1520541131020,"elapsedTimeMillisecs":"297198","errorFields":[],"firmware":[{"name":"Uboot","date":"","type":"Boot
+        ROM","build":"","version":"10.4.2.0","role":"","status":"N/A"},{"name":"Active
+        Image","date":"","type":"Main Image","build":"","version":"10.4.2.0","role":"","status":"Active"},{"name":"Standby
+        Image","date":"","type":"Main Image","build":"","version":"10.4.2.0","role":"","status":"Non-Active"}],"ipInterfaces":[{"name":"unknown","label":"unknown","IPv4enabled":false,"IPv4DHCPmode":"UNKNOWN","IPv6enabled":false,"IPv6DHCPenabled":false,"IPv4assignments":[{"id":0,"subnet":"127.0.0.1","gateway":"0.0.0.0","address":"10.243.4.78","type":"UNKNOWN"}],"IPv6assignments":[],"IPv6statelessEnabled":false,"IPv6staticEnabled":false}],"leds":[],"ntpPushEnabled":false,"ntpPushFrequency":0,"parent":{},"portDataSetTimestamp":"03:32:08","uri":"switches/00000000000010008000A48CDB984C00","userDescription":"","userDefinedName":"ThinkAgile-VX-NE1032-SW02","securityDescriptor":{"managedAuthSupported":false,"publicAccess":false,"uri":"switches/00000000000010008000a48cdb984c00","roleGroups":[],"managedAuthEnabled":false},"applyPending":"No","contact":"","cpuUtilization":"N/A","entitleSerialNumber":"MM41941","fans":[{"fanName":"Fan
+        1","fanSpeed":"1782 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        2","fanSpeed":"1914 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        3","fanSpeed":"1782 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        4","fanSpeed":"1914 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        5","fanSpeed":"1848 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        6","fanSpeed":"1914 RPM (23 PWM)","fanState":"Back-to-Front"}],"height":1,"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"manufacturingDate":"3817
+        (WWYY)","memoryUtilization":"","mgmtProcIPaddress":"10.243.4.78","panicDump":"Yes","ports":[{"configuredStatus":"up","interfaceIndex":"410001","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e6:47:50","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/1","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410002","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/2","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410003","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e6:47:18","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/3","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410004","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/4","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410005","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e3:23:f0","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/5","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410006","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/6","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410007","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e3:2d:c9","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/7","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410008","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/8","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410009","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e2:ff:20","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/9","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410010","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/10","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410011","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/11","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410012","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/12","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410013","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/13","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410014","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/14","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410015","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/15","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410016","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/16","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410017","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/17","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410018","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/18","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410019","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/19","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410020","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/20","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410021","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/21","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410022","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/22","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410023","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/23","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410024","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/24","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410025","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/25","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410026","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/26","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410027","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/27","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410028","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/28","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410029","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/29","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410030","operationalStatus":"up","peerMacAddress":"a4:8c:db:b3:40:00","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/30","PVID":"\"ESXi-Mgmt-Network-VLAN20\""},{"configuredStatus":"up","interfaceIndex":"410031","operationalStatus":"up","peerMacAddress":"a4:8c:db:98:4b:20","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/31","PVID":"\"ISL-Network-VLAN2001\""},{"configuredStatus":"up","interfaceIndex":"410032","operationalStatus":"up","peerMacAddress":"a4:8c:db:98:4b:21","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/32","PVID":"\"ISL-Network-VLAN2001\""}],"powerSupply":"Power
+        Supply 1: on;Power Supply 2: on.","resetReason":"1","savePending":"No","stackRole":"none","sysObjectID":"1.3.6.1.4.1.19046.1.7.32","temperatureSensors":[{"sensorName":"
+        MAC Temp","sensorState":" 34 C"},{"sensorName":" HotSpot1 Temp","sensorState":"
+        33 C"},{"sensorName":"Inlet Temp","sensorState":" 27 C"},{"sensorName":" Exhaust
+        Temp","sensorState":" 30 C"},{"sensorName":" HotSpot2 Temp","sensorState":"
+        30 C"}],"upTime":"1 day, 15:48:54","isConnectionTrusted":"true","OS":"CNOS"}}],"storageList":[],"placeholderList":[],"UUID":"STANDALONE_OBJECT_UUID"}]}'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:01 GMT
+- request:
+    method: get
+    uri: https://10.243.6.103/patterns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQYXNzdzByZA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:01 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=15550200; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - default-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src
+        'self' 'unsafe-inline'; worker-src 'self' blob:; child-src 'self' blob:; img-src
+        'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.0.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '610'
+    body:
+      encoding: UTF-8
+      string: '{"identifier":"id","label":"name","items":[{"formFactor":"r","userDefined":true,"serverType":"IMMv2","name":"cmm_ys21_pattern","inUse":false,"description":"Pattern
+        created from server: cmm-ys21\nLearned on: Feb 22, 2018 10:42:39 AM","id":"53","referencedBy":[],"type":"Server","nodeType":"sysx","uri":"/config/template/53"},{"formFactor":"r","userDefined":true,"serverType":"IMMv2","name":"new_cmm_ys21_pattern","inUse":true,"description":"Pattern
+        created from server: cmm-ys21\nLearned on: Feb 22, 2018 11:07:21 AM","id":"62","referencedBy":[],"type":"Server","nodeType":"sysx","uri":"/config/template/62"}]}
+
+'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:01 GMT
+- request:
+    method: get
+    uri: https://10.243.9.123/aicc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQQVNTVzByRA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:01 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=86400; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline'''
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '1'
+      Content-Type:
+      - application/com.lenovo.lxca-v1.2.2+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"ntp":{"servers":[{"v3_key_type":"","authenticated":false,"v3_key":"","v3_key_index":0,"server":"us.pool.ntp.org","version":1}]},"services":[{"id":"core","initd":"xhmc-core","state":0,"pid":2256},{"id":"keydaemon","initd":"lxca-keydaemon","state":4,"pid":-1},{"id":"watchdog","initd":"sympl-watchdog","state":0,"pid":2584},{"id":"apache","initd":"httpd","state":3,"pid":-1},{"id":"network","initd":"network","state":0,"pid":-1},{"id":"ntp","initd":"ntpd","state":0,"pid":2304},{"id":"portreserve","initd":"portreserve","state":3,"pid":-1},{"id":"slp","initd":"slpd","state":0,"pid":1665},{"id":"sftp","initd":"sshd","state":0,"pid":2288},{"id":"xcat","initd":"xcatd","state":3,"pid":-1}],"subscriptions":[{"id":1,"monitor_uri":"/aicc/network/interfaces","uri":"/netchangenotsec","submonitor_uri":""},{"id":2,"monitor_uri":"/aicc","uri":"/ntpNotification","submonitor_uri":"/ntp"},{"id":3,"monitor_uri":"/aicc/network/interfaces","uri":"/osdeployment/rest/internal/event/aicc","submonitor_uri":""}],"service_states":[{"description":"Service
+        is running","state":0},{"description":"Service is dead but PID file exists","state":1},{"description":"Service
+        is dead but lock file exists","state":2},{"description":"Service is not running","state":3},{"description":"Service
+        state is unknown","state":4},{"description":"Special purpose state used to
+        trigger restart through REST","state":191}],"network_interfaces":[{"mac_address":"00:0C:29:85:AC:49","id":"eth0","role":["management"],"ip_addresses":[{"prefix_length":64,"assign_method":"static","ip_linklocal":"true","version":6,"ip":"fe80:0:0:0:20c:29ff:fe85:ac49%2"},{"prefix_length":20,"assign_method":"static","ip_linklocal":"false","version":4,"ip":"10.243.9.123"},{"prefix_length":64,"assign_method":"dhcp","ip_linklocal":"false","version":6,"ip":"0::0%0"}],"rpf":"RFC3704Strict"},{"mac_address":"00:0C:29:85:AC:53","id":"eth1","role":["none"],"ip_addresses":[{"prefix_length":64,"assign_method":"static","ip_linklocal":"true","version":6,"ip":"fe80:0:0:0:20c:29ff:fe85:ac53%3"}],"rpf":"RFC3704Strict"}],"appliance_states":[{"description":"Halt
+        the appliance","runlevel":0},{"description":"Normal operation","runlevel":3},{"description":"Reboot
+        the appliance","runlevel":6}],"date":{"utc_offset":-18000000,"timezones":[{"id":"Etc/GMT+12","display_name":"GMT-12:00","utc_offset_w_dst":-43200000,"daylight_saves":0,"uses_daylight":false,"offset":-43200000,"utc_offset_raw":-43200000},{"id":"Etc/GMT+11","display_name":"GMT-11:00","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"Pacific/Midway","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"Pacific/Niue","display_name":"Niue
+        Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"Pacific/Pago_Pago","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"Pacific/Samoa","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"US/Samoa","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0,"uses_daylight":false,"offset":-39600000,"utc_offset_raw":-39600000},{"id":"America/Adak","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"America/Atka","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Etc/GMT+10","display_name":"GMT-10:00","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"HST","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Honolulu","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Johnston","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Rarotonga","display_name":"Cook
+        Is. Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Tahiti","display_name":"Tahiti
+        Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"SystemV/HST10","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"US/Aleutian","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"US/Hawaii","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0,"uses_daylight":false,"offset":-36000000,"utc_offset_raw":-36000000},{"id":"Pacific/Marquesas","display_name":"Marquesas
+        Time","utc_offset_w_dst":-34200000,"daylight_saves":0,"uses_daylight":false,"offset":-34200000,"utc_offset_raw":-34200000},{"id":"AST","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Anchorage","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Juneau","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Metlakatla","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Nome","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Sitka","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Yakutat","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"Etc/GMT+9","display_name":"GMT-09:00","utc_offset_w_dst":-32400000,"daylight_saves":0,"uses_daylight":false,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"Pacific/Gambier","display_name":"Gambier
+        Time","utc_offset_w_dst":-32400000,"daylight_saves":0,"uses_daylight":false,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"SystemV/YST9","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":0,"uses_daylight":false,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"SystemV/YST9YDT","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"US/Alaska","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-32400000,"utc_offset_raw":-32400000},{"id":"America/Dawson","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Ensenada","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Los_Angeles","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Santa_Isabel","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Tijuana","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Vancouver","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Whitehorse","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Canada/Pacific","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Canada/Yukon","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Etc/GMT+8","display_name":"GMT-08:00","utc_offset_w_dst":-28800000,"daylight_saves":0,"uses_daylight":false,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Mexico/BajaNorte","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"PST","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"PST8PDT","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"Pacific/Pitcairn","display_name":"Pitcairn
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":0,"uses_daylight":false,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"SystemV/PST8","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":0,"uses_daylight":false,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"SystemV/PST8PDT","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"US/Pacific","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"US/Pacific-New","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-28800000,"utc_offset_raw":-28800000},{"id":"America/Boise","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Cambridge_Bay","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Chihuahua","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Creston","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Dawson_Creek","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Denver","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Edmonton","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Fort_Nelson","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Hermosillo","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Inuvik","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Mazatlan","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Ojinaga","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Phoenix","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Shiprock","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Yellowknife","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"Canada/Mountain","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"Etc/GMT+7","display_name":"GMT-07:00","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"MST","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"MST7MDT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"Mexico/BajaSur","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"Navajo","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"PNT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"SystemV/MST7","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"SystemV/MST7MDT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"US/Arizona","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0,"uses_daylight":false,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"US/Mountain","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":-25200000,"utc_offset_raw":-25200000},{"id":"America/Bahia_Banderas","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Belize","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Chicago","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Costa_Rica","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/El_Salvador","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Guatemala","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Indiana/Knox","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Indiana/Tell_City","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Knox_IN","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Managua","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Matamoros","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Menominee","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Merida","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Mexico_City","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Monterrey","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/North_Dakota/Beulah","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/North_Dakota/Center","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/North_Dakota/New_Salem","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Rainy_River","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Rankin_Inlet","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Regina","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Resolute","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Swift_Current","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Tegucigalpa","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Winnipeg","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"CST","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"CST6CDT","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Canada/Central","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Canada/East-Saskatchewan","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Canada/Saskatchewan","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Chile/EasterIsland","display_name":"Easter
+        Is. Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-21600000},{"id":"Etc/GMT+6","display_name":"GMT-06:00","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Mexico/General","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"Pacific/Easter","display_name":"Easter
+        Is. Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-21600000},{"id":"Pacific/Galapagos","display_name":"Galapagos
+        Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"SystemV/CST6","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0,"uses_daylight":false,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"SystemV/CST6CDT","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"US/Central","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"US/Indiana-Starke","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-21600000,"utc_offset_raw":-21600000},{"id":"America/Atikokan","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Bogota","display_name":"Colombia
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Cancun","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Cayman","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Coral_Harbour","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Detroit","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Eirunepe","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Fort_Wayne","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Guayaquil","display_name":"Ecuador
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Havana","display_name":"Cuba
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Indianapolis","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Marengo","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Petersburg","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Vevay","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Vincennes","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indiana/Winamac","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Indianapolis","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Iqaluit","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Jamaica","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Kentucky/Louisville","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Kentucky/Monticello","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Lima","display_name":"Peru
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Louisville","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Montreal","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Nassau","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/New_York","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Nipigon","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Panama","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Pangnirtung","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Port-au-Prince","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Porto_Acre","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Rio_Branco","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Thunder_Bay","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Toronto","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Brazil/Acre","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Canada/Eastern","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Cuba","display_name":"Cuba
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"EST","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"EST5EDT","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Etc/GMT+5","display_name":"GMT-05:00","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"IET","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"Jamaica","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"SystemV/EST5","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0,"uses_daylight":false,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"SystemV/EST5EDT","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"US/East-Indiana","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"US/Eastern","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"US/Michigan","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000,"uses_daylight":true,"offset":-18000000,"utc_offset_raw":-18000000},{"id":"America/Anguilla","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Antigua","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Aruba","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Asuncion","display_name":"Paraguay
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-14400000},{"id":"America/Barbados","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Blanc-Sablon","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Boa_Vista","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Campo_Grande","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Caracas","display_name":"Venezuela
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Cuiaba","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Curacao","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Dominica","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Glace_Bay","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Goose_Bay","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Grand_Turk","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Grenada","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Guadeloupe","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Guyana","display_name":"Guyana
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Halifax","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Kralendijk","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/La_Paz","display_name":"Bolivia
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Lower_Princes","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Manaus","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Marigot","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Martinique","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Moncton","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Montserrat","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Port_of_Spain","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Porto_Velho","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Puerto_Rico","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Santiago","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-14400000},{"id":"America/Santo_Domingo","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Barthelemy","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Kitts","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Lucia","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Thomas","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Vincent","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Thule","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Tortola","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/Virgin","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"Antarctica/Palmer","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-14400000},{"id":"Atlantic/Bermuda","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"Brazil/West","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"Canada/Atlantic","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"Chile/Continental","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-14400000},{"id":"Etc/GMT+4","display_name":"GMT-04:00","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"PRT","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"SystemV/AST4","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0,"uses_daylight":false,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"SystemV/AST4ADT","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000,"uses_daylight":true,"offset":-14400000,"utc_offset_raw":-14400000},{"id":"America/St_Johns","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-12600000,"utc_offset_raw":-12600000},{"id":"CNT","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-12600000,"utc_offset_raw":-12600000},{"id":"Canada/Newfoundland","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-12600000,"utc_offset_raw":-12600000},{"id":"AGT","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Araguaina","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Buenos_Aires","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Catamarca","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/ComodRivadavia","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Cordoba","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Jujuy","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/La_Rioja","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Mendoza","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Rio_Gallegos","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Salta","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/San_Juan","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/San_Luis","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Tucuman","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Argentina/Ushuaia","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Bahia","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Belem","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Buenos_Aires","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Catamarca","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Cayenne","display_name":"French
+        Guiana Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Cordoba","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Fortaleza","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Godthab","display_name":"Western
+        Greenland Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Jujuy","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Maceio","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Mendoza","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Miquelon","display_name":"Pierre
+        & Miquelon Standard Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Montevideo","display_name":"Uruguay
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Paramaribo","display_name":"Suriname
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Recife","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Rosario","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Santarem","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Sao_Paulo","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"Antarctica/Rothera","display_name":"Rothera
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"Atlantic/Stanley","display_name":"Falkland
+        Is. Time","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"BET","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"Brazil/East","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000,"uses_daylight":true,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"Etc/GMT+3","display_name":"GMT-03:00","utc_offset_w_dst":-10800000,"daylight_saves":0,"uses_daylight":false,"offset":-10800000,"utc_offset_raw":-10800000},{"id":"America/Noronha","display_name":"Fernando
+        de Noronha Time","utc_offset_w_dst":-7200000,"daylight_saves":0,"uses_daylight":false,"offset":-7200000,"utc_offset_raw":-7200000},{"id":"Atlantic/South_Georgia","display_name":"South
+        Georgia Standard Time","utc_offset_w_dst":-7200000,"daylight_saves":0,"uses_daylight":false,"offset":-7200000,"utc_offset_raw":-7200000},{"id":"Brazil/DeNoronha","display_name":"Fernando
+        de Noronha Time","utc_offset_w_dst":-7200000,"daylight_saves":0,"uses_daylight":false,"offset":-7200000,"utc_offset_raw":-7200000},{"id":"Etc/GMT+2","display_name":"GMT-02:00","utc_offset_w_dst":-7200000,"daylight_saves":0,"uses_daylight":false,"offset":-7200000,"utc_offset_raw":-7200000},{"id":"America/Scoresbysund","display_name":"Eastern
+        Greenland Time","utc_offset_w_dst":-3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-3600000,"utc_offset_raw":-3600000},{"id":"Atlantic/Azores","display_name":"Azores
+        Time","utc_offset_w_dst":-3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":-3600000,"utc_offset_raw":-3600000},{"id":"Atlantic/Cape_Verde","display_name":"Cape
+        Verde Time","utc_offset_w_dst":-3600000,"daylight_saves":0,"uses_daylight":false,"offset":-3600000,"utc_offset_raw":-3600000},{"id":"Etc/GMT+1","display_name":"GMT-01:00","utc_offset_w_dst":-3600000,"daylight_saves":0,"uses_daylight":false,"offset":-3600000,"utc_offset_raw":-3600000},{"id":"Africa/Abidjan","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Accra","display_name":"Ghana
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Bamako","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Banjul","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Bissau","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Casablanca","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Africa/Conakry","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Dakar","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/El_Aaiun","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Africa/Freetown","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Lome","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Monrovia","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Nouakchott","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Ouagadougou","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Sao_Tome","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Timbuktu","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"America/Danmarkshavn","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Antarctica/Troll","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":7200000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Canary","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Faeroe","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Faroe","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Madeira","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/Reykjavik","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Atlantic/St_Helena","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Eire","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Etc/GMT","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/GMT+0","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/GMT-0","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/GMT0","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/Greenwich","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/UCT","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/UTC","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/Universal","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Etc/Zulu","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Europe/Belfast","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Dublin","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Guernsey","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Isle_of_Man","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Jersey","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/Lisbon","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Europe/London","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"GB","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"GB-Eire","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"GMT","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"GMT0","display_name":"GMT+00:00","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Greenwich","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Iceland","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Portugal","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"UCT","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"UTC","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Universal","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"WET","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000,"uses_daylight":true,"offset":0,"utc_offset_raw":0},{"id":"Zulu","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0,"uses_daylight":false,"offset":0,"utc_offset_raw":0},{"id":"Africa/Algiers","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Bangui","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Brazzaville","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Ceuta","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Douala","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Kinshasa","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Lagos","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Libreville","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Luanda","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Malabo","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Ndjamena","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Niamey","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Porto-Novo","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Tunis","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Africa/Windhoek","display_name":"Western
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":3600000},{"id":"Arctic/Longyearbyen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Atlantic/Jan_Mayen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"CET","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"ECT","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Etc/GMT-1","display_name":"GMT+01:00","utc_offset_w_dst":3600000,"daylight_saves":0,"uses_daylight":false,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Amsterdam","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Andorra","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Belgrade","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Berlin","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Bratislava","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Brussels","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Budapest","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Busingen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Copenhagen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Gibraltar","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Ljubljana","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Luxembourg","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Madrid","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Malta","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Monaco","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Oslo","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Paris","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Podgorica","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Prague","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Rome","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/San_Marino","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Sarajevo","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Skopje","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Stockholm","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Tirane","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Vaduz","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Vatican","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Vienna","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Warsaw","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Zagreb","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Europe/Zurich","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"MET","display_name":"Middle
+        Europe Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"Poland","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000,"uses_daylight":true,"offset":3600000,"utc_offset_raw":3600000},{"id":"ART","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Blantyre","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Bujumbura","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Cairo","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Gaborone","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Harare","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Johannesburg","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Kigali","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Lubumbashi","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Lusaka","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Maputo","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Maseru","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Mbabane","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Tripoli","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Amman","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Beirut","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Damascus","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Gaza","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Hebron","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Jerusalem","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Nicosia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Asia/Tel_Aviv","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"CAT","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"EET","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Egypt","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Etc/GMT-2","display_name":"GMT+02:00","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Athens","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Bucharest","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Chisinau","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Helsinki","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Kaliningrad","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Kiev","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Mariehamn","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Nicosia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Riga","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Sofia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Tallinn","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Tiraspol","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Uzhgorod","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Vilnius","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Europe/Zaporozhye","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Israel","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000,"uses_daylight":true,"offset":7200000,"utc_offset_raw":7200000},{"id":"Libya","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0,"uses_daylight":false,"offset":7200000,"utc_offset_raw":7200000},{"id":"Africa/Addis_Ababa","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Asmara","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Asmera","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Dar_es_Salaam","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Djibouti","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Juba","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Kampala","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Khartoum","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Mogadishu","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Africa/Nairobi","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Antarctica/Syowa","display_name":"Syowa
+        Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Aden","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Baghdad","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Bahrain","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Istanbul","display_name":"Eastern
+        European Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Kuwait","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Qatar","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Riyadh","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"EAT","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Etc/GMT-3","display_name":"GMT+03:00","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Istanbul","display_name":"Eastern
+        European Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Kirov","display_name":"GMT+03:00","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Minsk","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Moscow","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Simferopol","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Europe/Volgograd","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Indian/Antananarivo","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Indian/Comoro","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Indian/Mayotte","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Turkey","display_name":"Eastern
+        European Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"W-SU","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0,"uses_daylight":false,"offset":10800000,"utc_offset_raw":10800000},{"id":"Asia/Tehran","display_name":"Iran
+        Standard Time","utc_offset_w_dst":12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":12600000,"utc_offset_raw":12600000},{"id":"Iran","display_name":"Iran
+        Standard Time","utc_offset_w_dst":12600000,"daylight_saves":3600000,"uses_daylight":true,"offset":12600000,"utc_offset_raw":12600000},{"id":"Asia/Baku","display_name":"Azerbaijan
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Dubai","display_name":"Gulf
+        Standard Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Muscat","display_name":"Gulf
+        Standard Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Tbilisi","display_name":"Georgia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Yerevan","display_name":"Armenia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Etc/GMT-4","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Europe/Astrakhan","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Europe/Samara","display_name":"Samara
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Europe/Ulyanovsk","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Indian/Mahe","display_name":"Seychelles
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Indian/Mauritius","display_name":"Mauritius
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Indian/Reunion","display_name":"Reunion
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"NET","display_name":"Armenia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0,"uses_daylight":false,"offset":14400000,"utc_offset_raw":14400000},{"id":"Asia/Kabul","display_name":"Afghanistan
+        Time","utc_offset_w_dst":16200000,"daylight_saves":0,"uses_daylight":false,"offset":16200000,"utc_offset_raw":16200000},{"id":"Antarctica/Mawson","display_name":"Mawson
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Aqtau","display_name":"Aqtau
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Aqtobe","display_name":"Aqtobe
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Ashgabat","display_name":"Turkmenistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Ashkhabad","display_name":"Turkmenistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Dushanbe","display_name":"Tajikistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Karachi","display_name":"Pakistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Oral","display_name":"Oral
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Samarkand","display_name":"Uzbekistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Tashkent","display_name":"Uzbekistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Yekaterinburg","display_name":"Yekaterinburg
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Etc/GMT-5","display_name":"GMT+05:00","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Indian/Kerguelen","display_name":"French
+        Southern & Antarctic Lands Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Indian/Maldives","display_name":"Maldives
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"PLT","display_name":"Pakistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0,"uses_daylight":false,"offset":18000000,"utc_offset_raw":18000000},{"id":"Asia/Calcutta","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0,"uses_daylight":false,"offset":19800000,"utc_offset_raw":19800000},{"id":"Asia/Colombo","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0,"uses_daylight":false,"offset":19800000,"utc_offset_raw":19800000},{"id":"Asia/Kolkata","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0,"uses_daylight":false,"offset":19800000,"utc_offset_raw":19800000},{"id":"IST","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0,"uses_daylight":false,"offset":19800000,"utc_offset_raw":19800000},{"id":"Asia/Kathmandu","display_name":"Nepal
+        Time","utc_offset_w_dst":20700000,"daylight_saves":0,"uses_daylight":false,"offset":20700000,"utc_offset_raw":20700000},{"id":"Asia/Katmandu","display_name":"Nepal
+        Time","utc_offset_w_dst":20700000,"daylight_saves":0,"uses_daylight":false,"offset":20700000,"utc_offset_raw":20700000},{"id":"Antarctica/Vostok","display_name":"Vostok
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Almaty","display_name":"Alma-Ata
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Bishkek","display_name":"Kirgizstan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Dacca","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Dhaka","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Kashgar","display_name":"Xinjiang
+        Standard Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Omsk","display_name":"Omsk
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Qyzylorda","display_name":"Qyzylorda
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Thimbu","display_name":"Bhutan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Thimphu","display_name":"Bhutan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Urumqi","display_name":"Xinjiang
+        Standard Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"BST","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Etc/GMT-6","display_name":"GMT+06:00","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Indian/Chagos","display_name":"Indian
+        Ocean Territory Time","utc_offset_w_dst":21600000,"daylight_saves":0,"uses_daylight":false,"offset":21600000,"utc_offset_raw":21600000},{"id":"Asia/Rangoon","display_name":"Myanmar
+        Time","utc_offset_w_dst":23400000,"daylight_saves":0,"uses_daylight":false,"offset":23400000,"utc_offset_raw":23400000},{"id":"Asia/Yangon","display_name":"Myanmar
+        Time","utc_offset_w_dst":23400000,"daylight_saves":0,"uses_daylight":false,"offset":23400000,"utc_offset_raw":23400000},{"id":"Indian/Cocos","display_name":"Cocos
+        Islands Time","utc_offset_w_dst":23400000,"daylight_saves":0,"uses_daylight":false,"offset":23400000,"utc_offset_raw":23400000},{"id":"Antarctica/Davis","display_name":"Davis
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Bangkok","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Barnaul","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Ho_Chi_Minh","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Hovd","display_name":"Hovd
+        Time","utc_offset_w_dst":25200000,"daylight_saves":3600000,"uses_daylight":true,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Jakarta","display_name":"West
+        Indonesia Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Krasnoyarsk","display_name":"Krasnoyarsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Novokuznetsk","display_name":"Krasnoyarsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Novosibirsk","display_name":"Novosibirsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Phnom_Penh","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Pontianak","display_name":"West
+        Indonesia Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Saigon","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Tomsk","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Asia/Vientiane","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Etc/GMT-7","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Indian/Christmas","display_name":"Christmas
+        Island Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"VST","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0,"uses_daylight":false,"offset":25200000,"utc_offset_raw":25200000},{"id":"Antarctica/Casey","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Brunei","display_name":"Brunei
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Choibalsan","display_name":"Choibalsan
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Chongqing","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Chungking","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Harbin","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Hong_Kong","display_name":"Hong
+        Kong Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Irkutsk","display_name":"Irkutsk
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Kuala_Lumpur","display_name":"Malaysia
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Kuching","display_name":"Malaysia
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Macao","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Macau","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Makassar","display_name":"Central
+        Indonesia Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Manila","display_name":"Philippines
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Shanghai","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Singapore","display_name":"Singapore
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Taipei","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Ujung_Pandang","display_name":"Central
+        Indonesia Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Ulaanbaatar","display_name":"Ulaanbaatar
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Ulan_Bator","display_name":"Ulaanbaatar
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000,"uses_daylight":true,"offset":28800000,"utc_offset_raw":28800000},{"id":"Australia/Perth","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Australia/West","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"CTT","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Etc/GMT-8","display_name":"GMT+08:00","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Hongkong","display_name":"Hong
+        Kong Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"PRC","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Singapore","display_name":"Singapore
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0,"uses_daylight":false,"offset":28800000,"utc_offset_raw":28800000},{"id":"Asia/Pyongyang","display_name":"Korea
+        Standard Time","utc_offset_w_dst":30600000,"daylight_saves":0,"uses_daylight":false,"offset":30600000,"utc_offset_raw":30600000},{"id":"Australia/Eucla","display_name":"Australian
+        Central Western Standard Time","utc_offset_w_dst":31500000,"daylight_saves":0,"uses_daylight":false,"offset":31500000,"utc_offset_raw":31500000},{"id":"Asia/Chita","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Dili","display_name":"Timor-Leste
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Jayapura","display_name":"East
+        Indonesia Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Khandyga","display_name":"Khandyga
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Seoul","display_name":"Korea
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Tokyo","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Asia/Yakutsk","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Etc/GMT-9","display_name":"GMT+09:00","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"JST","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Japan","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"Pacific/Palau","display_name":"Palau
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"ROK","display_name":"Korea
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0,"uses_daylight":false,"offset":32400000,"utc_offset_raw":32400000},{"id":"ACT","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0,"uses_daylight":false,"offset":34200000,"utc_offset_raw":34200000},{"id":"Australia/Adelaide","display_name":"Australian
+        Central Standard Time (South Australia)","utc_offset_w_dst":37800000,"daylight_saves":3600000,"uses_daylight":true,"offset":37800000,"utc_offset_raw":34200000},{"id":"Australia/Broken_Hill","display_name":"Australian
+        Central Standard Time (South Australia/New South Wales)","utc_offset_w_dst":37800000,"daylight_saves":3600000,"uses_daylight":true,"offset":37800000,"utc_offset_raw":34200000},{"id":"Australia/Darwin","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0,"uses_daylight":false,"offset":34200000,"utc_offset_raw":34200000},{"id":"Australia/North","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0,"uses_daylight":false,"offset":34200000,"utc_offset_raw":34200000},{"id":"Australia/South","display_name":"Australian
+        Central Standard Time (South Australia)","utc_offset_w_dst":37800000,"daylight_saves":3600000,"uses_daylight":true,"offset":37800000,"utc_offset_raw":34200000},{"id":"Australia/Yancowinna","display_name":"Australian
+        Central Standard Time (South Australia/New South Wales)","utc_offset_w_dst":37800000,"daylight_saves":3600000,"uses_daylight":true,"offset":37800000,"utc_offset_raw":34200000},{"id":"AET","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Antarctica/DumontDUrville","display_name":"Dumont-d''Urville
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Asia/Ust-Nera","display_name":"Ust-Nera
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Asia/Vladivostok","display_name":"Vladivostok
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/ACT","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Brisbane","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/Canberra","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Currie","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Hobart","display_name":"Australian
+        Eastern Standard Time (Tasmania)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Lindeman","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/Melbourne","display_name":"Australian
+        Eastern Standard Time (Victoria)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/NSW","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Queensland","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/Sydney","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Tasmania","display_name":"Australian
+        Eastern Standard Time (Tasmania)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Australia/Victoria","display_name":"Australian
+        Eastern Standard Time (Victoria)","utc_offset_w_dst":39600000,"daylight_saves":3600000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":36000000},{"id":"Etc/GMT-10","display_name":"GMT+10:00","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Chuuk","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Guam","display_name":"Chamorro
+        Standard Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Port_Moresby","display_name":"Papua
+        New Guinea Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Saipan","display_name":"Chamorro
+        Standard Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Truk","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Pacific/Yap","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0,"uses_daylight":false,"offset":36000000,"utc_offset_raw":36000000},{"id":"Australia/LHI","display_name":"Lord
+        Howe Standard Time","utc_offset_w_dst":39600000,"daylight_saves":1800000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":37800000},{"id":"Australia/Lord_Howe","display_name":"Lord
+        Howe Standard Time","utc_offset_w_dst":39600000,"daylight_saves":1800000,"uses_daylight":true,"offset":39600000,"utc_offset_raw":37800000},{"id":"Antarctica/Macquarie","display_name":"Macquarie
+        Island Standard Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Asia/Magadan","display_name":"Magadan
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Asia/Sakhalin","display_name":"Sakhalin
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Asia/Srednekolymsk","display_name":"Srednekolymsk
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Etc/GMT-11","display_name":"GMT+11:00","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Bougainville","display_name":"Bougainville
+        Standard Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Efate","display_name":"Vanuatu
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Guadalcanal","display_name":"Solomon
+        Is. Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Kosrae","display_name":"Kosrae
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Norfolk","display_name":"Norfolk
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Noumea","display_name":"New
+        Caledonia Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Pohnpei","display_name":"Pohnpei
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Pacific/Ponape","display_name":"Pohnpei
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"SST","display_name":"Solomon
+        Is. Time","utc_offset_w_dst":39600000,"daylight_saves":0,"uses_daylight":false,"offset":39600000,"utc_offset_raw":39600000},{"id":"Antarctica/McMurdo","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"Antarctica/South_Pole","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"Asia/Anadyr","display_name":"Anadyr
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Asia/Kamchatka","display_name":"Petropavlovsk-Kamchatski
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Etc/GMT-12","display_name":"GMT+12:00","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Kwajalein","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"NST","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"NZ","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"Pacific/Auckland","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000,"uses_daylight":true,"offset":46800000,"utc_offset_raw":43200000},{"id":"Pacific/Fiji","display_name":"Fiji
+        Time","utc_offset_w_dst":43200000,"daylight_saves":3600000,"uses_daylight":true,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Funafuti","display_name":"Tuvalu
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Kwajalein","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Majuro","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Nauru","display_name":"Nauru
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Tarawa","display_name":"Gilbert
+        Is. Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Wake","display_name":"Wake
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"Pacific/Wallis","display_name":"Wallis
+        & Futuna Time","utc_offset_w_dst":43200000,"daylight_saves":0,"uses_daylight":false,"offset":43200000,"utc_offset_raw":43200000},{"id":"NZ-CHAT","display_name":"Chatham
+        Standard Time","utc_offset_w_dst":49500000,"daylight_saves":3600000,"uses_daylight":true,"offset":49500000,"utc_offset_raw":45900000},{"id":"Pacific/Chatham","display_name":"Chatham
+        Standard Time","utc_offset_w_dst":49500000,"daylight_saves":3600000,"uses_daylight":true,"offset":49500000,"utc_offset_raw":45900000},{"id":"Etc/GMT-13","display_name":"GMT+13:00","utc_offset_w_dst":46800000,"daylight_saves":0,"uses_daylight":false,"offset":46800000,"utc_offset_raw":46800000},{"id":"MIT","display_name":"West
+        Samoa Standard Time","utc_offset_w_dst":50400000,"daylight_saves":3600000,"uses_daylight":true,"offset":50400000,"utc_offset_raw":46800000},{"id":"Pacific/Apia","display_name":"West
+        Samoa Standard Time","utc_offset_w_dst":50400000,"daylight_saves":3600000,"uses_daylight":true,"offset":50400000,"utc_offset_raw":46800000},{"id":"Pacific/Enderbury","display_name":"Phoenix
+        Is. Time","utc_offset_w_dst":46800000,"daylight_saves":0,"uses_daylight":false,"offset":46800000,"utc_offset_raw":46800000},{"id":"Pacific/Fakaofo","display_name":"Tokelau
+        Time","utc_offset_w_dst":46800000,"daylight_saves":0,"uses_daylight":false,"offset":46800000,"utc_offset_raw":46800000},{"id":"Pacific/Tongatapu","display_name":"Tonga
+        Time","utc_offset_w_dst":46800000,"daylight_saves":0,"uses_daylight":false,"offset":46800000,"utc_offset_raw":46800000},{"id":"Etc/GMT-14","display_name":"GMT+14:00","utc_offset_w_dst":50400000,"daylight_saves":0,"uses_daylight":false,"offset":50400000,"utc_offset_raw":50400000},{"id":"Pacific/Kiritimati","display_name":"Line
+        Is. Time","utc_offset_w_dst":50400000,"daylight_saves":0,"uses_daylight":false,"offset":50400000,"utc_offset_raw":50400000}],"timezone":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"timezone_id":"America/New_York","parts":{"dd":8,"mm":3,"secs":2,"hours":15,"yyyy":2018,"mins":40},"uses_daylight":true,"date_time":"March
+        8, 2018 3:40:02 PM EST","utc_offset_raw":-18000000},"appliance":{"status":"Normal","name":"LXCA
+        - fe80:0:0:0:20c:29ff:fe85:ac49%2","uuid":"20fede5f-721f-4a73-b507-e06d823d677e","build":"162","date":"2016-11-22_06-49-00","runlevel":3,"version":"1.2.2"}}'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:02 GMT
+- request:
+    method: get
+    uri: https://10.243.9.123/cabinet?status=includestandalone
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQQVNTVzByRA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:02 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=86400; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline'''
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '1'
+      Content-Type:
+      - application/com.lenovo.lxca-v1.2.2+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"cabinetList":[{"storageList":[],"cabinetName":"cabinet71","height":42,"complexList":[],"chassisList":[],"location":"","UUID":"096F8C92-08D4-4A24-ABD8-FE56D482F8C4","nodeList":[{"itemParentUUID":null,"itemName":"IMM2-e41f13ed5a1e","itemLowerUnit":42,"itemType":"SERVER","itemLocationRack":"cabinet71","itemSubType":"LegacyServer","itemUUID":"BD775D06821111E189A3E41F13ED5A1A","itemInventory":{"accessState":"Online","arch":"x86_64","manufacturerId":"","location":{"lowestRackUnit":42,"location":"","rack":"cabinet71","room":""},"addinCardSlots":0,"serialNumber":"06AREZ9","driveBays":0,"macAddress":"e4:1f:13:ed:5a:1f","type":"Rack-Tower
+        Server","lanOverUsb":"disabled","height":1,"leds":[{"conditions":"Warning","color":"Yellow","location":"Front
+        Panel","name":"Check Log","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Front
+        Panel","name":"Fault","state":"Off"},{"conditions":"Attention","color":"Blue","location":"Front
+        Panel","name":"Identify","state":"Off"},{"conditions":"Health","color":"Green","location":"Front
+        Panel","name":"Power","state":"On"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"BOARD","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"Battery","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"CONFIG","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"CPU","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"CPU 1","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"CPU 2","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 1","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 10","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 11","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 12","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 13","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 14","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 15","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 16","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 17","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 18","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 19","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 2","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 20","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 21","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 22","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 23","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 24","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 3","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 4","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 5","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 6","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 7","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 8","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"DIMM 9","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"FAN","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 1","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 2","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 3","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 4","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 5","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"FAN 6","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"HDD","state":"Off"},{"conditions":"Health","color":"Green","location":"System
+        Board","name":"IMM2 Heartbeat","state":"Blink"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"Internal RAID","state":"Off"},{"conditions":"Health","color":"Green","location":"Lightpath
+        Card","name":"LINK","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"MEM","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"Mezz Card Error","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"NMI","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"OVER SPEC","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"PCI","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"FRU","name":"PCI
+        1","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"FRU","name":"PCI
+        2","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"PS","state":"Off"},{"conditions":"Status","color":"Green","location":"FRU","name":"Power","state":"On"},{"conditions":"Warning","color":"Yellow","location":"System
+        Board","name":"SysBrd Fault","state":"Off"},{"conditions":"Warning","color":"Yellow","location":"Lightpath
+        Card","name":"TEMP","state":"Off"}],"description":"chassis System x3550 M4","mgmtProcIPaddress":"10.243.9.112","expansionCards":[],"errorFields":[],"FQDN":"ratchetimm2.labs.lenovo.com","ipInterfaces":[],"firmware":[{"status":"ACTIVE","name":"IMM","role":"","date":"","type":"IMM","build":"","version":"1AOO72H-5.60"},{"status":"ACTIVE","name":"Preboot
+        DSA","role":"","date":"","type":"Preboot DSA","build":"","version":"DSYTD8G-9.54"},{"status":"ACTIVE","name":"UEFI","role":"","date":"","type":"UEFI","build":"","version":"D7E152CUS-2.11"}],"bladeState":0,"activationKeys":[],"status":{"message":"managed","name":"MANAGED"},"powerCappingPolicy":{"cappingACorDCMode":"UNKNOWN","minimumHardCapLevel":-1,"cappingPolicy":"UNKNOWN","maxPowerCap":-1,"minimumPowerCappingHotPlugLevel":-1,"powerCappingAllocUnit":"watts","maximumPowerCappingHotPlugLevel":-1,"currentPowerCap":0,"minPowerCap":-1},"parent":{"uuid":"096F8C92-08D4-4A24-ABD8-FE56D482F8C4","uri":"cabinet/096F8C92-08D4-4A24-ABD8-FE56D482F8C4"},"hostname":"IMM2-e41f13ed5a1e","powerSupplies":[{"model":"43X3313","manufacturerId":"EMER","serialNumber":"
+        K118122706D","inputVoltageIsAC":false,"inputVoltageMin":0,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":null,"leds":[{"color":"Green","location":"FRU","name":"IN","state":"On"},{"color":"Green","location":"FRU","name":"OUT","state":"On"},{"color":"Amber","location":"FRU","name":"FAULT","state":"Off"}],"description":"Power
+        Supply 1","name":" K118122706D","userDescription":null,"manufactureDate":"2011-12-02","partNumber":null,"firmware":[],"healthState":"GOOD","machineType":null,"hardwareRevision":null,"FRU":null,"uri":"powerSupply/null","productId":null,"powerAllocation":{"totalInputPower":0,"totalOutputPower":0},"powerState":null,"posID":null,"slots":[0],"manufacturer":null,"vpdID":null,"uuid":null,"productName":null,"fruSerialNumber":null,"inputVoltageMax":0}],"FRU":"","thinkServerFru":[],"uri":"node/BD775D06821111E189A3E41F13ED5A1A","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":0,"minimumAllocatedPower":0},"expansionProductType":"","powerStatus":8,"bootOrder":{"uri":"node/BD775D06821111E189A3E41F13ED5A1A/bootOrder","bootOrderList":[{"currentBootOrderDevices":["default"],"bootType":"SingleUse","possibleBootOrderDevices":["setup","network","hd","cd","default"]}]},"expansionProducts":[],"ipv6Addresses":["fe80::e61f:13ff:feed:5a1f"],"slots":[1],"manufacturer":"
+        IBM","raidSettings":[],"vpdID":"","uuid":"BD775D06821111E189A3E41F13ED5A1A","isConnectionTrusted":"true","memoryModules":[{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"d95bfb8c","displayName":"DIMM 1","slot":1,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"1a8c3c7d","displayName":"DIMM 2","slot":2,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540750c","displayName":"DIMM 4","slot":4,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"1a8c3c8e","displayName":"DIMM 5","slot":5,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"35407521","displayName":"DIMM 8","slot":8,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"d67318ee","displayName":"DIMM 9","slot":9,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540751c","displayName":"DIMM 11","slot":11,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540753b","displayName":"DIMM 12","slot":12,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540751e","displayName":"DIMM 13","slot":13,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"1a8c3c39","displayName":"DIMM 14","slot":14,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540750b","displayName":"DIMM 16","slot":16,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"1a8c3c4c","displayName":"DIMM 17","slot":17,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"3540753d","displayName":"DIMM 20","slot":20,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Hyundai
+        Electronics","capacity":8,"serialNumber":"44c11b68","displayName":"DIMM 21","slot":21,"type":"DDR3
+        SDRAM","partNumber":"HMT31GR7CFR4C-PB  "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"354074be","displayName":"DIMM 23","slot":23,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "},{"model":"","voltage":null,"speed":12800,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"354074c0","displayName":"DIMM 24","slot":24,"type":"DDR3
+        SDRAM","partNumber":"36JSF1G72PZ-1G6M1 "}],"fruSerialNumber":"Y015UN23X13P","secureBootMode":{"possibleValues":[],"currentValue":""},"tlsVersion":{"possibleValues":["TLS_10","TLS_11","TLS_12","unsupported"],"currentValue":"unsupported"},"model":"AC1","isScalable":false,"expansionCardSlots":0,"fans":[],"isITME":false,"hostMacAddresses":"","contact":"","dataHandle":0,"ipv4Addresses":["10.243.9.112"],"cmmDisplayName":"","backedBy":"real","complexID":-1,"name":"IMM2-e41f13ed5a1e","memorySlots":0,"drives":[],"cmmHealthState":"Normal","userDescription":"","subSlots":[],"partNumber":null,"excludedHealthState":"Normal","machineType":"7914","isRemotePresenceEnabled":false,"pciDevices":[],"domainName":"","processors":[{"speed":2.7,"manufacturer":"Intel(R)
+        Corporation","family":"Intel(R) Xeon(R) processor","displayName":"","slot":1,"productVersion":"Intel(R)
+        Xeon(R) CPU E5-2680 0 @ 2.70GHz","cores":8},{"speed":2.7,"manufacturer":"Intel(R)
+        Corporation","family":"Intel(R) Xeon(R) processor","displayName":"","slot":2,"productVersion":"Intel(R)
+        Xeon(R) CPU E5-2680 0 @ 2.70GHz","cores":8}],"processorSlots":0,"pciCapabilities":[],"productId":"","hasOS":false,"bootMode":{"possibleValues":["uefi","bios"],"currentValue":"unspecified"},"ports":[],"embeddedHypervisorPresence":false,"posID":"","nist":{"possibleValues":["Compatibility","Nist_800_131A_Strict","Nist_800_131A_Custom","unsupported"],"currentValue":"unsupported"},"overallHealthState":"Normal","subType":"LegacyServer","partitionID":-1,"flashStorage":[],"productName":"System
+        x3550 M4"},"itemLocation":"","itemHeight":1,"itemLocationRoom":""}],"placeholderList":[],"switchList":[],"room":""},{"storageList":[],"cabinetName":"STANDALONE_OBJECT_NAME","height":42,"complexList":[{"partition":[],"orphanNodes":[{"accessState":"Offline","arch":"x86","manufacturerId":"
+        IBM(CLCN)","location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"addinCardSlots":0,"serialNumber":"23Y6458","driveBays":17,"macAddress":"6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16","type":"Rack-Tower
+        Server","lanOverUsb":"enabled","onboardPciDevices":[{"pciSubID":"0","firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","softwareID":"0:0","type":"","build":"0","date":"","version":""}],"fodUniqueID":"","pciRevision":"0","isAgentless":false,"pciBusNumber":"27","pciSubVendorID":"0","isAddOnCard":false,"pciDeviceNumber":"0","posID":"534","pciFunctionNumber":"0","name":"","portInfo":{},"vpdID":"102b"}],"height":4,"leds":[{"color":"Yellow","location":"FrontRearPanel","name":"Fault","state":"Off"},{"color":"Blue","location":"FrontRearPanel","name":"Identify","state":"Off"},{"color":"Yellow","location":"FrontPanel","name":"Check
+        Log","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"CNFG","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"CPU","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"PS","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"DASD","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"FAN","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"MEM","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"NMI","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"OVER
+        SPEC","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"TEMP","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"PCI","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"LINK","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        5","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        9","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 10PEC","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 10Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 11Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 12Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 13Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 14Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 15Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        5","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        9","state":"Off"},{"color":"Yellow","location":"FRU","name":"ML2","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        11DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        12DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"Planar","name":"SysBrd","state":"Off"},{"color":"Yellow","location":"Planar","name":"CMOS
+        Batt Error","state":"Off"},{"color":"Green","location":"FrontRearPanel","name":"Power","state":"On"},{"color":"Green","location":"Planar","name":"BMC
+        Heartbeat","state":"Blinking"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book
+        1 Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book 2
+        Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book 3 Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book
+        4 Board4","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 1
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 2
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 3
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 4
+        Attention","state":"Off"}],"description":"Chassis","mgmtProcIPaddress":"10.243.6.17","expansionCards":[],"errorFields":[],"FQDN":"cmm-dt1.labs.lenovo.com","ipInterfaces":[{"IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.17","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"},{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"}],"name":"eth0","IPv6statelessEnabled":true,"label":"unknown","IPv6staticEnabled":false}],"firmware":[{"status":"Active","name":"UEFI
+        Firmware/BIOS","role":"Primary","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"A9E143HUS","version":"4.30"},{"status":"Inactive","name":"UEFI
+        Backup Firmware/BIOS","role":"Backup","date":"2017-02-21T00:00:00Z","type":"UEFI-Backup","build":"A9E139GUS","version":"4.10"},{"status":"Active","name":"DSA
+        Diagnostic Software","role":"Primary","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2"},{"status":"Active","name":"IMM2
+        Firmware","role":"Primary","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70"},{"status":"Inactive","name":"IMM2
+        Backup Firmware","role":"Backup","date":"2016-12-05T00:00:00Z","type":"IMM2-Backup","build":"TCOO59G","version":"9.00"}],"bladeState":0,"activationKeys":[],"status":{"message":"managed","name":"MANAGED"},"powerCappingPolicy":{"cappingACorDCMode":"DC","minimumHardCapLevel":434300,"cappingPolicy":"OFF","maxPowerCap":535000,"minimumPowerCappingHotPlugLevel":754000,"powerCappingAllocUnit":"watts*10^-3","maximumPowerCappingHotPlugLevel":856000,"currentPowerCap":0,"minPowerCap":130000},"hostname":"IMM2-6cae8b4b4f15","powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K115136V11E","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","FRU":"","uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[2],"manufacturer":"DELT","vpdID":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1},{"model":"","manufacturerId":"","serialNumber":"K115136V11L","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 2","leds":[],"description":"","name":"Power Supply 2","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","FRU":"","uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[3],"manufacturer":"DELT","vpdID":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1}],"parentComplexID":"7936DD182C5311E3A8D6000AF7256738","FRU":"None","uri":"node/7936DD182C5311E3A8D6000AF7256738","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":1710,"minimumAllocatedPower":26},"expansionProductType":"","powerStatus":8,"bootOrder":{"uri":"node/7936DD182C5311E3A8D6000AF7256738/bootOrder","bootOrderList":[{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]},{"currentBootOrderDevices":["Hard Disk 0","CentOS Linux","Windows
+        Boot Manager","PXE Network","CD/DVD Rom"],"bootType":"Permanent","possibleBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS Linux","Windows Boot Manager","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]}]},"expansionProducts":[],"ipv6Addresses":["fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","fe80:0:0:0:6eae:8bff:fe4b:4f15"],"slots":[1],"manufacturer":"
+        IBM(CLCN)","addinCards":[{"pciSubID":"454","firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Software
+        Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"slotSupportsHotPlug":"false","fodUniqueID":"N/A","pciRevision":"2","isAgentless":true,"pciBusNumber":"7","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","pciDeviceNumber":"0","slotNumber":"12","posID":"5d","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"vpdID":"1000","productName":"ServeRAID M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"}],"parentPartitionUUID":"","raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Firmware","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"description":"ServeRAID
+        M5210","name":"ServeRAID M5210","uuid":"0000000000000000500605B006E6ED5B","storagePools":[{"raidLevel":0,"description":"0000000000000000500605B006E6ED5B_Storage
+        Pool_M5210_0000000000000000500605B006E6ED5B_c:Pool:0","storageVolumes":[{"bootable":true,"volumeUID":"0","primaryPartition":0,"volumeID":"6","numberOfBlocks":583983104,"volumeStatus":"Dynamic
+        Reconfig","description":"Volume 0 0000000000000000500605B006E6ED5B_0","stripeSize":65536,"name":"GenericR0_0","blockSize":512,"health":"Unknown"}],"name":"Pool_0","totalManagedSpace":298999349248,"remainingSpace":0,"arrayUid":"0","arrayStatus":"Offline","diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"FRU":"42D0628","mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631"}]}],"diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"FRU":"42D0628","mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631"}]}],"vpdID":"","uuid":"7936DD182C5311E3A8D6000AF7256738","isConnectionTrusted":"false","memoryModules":[{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65F9","displayName":"CPU 1 DIMM
+        9,12800 MB/s","slot":9,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FA","displayName":"CPU 1 DIMM
+        15,12800 MB/s","slot":15,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FE","displayName":"CPU 2 DIMM
+        9,12800 MB/s","slot":9,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF6603","displayName":"CPU 2 DIMM
+        15,12800 MB/s","slot":15,"type":"DDR3","partNumber":"Unknown"}],"partitionEnabled":false,"fruSerialNumber":"None","secureBootMode":{"possibleValues":["Disabled","Enabled"],"currentValue":"Disabled"},"encapsulation":{"encapsulationMode":"normal"},"tlsVersion":{"possibleValues":["TLS_10","TLS_11","TLS_12","unsupported"],"currentValue":"TLS_12"},"model":"AC1","isScalable":true,"expansionCardSlots":0,"fans":[{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 1","slots":1,"name":"Fan 1"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 2","slots":2,"name":"Fan 2"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 3","slots":3,"name":"Fan 3"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 4","slots":4,"name":"Fan 4"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 5","slots":5,"name":"Fan 5"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 6","slots":6,"name":"Fan 6"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 7","slots":7,"name":"Fan 7"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 8","slots":8,"name":"Fan 8"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 9","slots":9,"name":"Fan 9"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 10","slots":10,"name":"Fan 10"}],"isITME":false,"hostMacAddresses":"00:0A:F7:25:67:38,00:0A:F7:25:67:39","contact":"","dataHandle":1518063984527,"ipv4Addresses":["10.243.6.17","169.254.95.118"],"cmmDisplayName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","backedBy":"real","complexID":1,"name":"cmm-dt1.labs.lenovo.com","memorySlots":0,"drives":[],"cmmHealthState":"Normal","userDescription":"","subSlots":[],"partNumber":"00D0188     ","excludedHealthState":"Warning","machineType":"6241","isRemotePresenceEnabled":true,"pciDevices":[{"pciSubID":"454","firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Software
+        Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"slotSupportsHotPlug":"false","fodUniqueID":"N/A","pciRevision":"2","isAgentless":true,"pciBusNumber":"7","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","pciDeviceNumber":"0","slotNumber":"12","posID":"5d","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"vpdID":"1000","productName":"ServeRAID M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)"},{"pciSubID":"0","firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","softwareID":"0:0","type":"","build":"0","date":"","version":""}],"fodUniqueID":"","pciRevision":"0","isAgentless":false,"pciBusNumber":"27","pciSubVendorID":"0","isAddOnCard":false,"pciDeviceNumber":"0","posID":"534","pciFunctionNumber":"0","name":"","portInfo":{},"vpdID":"102b"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"}],"domainName":"mm-dt1.labs.lenovo.com","processors":[{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15},{"speed":2.2,"manufacturer":"Intel(R) Corporation","family":"PENTIUM_R_4","displayName":"Intel(R)
+        Xeon(R) CPU E7-8880L v2 @ 2.20GHz","slot":2,"productVersion":"Intel(R) Xeon(R)
+        CPU E7-8880L v2 @ 2.20GHz","cores":15}],"processorSlots":0,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config"],"productId":"4D4F00","hasOS":false,"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"ports":[{"ioModuleBay":0,"portNumber":49},{"ioModuleBay":0,"portNumber":50}],"embeddedHypervisorPresence":false,"posID":"","nist":{"possibleValues":["Compatibility","Nist_800_131A_Strict","unsupported"],"currentValue":"Compatibility"},"overallHealthState":"Warning","subType":"","partitionID":-1,"physicalID":0,"flashStorage":[],"productName":"Lenovo
+        System x3850 X6"}],"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"complexID":"7936DD182C5311E3A8D6000AF7256738","partitionCount":0,"uuid":"7936DD182C5311E3A8D6000AF7256738","nodeCount":1}],"chassisList":[],"location":"","UUID":"STANDALONE_OBJECT_UUID","nodeList":[{"itemParentUUID":null,"itemName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","complexNodeCount":1,"itemLowerUnit":0,"itemType":"SERVER","itemUUID":"7936DD182C5311E3A8D6000AF7256738","itemSubType":"","itemHeight":4,"itemInventory":{"accessState":"Offline","arch":"x86","manufacturerId":"
+        IBM(CLCN)","location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"addinCardSlots":0,"serialNumber":"23Y6458","driveBays":17,"macAddress":"6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16","type":"Rack-Tower
+        Server","lanOverUsb":"enabled","onboardPciDevices":[{"pciSubID":"0","firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","softwareID":"0:0","type":"","build":"0","date":"","version":""}],"fodUniqueID":"","pciRevision":"0","isAgentless":false,"pciBusNumber":"27","pciSubVendorID":"0","isAddOnCard":false,"pciDeviceNumber":"0","posID":"534","pciFunctionNumber":"0","name":"","portInfo":{},"vpdID":"102b"}],"height":4,"leds":[{"color":"Yellow","location":"FrontRearPanel","name":"Fault","state":"Off"},{"color":"Blue","location":"FrontRearPanel","name":"Identify","state":"Off"},{"color":"Yellow","location":"FrontPanel","name":"Check
+        Log","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"CNFG","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"CPU","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"PS","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"DASD","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"FAN","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"MEM","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"NMI","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"OVER
+        SPEC","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"TEMP","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"PCI","state":"Off"},{"color":"Yellow","location":"LightPathCard","name":"LINK","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        5","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN
+        9","state":"Off"},{"color":"Yellow","location":"FRU","name":"FAN 10PEC","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 10Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 11Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 12Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 13Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 14Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 15Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        1","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        5","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        9","state":"Off"},{"color":"Yellow","location":"FRU","name":"ML2","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        11DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"FRU","name":"PCI
+        12DIMM 16Ctlr","state":"Off"},{"color":"Yellow","location":"Planar","name":"SysBrd","state":"Off"},{"color":"Yellow","location":"Planar","name":"CMOS
+        Batt Error","state":"Off"},{"color":"Green","location":"FrontRearPanel","name":"Power","state":"On"},{"color":"Green","location":"Planar","name":"BMC
+        Heartbeat","state":"Blinking"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        1 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 1 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        2 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 2 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        3 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 3 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 1","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 2","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        3","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 4","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 5","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 6","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        7","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 8","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 9","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 10","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        11","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 12","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 13","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 14","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        15","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 16","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 17","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 18","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        19","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 20","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU
+        4 DIMM 21","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4
+        DIMM 22","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM
+        23","state":"Off"},{"color":"Yellow","location":"FRU","name":"CPU 4 DIMM 24","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book
+        1 Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book 2
+        Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book 3 Board4","state":"Off"},{"color":"Yellow","location":"FRU","name":"Book
+        4 Board4","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 1
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 2
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 3
+        Attention","state":"Off"},{"color":"Amber","location":"FRU","name":"Book 4
+        Attention","state":"Off"}],"description":"Chassis","mgmtProcIPaddress":"10.243.6.17","expansionCards":[],"errorFields":[],"FQDN":"cmm-dt1.labs.lenovo.com","ipInterfaces":[{"IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.17","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"},{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"}],"name":"eth0","IPv6statelessEnabled":true,"label":"unknown","IPv6staticEnabled":false}],"firmware":[{"status":"Active","name":"UEFI
+        Firmware/BIOS","role":"Primary","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"A9E143HUS","version":"4.30"},{"status":"Inactive","name":"UEFI
+        Backup Firmware/BIOS","role":"Backup","date":"2017-02-21T00:00:00Z","type":"UEFI-Backup","build":"A9E139GUS","version":"4.10"},{"status":"Active","name":"DSA
+        Diagnostic Software","role":"Primary","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2"},{"status":"Active","name":"IMM2
+        Firmware","role":"Primary","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70"},{"status":"Inactive","name":"IMM2
+        Backup Firmware","role":"Backup","date":"2016-12-05T00:00:00Z","type":"IMM2-Backup","build":"TCOO59G","version":"9.00"}],"bladeState":0,"activationKeys":[],"status":{"message":"managed","name":"MANAGED"},"powerCappingPolicy":{"cappingACorDCMode":"DC","minimumHardCapLevel":434300,"cappingPolicy":"OFF","maxPowerCap":535000,"minimumPowerCappingHotPlugLevel":754000,"powerCappingAllocUnit":"watts*10^-3","maximumPowerCappingHotPlugLevel":856000,"currentPowerCap":0,"minPowerCap":130000},"hostname":"IMM2-6cae8b4b4f15","powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K115136V11E","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","FRU":"","uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[2],"manufacturer":"DELT","vpdID":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1},{"model":"","manufacturerId":"","serialNumber":"K115136V11L","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 2","leds":[],"description":"","name":"Power Supply 2","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","FRU":"","uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[3],"manufacturer":"DELT","vpdID":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1}],"parentComplexID":"7936DD182C5311E3A8D6000AF7256738","FRU":"None","uri":"node/7936DD182C5311E3A8D6000AF7256738","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":1710,"minimumAllocatedPower":26},"expansionProductType":"","powerStatus":8,"bootOrder":{"uri":"node/7936DD182C5311E3A8D6000AF7256738/bootOrder","bootOrderList":[{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]},{"currentBootOrderDevices":["Hard Disk 0","CentOS Linux","Windows
+        Boot Manager","PXE Network","CD/DVD Rom"],"bootType":"Permanent","possibleBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS Linux","Windows Boot Manager","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]}]},"expansionProducts":[],"ipv6Addresses":["fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","fe80:0:0:0:6eae:8bff:fe4b:4f15"],"slots":[1],"manufacturer":"
+        IBM(CLCN)","addinCards":[{"pciSubID":"454","firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Software
+        Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"slotSupportsHotPlug":"false","fodUniqueID":"N/A","pciRevision":"2","isAgentless":true,"pciBusNumber":"7","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","pciDeviceNumber":"0","slotNumber":"12","posID":"5d","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"vpdID":"1000","productName":"ServeRAID M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"}],"parentPartitionUUID":"","raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Firmware","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"description":"ServeRAID
+        M5210","name":"ServeRAID M5210","uuid":"0000000000000000500605B006E6ED5B","storagePools":[{"raidLevel":0,"description":"0000000000000000500605B006E6ED5B_Storage
+        Pool_M5210_0000000000000000500605B006E6ED5B_c:Pool:0","storageVolumes":[{"bootable":true,"volumeUID":"0","primaryPartition":0,"volumeID":"6","numberOfBlocks":583983104,"volumeStatus":"Dynamic
+        Reconfig","description":"Volume 0 0000000000000000500605B006E6ED5B_0","stripeSize":65536,"name":"GenericR0_0","blockSize":512,"health":"Unknown"}],"name":"Pool_0","totalManagedSpace":298999349248,"remainingSpace":0,"arrayUid":"0","arrayStatus":"Offline","diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"FRU":"42D0628","mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631"}]}],"diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"FRU":"42D0628","mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631"}]}],"vpdID":"","uuid":"7936DD182C5311E3A8D6000AF7256738","isConnectionTrusted":"false","memoryModules":[{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65F9","displayName":"CPU 1 DIMM
+        9,12800 MB/s","slot":9,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FA","displayName":"CPU 1 DIMM
+        15,12800 MB/s","slot":15,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FE","displayName":"CPU 2 DIMM
+        9,12800 MB/s","slot":9,"type":"DDR3","partNumber":"Unknown"},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF6603","displayName":"CPU 2 DIMM
+        15,12800 MB/s","slot":15,"type":"DDR3","partNumber":"Unknown"}],"partitionEnabled":false,"fruSerialNumber":"None","secureBootMode":{"possibleValues":["Disabled","Enabled"],"currentValue":"Disabled"},"encapsulation":{"encapsulationMode":"normal"},"tlsVersion":{"possibleValues":["TLS_10","TLS_11","TLS_12","unsupported"],"currentValue":"TLS_12"},"model":"AC1","isScalable":true,"expansionCardSlots":0,"fans":[{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 1","slots":1,"name":"Fan 1"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 2","slots":2,"name":"Fan 2"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 3","slots":3,"name":"Fan 3"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 4","slots":4,"name":"Fan 4"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 5","slots":5,"name":"Fan 5"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 6","slots":6,"name":"Fan 6"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 7","slots":7,"name":"Fan 7"},{"healthState":"Warning","status":"Degraded","speed":3440,"description":"Logical
+        Device for fan / cooling device 8","slots":8,"name":"Fan 8"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 9","slots":9,"name":"Fan 9"},{"healthState":"Normal","status":"OK","speed":3440,"description":"Logical
+        Device for fan / cooling device 10","slots":10,"name":"Fan 10"}],"isITME":false,"hostMacAddresses":"00:0A:F7:25:67:38,00:0A:F7:25:67:39","contact":"","dataHandle":1518063984527,"ipv4Addresses":["10.243.6.17","169.254.95.118"],"cmmDisplayName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","backedBy":"real","complexID":1,"name":"cmm-dt1.labs.lenovo.com","memorySlots":0,"drives":[],"cmmHealthState":"Normal","userDescription":"","subSlots":[],"partNumber":"00D0188     ","excludedHealthState":"Warning","machineType":"6241","isRemotePresenceEnabled":true,"pciDevices":[{"pciSubID":"454","firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","softwareID":"10140454","type":"Software
+        Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020"}],"slotSupportsHotPlug":"false","fodUniqueID":"N/A","pciRevision":"2","isAgentless":true,"pciBusNumber":"7","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","pciDeviceNumber":"0","slotNumber":"12","posID":"5d","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"vpdID":"1000","productName":"ServeRAID M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)"},{"pciSubID":"0","firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","softwareID":"0:0","type":"","build":"0","date":"","version":""}],"fodUniqueID":"","pciRevision":"0","isAgentless":false,"pciBusNumber":"27","pciSubVendorID":"0","isAddOnCard":false,"pciDeviceNumber":"0","posID":"534","pciFunctionNumber":"0","name":"","portInfo":{},"vpdID":"102b"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"},{"pciSubID":"450","firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","softwareID":"10140450","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c"}],"slotSupportsHotPlug":"false","fodUniqueID":"11S90Y9372Y0502037P0ES","pciRevision":"0","isAgentless":true,"pciBusNumber":"145","pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","pciDeviceNumber":"0","slotNumber":"7","posID":"165f","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"vpdID":"14e4","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7"}],"domainName":"mm-dt1.labs.lenovo.com","processors":[{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15},{"speed":2.2,"manufacturer":"Intel(R) Corporation","family":"PENTIUM_R_4","displayName":"Intel(R)
+        Xeon(R) CPU E7-8880L v2 @ 2.20GHz","slot":2,"productVersion":"Intel(R) Xeon(R)
+        CPU E7-8880L v2 @ 2.20GHz","cores":15}],"processorSlots":0,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config"],"productId":"4D4F00","hasOS":false,"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"ports":[{"ioModuleBay":0,"portNumber":49},{"ioModuleBay":0,"portNumber":50}],"embeddedHypervisorPresence":false,"posID":"","nist":{"possibleValues":["Compatibility","Nist_800_131A_Strict","unsupported"],"currentValue":"Compatibility"},"overallHealthState":"Warning","subType":"","partitionID":-1,"physicalID":0,"flashStorage":[],"productName":"Lenovo
+        System x3850 X6"},"complexNodeUUIDs":["7936DD182C5311E3A8D6000AF7256738"],"complexID":"7936DD182C5311E3A8D6000AF7256738","itemLocationRack":"","physicalID":0,"nodeCount":1,"itemLocation":"","itemLocationRoom":""}],"placeholderList":[],"switchList":[],"room":""},{"storageList":[],"cabinetName":"solution-1","height":42,"complexList":[],"chassisList":[],"location":"","UUID":"FCD07E7C-F69F-4469-A57B-3FAF4D064C49","nodeList":[],"placeholderList":[],"switchList":[],"room":""},{"storageList":[],"cabinetName":"rack-2","height":42,"complexList":[],"chassisList":[],"location":"","UUID":"43D47624-E655-45B6-A0A7-D914BBC1D2D7","nodeList":[],"placeholderList":[],"switchList":[],"room":""}]}'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:02 GMT
+- request:
+    method: get
+    uri: https://10.243.9.123/patterns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQQVNTVzByRA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:02 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=86400; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Security-Policy:
+      - 'default-src https:; script-src https: ''unsafe-inline'' ''unsafe-eval'';
+        style-src https: ''unsafe-inline'''
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - '1'
+      Content-Type:
+      - application/com.lenovo.lxca-v1.2.2+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '1162'
+    body:
+      encoding: UTF-8
+      string: '{"identifier":"id","label":"name","items":[{"id":"77","referencedBy":[],"userDefined":true,"formFactor":"r","inUse":false,"description":"Pattern
+        generated from 10.243.6.71\nPattern created from server: XinYi-71\nLearned
+        on: Oct 19, 2017 2:38:29 PM","name":"XinYi-71-config","nodeType":"sysx","type":"Server","uri":"/config/template/77"},{"id":"96","referencedBy":[],"userDefined":true,"formFactor":"r","inUse":true,"description":"Pattern
+        created from server: DaAn-68-gui\nLearned on: Oct 25, 2017 8:28:52 PM","name":"DaAn-68-gui-config","nodeType":"sysx","type":"Server","uri":"/config/template/96"},{"id":"65","referencedBy":[],"userDefined":true,"formFactor":"rc","inUse":false,"description":"Copy
+        of the 17dspncsvdm server''s settings\nPattern created from server: 17dspncsvdm\nLearned
+        on: Sep 19, 2017 10:58:18 AM","name":"17dspncsvdm-config","nodeType":"sysx","type":"Server","uri":"/config/template/65"},{"id":"54","referencedBy":[],"userDefined":true,"formFactor":"r","inUse":false,"description":"Pattern
+        created from server: DaAn-68-gui\nLearned on: Aug 28, 2017 12:47:37 PM","name":"DaAn","nodeType":"sysx","type":"Server","uri":"/config/template/54"}]}
+
+'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:02 GMT
+- request:
+    method: get
+    uri: https://10.243.6.103/aicc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQYXNzdzByZA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:02 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=15550200; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - default-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src
+        'self' 'unsafe-inline'; worker-src 'self' blob:; child-src 'self' blob:; img-src
+        'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.0.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"date":{"utc_offset":-18000000,"utc_offset_raw":-18000000,"uses_daylight":true,"timezones":[{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Abidjan","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Accra","display_name":"Ghana
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Addis_Ababa","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Algiers","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Asmara","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Asmera","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Bamako","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Bangui","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Banjul","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Bissau","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Blantyre","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Brazzaville","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Bujumbura","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Cairo","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Africa/Casablanca","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Africa/Ceuta","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Conakry","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Dakar","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Dar_es_Salaam","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Djibouti","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Douala","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Africa/El_Aaiun","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Freetown","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Gaborone","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Harare","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Johannesburg","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Juba","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Kampala","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Khartoum","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Kigali","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Kinshasa","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Lagos","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Libreville","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Lome","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Luanda","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Lubumbashi","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Lusaka","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Malabo","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Maputo","display_name":"Central
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Maseru","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Mbabane","display_name":"South
+        Africa Standard Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Mogadishu","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Monrovia","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Africa/Nairobi","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Ndjamena","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Niamey","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Nouakchott","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Ouagadougou","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Porto-Novo","display_name":"Western
+        African Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Sao_Tome","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Africa/Timbuktu","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Africa/Tripoli","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Africa/Tunis","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":7200000,"id":"Africa/Windhoek","display_name":"Western
+        African Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":-36000000,"uses_daylight":true,"offset":-36000000,"id":"America/Adak","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Anchorage","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Anguilla","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Antigua","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Araguaina","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Buenos_Aires","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Catamarca","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/ComodRivadavia","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Cordoba","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Jujuy","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/La_Rioja","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Mendoza","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Rio_Gallegos","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Salta","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/San_Juan","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/San_Luis","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Tucuman","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Argentina/Ushuaia","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Aruba","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-10800000,"id":"America/Asuncion","display_name":"Paraguay
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Atikokan","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":true,"offset":-36000000,"id":"America/Atka","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Bahia","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Bahia_Banderas","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Barbados","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Belem","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Belize","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Blanc-Sablon","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Boa_Vista","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Bogota","display_name":"Colombia
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Boise","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Buenos_Aires","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Cambridge_Bay","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Campo_Grande","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Cancun","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Caracas","display_name":"Venezuela
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Catamarca","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Cayenne","display_name":"French
+        Guiana Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Cayman","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Chicago","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Chihuahua","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Coral_Harbour","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Cordoba","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Costa_Rica","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Creston","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Cuiaba","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Curacao","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"America/Danmarkshavn","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Dawson","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Dawson_Creek","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Denver","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Detroit","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Dominica","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Edmonton","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Eirunepe","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/El_Salvador","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Ensenada","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Fort_Nelson","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Fort_Wayne","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Fortaleza","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Glace_Bay","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":true,"offset":-10800000,"id":"America/Godthab","display_name":"Western
+        Greenland Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Goose_Bay","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Grand_Turk","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Grenada","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Guadeloupe","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Guatemala","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Guayaquil","display_name":"Ecuador
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Guyana","display_name":"Guyana
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Halifax","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Havana","display_name":"Cuba
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Hermosillo","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Indianapolis","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Indiana/Knox","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Marengo","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Petersburg","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Indiana/Tell_City","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Vevay","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Vincennes","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indiana/Winamac","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Indianapolis","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Inuvik","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Iqaluit","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Jamaica","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Jujuy","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Juneau","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Kentucky/Louisville","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Kentucky/Monticello","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Knox_IN","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Kralendijk","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/La_Paz","display_name":"Bolivia
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Lima","display_name":"Peru
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Los_Angeles","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Louisville","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Lower_Princes","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Maceio","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Managua","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Manaus","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Marigot","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Martinique","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Matamoros","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Mazatlan","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Mendoza","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Menominee","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Merida","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Metlakatla","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Mexico_City","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":true,"offset":-10800000,"id":"America/Miquelon","display_name":"Pierre
+        & Miquelon Standard Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Moncton","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Monterrey","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Montevideo","display_name":"Uruguay
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Montreal","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Montserrat","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Nassau","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/New_York","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Nipigon","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Nome","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-7200000,"uses_daylight":false,"offset":-7200000,"id":"America/Noronha","display_name":"Fernando
+        de Noronha Time","utc_offset_w_dst":-7200000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/North_Dakota/Beulah","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/North_Dakota/Center","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/North_Dakota/New_Salem","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Ojinaga","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Panama","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Pangnirtung","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Paramaribo","display_name":"Suriname
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"America/Phoenix","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Port-au-Prince","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Port_of_Spain","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Porto_Acre","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Porto_Velho","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Puerto_Rico","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Rainy_River","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Rankin_Inlet","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Recife","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Regina","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Resolute","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"America/Rio_Branco","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Rosario","display_name":"Argentine
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Santa_Isabel","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"America/Santarem","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-10800000,"id":"America/Santiago","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Santo_Domingo","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":true,"offset":-10800000,"id":"America/Sao_Paulo","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-3600000,"uses_daylight":true,"offset":-3600000,"id":"America/Scoresbysund","display_name":"Eastern
+        Greenland Time","utc_offset_w_dst":-3600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Shiprock","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Sitka","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Barthelemy","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-12600000,"uses_daylight":true,"offset":-12600000,"id":"America/St_Johns","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Kitts","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Lucia","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Thomas","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/St_Vincent","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Swift_Current","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"America/Tegucigalpa","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"America/Thule","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Thunder_Bay","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Tijuana","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"America/Toronto","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Tortola","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Vancouver","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"America/Virgin","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"America/Whitehorse","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"America/Winnipeg","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"America/Yakutat","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"America/Yellowknife","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Antarctica/Casey","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Antarctica/Davis","display_name":"Davis
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Antarctica/DumontDUrville","display_name":"Dumont-d''Urville
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Antarctica/Macquarie","display_name":"Macquarie
+        Island Standard Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Antarctica/Mawson","display_name":"Mawson
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":46800000,"id":"Antarctica/McMurdo","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-10800000,"id":"Antarctica/Palmer","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"Antarctica/Rothera","display_name":"Rothera
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":46800000,"id":"Antarctica/South_Pole","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Antarctica/Syowa","display_name":"Syowa
+        Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Antarctica/Troll","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":7200000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Antarctica/Vostok","display_name":"Vostok
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Arctic/Longyearbyen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Aden","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Almaty","display_name":"Alma-Ata
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Amman","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Asia/Anadyr","display_name":"Anadyr
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Aqtau","display_name":"Aqtau
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Aqtobe","display_name":"Aqtobe
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Ashgabat","display_name":"Turkmenistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Ashkhabad","display_name":"Turkmenistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Baghdad","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Bahrain","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Baku","display_name":"Azerbaijan
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Bangkok","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Barnaul","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Beirut","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Bishkek","display_name":"Kirgizstan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Brunei","display_name":"Brunei
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":19800000,"uses_daylight":false,"offset":19800000,"id":"Asia/Calcutta","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Chita","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":true,"offset":28800000,"id":"Asia/Choibalsan","display_name":"Choibalsan
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Chongqing","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Chungking","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":19800000,"uses_daylight":false,"offset":19800000,"id":"Asia/Colombo","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Dacca","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Damascus","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Dhaka","display_name":"Bangladesh
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Dili","display_name":"Timor-Leste
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Dubai","display_name":"Gulf
+        Standard Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Dushanbe","display_name":"Tajikistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Gaza","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Harbin","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Hebron","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Ho_Chi_Minh","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Hong_Kong","display_name":"Hong
+        Kong Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":true,"offset":25200000,"id":"Asia/Hovd","display_name":"Hovd
+        Time","utc_offset_w_dst":25200000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Irkutsk","display_name":"Irkutsk
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Istanbul","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Jakarta","display_name":"West
+        Indonesia Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Jayapura","display_name":"East
+        Indonesia Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Jerusalem","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":16200000,"uses_daylight":false,"offset":16200000,"id":"Asia/Kabul","display_name":"Afghanistan
+        Time","utc_offset_w_dst":16200000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Asia/Kamchatka","display_name":"Petropavlovsk-Kamchatski
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Karachi","display_name":"Pakistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Kashgar","display_name":"Xinjiang
+        Standard Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":20700000,"uses_daylight":false,"offset":20700000,"id":"Asia/Kathmandu","display_name":"Nepal
+        Time","utc_offset_w_dst":20700000,"daylight_saves":0},{"utc_offset_raw":20700000,"uses_daylight":false,"offset":20700000,"id":"Asia/Katmandu","display_name":"Nepal
+        Time","utc_offset_w_dst":20700000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Khandyga","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":19800000,"uses_daylight":false,"offset":19800000,"id":"Asia/Kolkata","display_name":"India
+        Standard Time","utc_offset_w_dst":19800000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Krasnoyarsk","display_name":"Krasnoyarsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Kuala_Lumpur","display_name":"Malaysia
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Kuching","display_name":"Malaysia
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Kuwait","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Macao","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Macau","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Asia/Magadan","display_name":"Magadan
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Makassar","display_name":"Central
+        Indonesia Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Manila","display_name":"Philippines
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Muscat","display_name":"Gulf
+        Standard Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Nicosia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Novokuznetsk","display_name":"Krasnoyarsk
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Novosibirsk","display_name":"Novosibirsk
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Omsk","display_name":"Omsk
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Oral","display_name":"Oral
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Phnom_Penh","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Pontianak","display_name":"West
+        Indonesia Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":30600000,"uses_daylight":false,"offset":30600000,"id":"Asia/Pyongyang","display_name":"Korea
+        Standard Time","utc_offset_w_dst":30600000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Qatar","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Qyzylorda","display_name":"Qyzylorda
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":23400000,"uses_daylight":false,"offset":23400000,"id":"Asia/Rangoon","display_name":"Myanmar
+        Time","utc_offset_w_dst":23400000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Asia/Riyadh","display_name":"Arabia
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Saigon","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Asia/Sakhalin","display_name":"Sakhalin
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Samarkand","display_name":"Uzbekistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Seoul","display_name":"Korea
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Shanghai","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Singapore","display_name":"Singapore
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Asia/Srednekolymsk","display_name":"Srednekolymsk
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Taipei","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Tashkent","display_name":"Uzbekistan
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Tbilisi","display_name":"Georgia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":12600000,"uses_daylight":true,"offset":12600000,"id":"Asia/Tehran","display_name":"Iran
+        Standard Time","utc_offset_w_dst":12600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Asia/Tel_Aviv","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Thimbu","display_name":"Bhutan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Thimphu","display_name":"Bhutan
+        Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Tokyo","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Tomsk","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Asia/Ujung_Pandang","display_name":"Central
+        Indonesia Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":true,"offset":28800000,"id":"Asia/Ulaanbaatar","display_name":"Ulaanbaatar
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":true,"offset":28800000,"id":"Asia/Ulan_Bator","display_name":"Ulaanbaatar
+        Time","utc_offset_w_dst":28800000,"daylight_saves":3600000},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Asia/Urumqi","display_name":"Xinjiang
+        Standard Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Asia/Ust-Nera","display_name":"Ust-Nera
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Asia/Vientiane","display_name":"Indochina
+        Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Asia/Vladivostok","display_name":"Vladivostok
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Asia/Yakutsk","display_name":"Yakutsk
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Asia/Yekaterinburg","display_name":"Yekaterinburg
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Asia/Yerevan","display_name":"Armenia
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":-3600000,"uses_daylight":true,"offset":-3600000,"id":"Atlantic/Azores","display_name":"Azores
+        Time","utc_offset_w_dst":-3600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"Atlantic/Bermuda","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Atlantic/Canary","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":-3600000,"uses_daylight":false,"offset":-3600000,"id":"Atlantic/Cape_Verde","display_name":"Cape
+        Verde Time","utc_offset_w_dst":-3600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Atlantic/Faeroe","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Atlantic/Faroe","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Atlantic/Jan_Mayen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Atlantic/Madeira","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Atlantic/Reykjavik","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-7200000,"uses_daylight":false,"offset":-7200000,"id":"Atlantic/South_Georgia","display_name":"South
+        Georgia Standard Time","utc_offset_w_dst":-7200000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Atlantic/St_Helena","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"Atlantic/Stanley","display_name":"Falkland
+        Is. Time","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/ACT","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":34200000,"uses_daylight":true,"offset":37800000,"id":"Australia/Adelaide","display_name":"Australian
+        Central Standard Time (South Australia)","utc_offset_w_dst":37800000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Australia/Brisbane","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":34200000,"uses_daylight":true,"offset":37800000,"id":"Australia/Broken_Hill","display_name":"Australian
+        Central Standard Time (South Australia/New South Wales)","utc_offset_w_dst":37800000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Canberra","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Currie","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":34200000,"uses_daylight":false,"offset":34200000,"id":"Australia/Darwin","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0},{"utc_offset_raw":31500000,"uses_daylight":false,"offset":31500000,"id":"Australia/Eucla","display_name":"Australian
+        Central Western Standard Time","utc_offset_w_dst":31500000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Hobart","display_name":"Australian
+        Eastern Standard Time (Tasmania)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":37800000,"uses_daylight":true,"offset":39600000,"id":"Australia/LHI","display_name":"Lord
+        Howe Standard Time","utc_offset_w_dst":39600000,"daylight_saves":1800000},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Australia/Lindeman","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":37800000,"uses_daylight":true,"offset":39600000,"id":"Australia/Lord_Howe","display_name":"Lord
+        Howe Standard Time","utc_offset_w_dst":39600000,"daylight_saves":1800000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Melbourne","display_name":"Australian
+        Eastern Standard Time (Victoria)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/NSW","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":34200000,"uses_daylight":false,"offset":34200000,"id":"Australia/North","display_name":"Australian
+        Central Standard Time (Northern Territory)","utc_offset_w_dst":34200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Australia/Perth","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Australia/Queensland","display_name":"Australian
+        Eastern Standard Time (Queensland)","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":34200000,"uses_daylight":true,"offset":37800000,"id":"Australia/South","display_name":"Australian
+        Central Standard Time (South Australia)","utc_offset_w_dst":37800000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Sydney","display_name":"Australian
+        Eastern Standard Time (New South Wales)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Tasmania","display_name":"Australian
+        Eastern Standard Time (Tasmania)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":true,"offset":39600000,"id":"Australia/Victoria","display_name":"Australian
+        Eastern Standard Time (Victoria)","utc_offset_w_dst":39600000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Australia/West","display_name":"Australian
+        Western Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":34200000,"uses_daylight":true,"offset":37800000,"id":"Australia/Yancowinna","display_name":"Australian
+        Central Standard Time (South Australia/New South Wales)","utc_offset_w_dst":37800000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"Brazil/Acre","display_name":"Acre
+        Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-7200000,"uses_daylight":false,"offset":-7200000,"id":"Brazil/DeNoronha","display_name":"Fernando
+        de Noronha Time","utc_offset_w_dst":-7200000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":true,"offset":-10800000,"id":"Brazil/East","display_name":"Brasilia
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"Brazil/West","display_name":"Amazon
+        Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"CET","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"CST6CDT","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"Canada/Atlantic","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"Canada/Central","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"Canada/East-Saskatchewan","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"Canada/Eastern","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"Canada/Mountain","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-12600000,"uses_daylight":true,"offset":-12600000,"id":"Canada/Newfoundland","display_name":"Newfoundland
+        Standard Time","utc_offset_w_dst":-12600000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"Canada/Pacific","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"Canada/Saskatchewan","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"Canada/Yukon","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-10800000,"id":"Chile/Continental","display_name":"Chile
+        Time","utc_offset_w_dst":-10800000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-18000000,"id":"Chile/EasterIsland","display_name":"Easter
+        Is. Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"Cuba","display_name":"Cuba
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"EET","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"EST5EDT","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Egypt","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Eire","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/GMT","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/GMT+0","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-3600000,"uses_daylight":false,"offset":-3600000,"id":"Etc/GMT+1","display_name":"GMT-01:00","utc_offset_w_dst":-3600000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Etc/GMT+10","display_name":"GMT-10:00","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Etc/GMT+11","display_name":"GMT-11:00","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":-43200000,"uses_daylight":false,"offset":-43200000,"id":"Etc/GMT+12","display_name":"GMT-12:00","utc_offset_w_dst":-43200000,"daylight_saves":0},{"utc_offset_raw":-7200000,"uses_daylight":false,"offset":-7200000,"id":"Etc/GMT+2","display_name":"GMT-02:00","utc_offset_w_dst":-7200000,"daylight_saves":0},{"utc_offset_raw":-10800000,"uses_daylight":false,"offset":-10800000,"id":"Etc/GMT+3","display_name":"GMT-03:00","utc_offset_w_dst":-10800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"Etc/GMT+4","display_name":"GMT-04:00","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"Etc/GMT+5","display_name":"GMT-05:00","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"Etc/GMT+6","display_name":"GMT-06:00","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"Etc/GMT+7","display_name":"GMT-07:00","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":false,"offset":-28800000,"id":"Etc/GMT+8","display_name":"GMT-08:00","utc_offset_w_dst":-28800000,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":false,"offset":-32400000,"id":"Etc/GMT+9","display_name":"GMT-09:00","utc_offset_w_dst":-32400000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/GMT-0","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":false,"offset":3600000,"id":"Etc/GMT-1","display_name":"GMT+01:00","utc_offset_w_dst":3600000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Etc/GMT-10","display_name":"GMT+10:00","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Etc/GMT-11","display_name":"GMT+11:00","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Etc/GMT-12","display_name":"GMT+12:00","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":46800000,"uses_daylight":false,"offset":46800000,"id":"Etc/GMT-13","display_name":"GMT+13:00","utc_offset_w_dst":46800000,"daylight_saves":0},{"utc_offset_raw":50400000,"uses_daylight":false,"offset":50400000,"id":"Etc/GMT-14","display_name":"GMT+14:00","utc_offset_w_dst":50400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Etc/GMT-2","display_name":"GMT+02:00","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Etc/GMT-3","display_name":"GMT+03:00","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Etc/GMT-4","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Etc/GMT-5","display_name":"GMT+05:00","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Etc/GMT-6","display_name":"GMT+06:00","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Etc/GMT-7","display_name":"GMT+07:00","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Etc/GMT-8","display_name":"GMT+08:00","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Etc/GMT-9","display_name":"GMT+09:00","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/GMT0","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/Greenwich","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/UCT","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/UTC","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/Universal","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Etc/Zulu","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Amsterdam","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Andorra","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Europe/Astrakhan","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Athens","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Belfast","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Belgrade","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Berlin","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Bratislava","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Brussels","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Bucharest","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Budapest","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Busingen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Chisinau","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Copenhagen","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Dublin","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Gibraltar","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Guernsey","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Helsinki","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Isle_of_Man","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Istanbul","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Jersey","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Europe/Kaliningrad","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Kiev","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Kirov","display_name":"GMT+03:00","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/Lisbon","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Ljubljana","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Europe/London","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Luxembourg","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Madrid","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Malta","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Mariehamn","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Minsk","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Monaco","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Moscow","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Nicosia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Oslo","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Paris","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Podgorica","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Prague","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Riga","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Rome","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Europe/Samara","display_name":"Samara
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/San_Marino","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Sarajevo","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Simferopol","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Skopje","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Sofia","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Stockholm","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Tallinn","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Tirane","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Tiraspol","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Europe/Ulyanovsk","display_name":"GMT+04:00","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Uzhgorod","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Vaduz","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Vatican","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Vienna","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Vilnius","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Europe/Volgograd","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Warsaw","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Zagreb","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Europe/Zaporozhye","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Europe/Zurich","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"GB","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"GB-Eire","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"GMT","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"GMT0","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Greenwich","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Hongkong","display_name":"Hong
+        Kong Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Iceland","display_name":"Greenwich
+        Mean Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Indian/Antananarivo","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":21600000,"uses_daylight":false,"offset":21600000,"id":"Indian/Chagos","display_name":"Indian
+        Ocean Territory Time","utc_offset_w_dst":21600000,"daylight_saves":0},{"utc_offset_raw":25200000,"uses_daylight":false,"offset":25200000,"id":"Indian/Christmas","display_name":"Christmas
+        Island Time","utc_offset_w_dst":25200000,"daylight_saves":0},{"utc_offset_raw":23400000,"uses_daylight":false,"offset":23400000,"id":"Indian/Cocos","display_name":"Cocos
+        Islands Time","utc_offset_w_dst":23400000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Indian/Comoro","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Indian/Kerguelen","display_name":"French
+        Southern & Antarctic Lands Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Indian/Mahe","display_name":"Seychelles
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":18000000,"uses_daylight":false,"offset":18000000,"id":"Indian/Maldives","display_name":"Maldives
+        Time","utc_offset_w_dst":18000000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Indian/Mauritius","display_name":"Mauritius
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"Indian/Mayotte","display_name":"Eastern
+        African Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":14400000,"uses_daylight":false,"offset":14400000,"id":"Indian/Reunion","display_name":"Reunion
+        Time","utc_offset_w_dst":14400000,"daylight_saves":0},{"utc_offset_raw":12600000,"uses_daylight":true,"offset":12600000,"id":"Iran","display_name":"Iran
+        Standard Time","utc_offset_w_dst":12600000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Israel","display_name":"Israel
+        Standard Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"Jamaica","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Japan","display_name":"Japan
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Kwajalein","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":7200000,"uses_daylight":false,"offset":7200000,"id":"Libya","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"MET","display_name":"Middle
+        Europe Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"MST7MDT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"Mexico/BajaNorte","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"Mexico/BajaSur","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"Mexico/General","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":46800000,"id":"NZ","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000},{"utc_offset_raw":45900000,"uses_daylight":true,"offset":49500000,"id":"NZ-CHAT","display_name":"Chatham
+        Standard Time","utc_offset_w_dst":49500000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"Navajo","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"PRC","display_name":"China
+        Standard Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"PST8PDT","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":46800000,"uses_daylight":true,"offset":50400000,"id":"Pacific/Apia","display_name":"West
+        Samoa Standard Time","utc_offset_w_dst":50400000,"daylight_saves":3600000},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":46800000,"id":"Pacific/Auckland","display_name":"New
+        Zealand Standard Time","utc_offset_w_dst":46800000,"daylight_saves":3600000},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Bougainville","display_name":"Bougainville
+        Standard Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":45900000,"uses_daylight":true,"offset":49500000,"id":"Pacific/Chatham","display_name":"Chatham
+        Standard Time","utc_offset_w_dst":49500000,"daylight_saves":3600000},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Chuuk","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-18000000,"id":"Pacific/Easter","display_name":"Easter
+        Is. Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Efate","display_name":"Vanuatu
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":46800000,"uses_daylight":false,"offset":46800000,"id":"Pacific/Enderbury","display_name":"Phoenix
+        Is. Time","utc_offset_w_dst":46800000,"daylight_saves":0},{"utc_offset_raw":46800000,"uses_daylight":false,"offset":46800000,"id":"Pacific/Fakaofo","display_name":"Tokelau
+        Time","utc_offset_w_dst":46800000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":true,"offset":43200000,"id":"Pacific/Fiji","display_name":"Fiji
+        Time","utc_offset_w_dst":43200000,"daylight_saves":3600000},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Funafuti","display_name":"Tuvalu
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"Pacific/Galapagos","display_name":"Galapagos
+        Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":false,"offset":-32400000,"id":"Pacific/Gambier","display_name":"Gambier
+        Time","utc_offset_w_dst":-32400000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Guadalcanal","display_name":"Solomon
+        Is. Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Guam","display_name":"Chamorro
+        Standard Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Pacific/Honolulu","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Pacific/Johnston","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":50400000,"uses_daylight":false,"offset":50400000,"id":"Pacific/Kiritimati","display_name":"Line
+        Is. Time","utc_offset_w_dst":50400000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Kosrae","display_name":"Kosrae
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Kwajalein","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Majuro","display_name":"Marshall
+        Islands Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":-34200000,"uses_daylight":false,"offset":-34200000,"id":"Pacific/Marquesas","display_name":"Marquesas
+        Time","utc_offset_w_dst":-34200000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Pacific/Midway","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Nauru","display_name":"Nauru
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Pacific/Niue","display_name":"Niue
+        Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Norfolk","display_name":"Norfolk
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Noumea","display_name":"New
+        Caledonia Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Pacific/Pago_Pago","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"Pacific/Palau","display_name":"Palau
+        Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":false,"offset":-28800000,"id":"Pacific/Pitcairn","display_name":"Pitcairn
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Pohnpei","display_name":"Pohnpei
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":39600000,"uses_daylight":false,"offset":39600000,"id":"Pacific/Ponape","display_name":"Pohnpei
+        Time","utc_offset_w_dst":39600000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Port_Moresby","display_name":"Papua
+        New Guinea Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Pacific/Rarotonga","display_name":"Cook
+        Is. Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Saipan","display_name":"Chamorro
+        Standard Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"Pacific/Samoa","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"Pacific/Tahiti","display_name":"Tahiti
+        Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Tarawa","display_name":"Gilbert
+        Is. Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":46800000,"uses_daylight":false,"offset":46800000,"id":"Pacific/Tongatapu","display_name":"Tonga
+        Time","utc_offset_w_dst":46800000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Truk","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Wake","display_name":"Wake
+        Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":43200000,"uses_daylight":false,"offset":43200000,"id":"Pacific/Wallis","display_name":"Wallis
+        & Futuna Time","utc_offset_w_dst":43200000,"daylight_saves":0},{"utc_offset_raw":36000000,"uses_daylight":false,"offset":36000000,"id":"Pacific/Yap","display_name":"Chuuk
+        Time","utc_offset_w_dst":36000000,"daylight_saves":0},{"utc_offset_raw":3600000,"uses_daylight":true,"offset":3600000,"id":"Poland","display_name":"Central
+        European Time","utc_offset_w_dst":3600000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"Portugal","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":32400000,"uses_daylight":false,"offset":32400000,"id":"ROK","display_name":"Korea
+        Standard Time","utc_offset_w_dst":32400000,"daylight_saves":0},{"utc_offset_raw":28800000,"uses_daylight":false,"offset":28800000,"id":"Singapore","display_name":"Singapore
+        Time","utc_offset_w_dst":28800000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":false,"offset":-14400000,"id":"SystemV/AST4","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":0},{"utc_offset_raw":-14400000,"uses_daylight":true,"offset":-14400000,"id":"SystemV/AST4ADT","display_name":"Atlantic
+        Standard Time","utc_offset_w_dst":-14400000,"daylight_saves":3600000},{"utc_offset_raw":-21600000,"uses_daylight":false,"offset":-21600000,"id":"SystemV/CST6","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"SystemV/CST6CDT","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"SystemV/EST5","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"SystemV/EST5EDT","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"SystemV/HST10","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"SystemV/MST7","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"SystemV/MST7MDT","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":false,"offset":-28800000,"id":"SystemV/PST8","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":0},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"SystemV/PST8PDT","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-32400000,"uses_daylight":false,"offset":-32400000,"id":"SystemV/YST9","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"SystemV/YST9YDT","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":7200000,"uses_daylight":true,"offset":7200000,"id":"Turkey","display_name":"Eastern
+        European Time","utc_offset_w_dst":7200000,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"UCT","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-32400000,"uses_daylight":true,"offset":-32400000,"id":"US/Alaska","display_name":"Alaska
+        Standard Time","utc_offset_w_dst":-32400000,"daylight_saves":3600000},{"utc_offset_raw":-36000000,"uses_daylight":true,"offset":-36000000,"id":"US/Aleutian","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"US/Arizona","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"US/Central","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"US/East-Indiana","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"US/Eastern","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"US/Hawaii","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-21600000,"uses_daylight":true,"offset":-21600000,"id":"US/Indiana-Starke","display_name":"Central
+        Standard Time","utc_offset_w_dst":-21600000,"daylight_saves":3600000},{"utc_offset_raw":-18000000,"uses_daylight":true,"offset":-18000000,"id":"US/Michigan","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":3600000},{"utc_offset_raw":-25200000,"uses_daylight":true,"offset":-25200000,"id":"US/Mountain","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"US/Pacific","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-28800000,"uses_daylight":true,"offset":-28800000,"id":"US/Pacific-New","display_name":"Pacific
+        Standard Time","utc_offset_w_dst":-28800000,"daylight_saves":3600000},{"utc_offset_raw":-39600000,"uses_daylight":false,"offset":-39600000,"id":"US/Samoa","display_name":"Samoa
+        Standard Time","utc_offset_w_dst":-39600000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"UTC","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Universal","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":10800000,"uses_daylight":false,"offset":10800000,"id":"W-SU","display_name":"Moscow
+        Standard Time","utc_offset_w_dst":10800000,"daylight_saves":0},{"utc_offset_raw":0,"uses_daylight":true,"offset":0,"id":"WET","display_name":"Western
+        European Time","utc_offset_w_dst":0,"daylight_saves":3600000},{"utc_offset_raw":0,"uses_daylight":false,"offset":0,"id":"Zulu","display_name":"Coordinated
+        Universal Time","utc_offset_w_dst":0,"daylight_saves":0},{"utc_offset_raw":-18000000,"uses_daylight":false,"offset":-18000000,"id":"EST","display_name":"Eastern
+        Standard Time","utc_offset_w_dst":-18000000,"daylight_saves":0},{"utc_offset_raw":-36000000,"uses_daylight":false,"offset":-36000000,"id":"HST","display_name":"Hawaii
+        Standard Time","utc_offset_w_dst":-36000000,"daylight_saves":0},{"utc_offset_raw":-25200000,"uses_daylight":false,"offset":-25200000,"id":"MST","display_name":"Mountain
+        Standard Time","utc_offset_w_dst":-25200000,"daylight_saves":0}],"date_time":"March
+        8, 2018 3:40:03 PM EST","timezone":"Eastern Standard Time","timezone_id":"EST5EDT","parts":{"mm":3,"dd":8,"hours":15,"mins":40,"secs":3,"yyyy":2018},"utc_offset_w_dst":-18000000},"appliance":{"date":"2018-02-09_13-37-27","build":"423","name":"LXCA
+        - 10.243.6.103","runlevel":3,"version":"2.0.0","uuid":"85acba9f-9ddf-4a62-91e6-9a1c4f1beda5","status":"Normal"},"subscriptions":[{"submonitor_uri":"","id":1,"monitor_uri":"/aicc/network/interfaces","uri":"/osdeployment/rest/internal/event/aicc"},{"submonitor_uri":"","id":2,"monitor_uri":"/aicc/network/interfaces","uri":"/netchangenotsec"},{"submonitor_uri":"/ntp","id":3,"monitor_uri":"/aicc","uri":"/ntpNotification"}],"appliance_states":[{"description":"Halt
+        the appliance","runlevel":0},{"description":"Normal operation","runlevel":3},{"description":"Reboot
+        the appliance","runlevel":6}],"preferredDisplayName":"byDefault","services":[{"pid":26614,"id":"core","state":0,"initd":"xhmc-core"},{"pid":1428,"id":"keydaemon","state":0,"initd":"sympl-keydaemon"},{"pid":1577,"id":"watchdog","state":0,"initd":"sympl-watchdog"},{"pid":-1,"id":"apache","state":1,"initd":"httpd"},{"pid":-1,"id":"network","state":0,"initd":"network"},{"pid":23849,"id":"ntp","state":0,"initd":"ntpd"},{"pid":1764,"id":"sftp","state":0,"initd":"sshd"},{"pid":22528,"id":"xcat","state":0,"initd":"xcatd"}],"ntp":{"servers":[{"server":"us.pool.ntp.org","authenticated":false,"v3_key_type":"","v3_key":"","v3_key_index":0,"version":1},{"server":"","authenticated":false,"v3_key_type":"","v3_key":"","v3_key_index":0,"version":0}]},"network_interfaces":[{"role":["management","osdeployment"],"mac_address":"52:54:00:C2:BF:23","ip_addresses":[{"ip":"fe80:0:0:0:5054:ff:fec2:bf23%eth0","ip_linklocal":"true","prefix_length":64,"version":6,"assign_method":"static"},{"ip":"10.243.6.103","ip_linklocal":"false","prefix_length":20,"version":4,"assign_method":"static"},{"ip":"0::0%0","ip_linklocal":"false","prefix_length":64,"version":6,"assign_method":"dhcp"}],"rpf":"RFC3704Strict","id":"eth0"}],"service_states":[{"description":"Service
+        is running","state":0},{"description":"Service is dead but PID file exists","state":1},{"description":"Service
+        is dead but lock file exists","state":2},{"description":"Service is not running","state":3},{"description":"Service
+        state is unknown","state":4},{"description":"Special purpose state used to
+        trigger restart through REST","state":191}]}'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:03 GMT
+- request:
+    method: get
+    uri: https://10.243.6.103/cabinet?status=includestandalone
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQYXNzdzByZA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:03 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=15550200; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - default-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src
+        'self' 'unsafe-inline'; worker-src 'self' blob:; child-src 'self' blob:; img-src
+        'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.0.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"cabinetList":[{"cabinetName":"solution-1","height":42,"room":"","location":"","chassisList":[],"complexList":[],"nodeList":[{"itemName":"Management
+        Controller UUID-F812491A398611E4B45040F2E9A61078","itemUUID":"F812491A398611E4B45040F2E9A61078","itemLocationRoom":"","itemLocationRack":"solution-1","itemLocation":"","itemLowerUnit":1,"itemType":"SERVER","itemHeight":5,"itemSubType":"","complexNodeCount":-1,"nodeCount":-1,"physicalID":-1,"itemInventory":{"name":"cmm-ys21","uuid":"F812491A398611E4B45040F2E9A61078","status":{"message":"managed","name":"MANAGED"},"hostname":"IMM2-40f2e9a6107d","overallHealthState":"Warning","productName":"Lenovo
+        System x3500 M5","type":"Rack-Tower Server","manufacturer":"LNVO(WIST)","machineType":"5464","model":"AC1","mgmtProcIPaddress":"10.243.6.150","arch":"x86","serialNumber":"06CHKBV","partNumber":"00KC305     ","FRU":"None","fruSerialNumber":"None","domainName":"labs.lenovo.com","FQDN":"RodneySystem.labs.lenovo.com","powerStatus":8,"userDescription":"","macAddress":"40:F2:E9:A6:10:7D,40:F2:E9:A6:10:7E","hostMacAddresses":"40:F2:E9:A6:10:78,40:F2:E9:A6:10:79,40:F2:E9:A6:10:7A,40:F2:E9:A6:10:7B","tlsVersion":{"possibleValues":["unsupported","TLS_12","TLS_11","TLS_10"],"currentValue":"TLS_10"},"nist":{"possibleValues":["Nist_800_131A_Strict","unsupported","Compatibility"],"currentValue":"Compatibility"},"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"location":{"lowestRackUnit":0,"location":"","rack":"solution-1","room":""},"lanOverUsb":"enabled","description":"Chassis","mgmtProcType":"IMM2","isRemotePresenceEnabled":true,"height":5,"leds":[{"name":"DIMM
+        13","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 2","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CONFIG","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        4","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM 23","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        18","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 7","state":"Off","color":"Yellow","location":"Planar"},{"name":"Power","state":"On","color":"Green","location":"FrontRearPanel"},{"name":"Fan
+        2","state":"Off","color":"Yellow","location":"Planar"},{"name":"PS","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"Check
+        Log","state":"Off","color":"Yellow","location":"FrontPanel"},{"name":"PCI
+        7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU MISMATCH","state":"Off","color":"Yellow","location":"FRU"},{"name":"HYP
+        SKT2","state":"Off","color":"Yellow","location":"FRU"},{"name":"SD ERR","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM
+        22","state":"Off","color":"Yellow","location":"Planar"},{"name":"MEM","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"DIMM
+        12","state":"Off","color":"Yellow","location":"Planar"},{"name":"NMI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"SysBrd
+        Fault","state":"Off","color":"Yellow","location":"Planar"},{"name":"HYP SKT1","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM
+        5","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 19","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"Fan 4","state":"Off","color":"Yellow","location":"Planar"},{"name":"Fan
+        1","state":"Off","color":"Yellow","location":"Planar"},{"name":"IMM2 Heartbeat","state":"Blinking","color":"Green","location":"Planar"},{"name":"DIMM
+        8","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 1","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        15","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM
+        21","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 9","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        4","state":"Off","color":"Yellow","location":"Planar"},{"name":"Fan 3","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU
+        2","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 16","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        11","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Identify","state":"Off","color":"Blue","location":"FrontRearPanel"},{"name":"FAN","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"Battery","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        14","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 3","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU
+        1","state":"Off","color":"Yellow","location":"Planar"},{"name":"SP ERR","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"DIMM
+        24","state":"Off","color":"Yellow","location":"Planar"},{"name":"TEMP","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        5","state":"Off","color":"Yellow","location":"FRU"},{"name":"HDD","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"DIMM
+        17","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"Fault","state":"Off","color":"Yellow","location":"FrontRearPanel"},{"name":"DIMM
+        6","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"BOARD","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"DIMM
+        20","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 10","state":"Off","color":"Yellow","location":"Planar"}],"expansionCards":[],"firmware":[{"name":"DSA
+        Diagnostic Software","date":"2016-07-08T00:00:00Z","type":"DSA","build":"DSALA7K","version":"10.2","role":"Primary","status":"Active"},{"name":"IMM2
+        Firmware","date":"2016-08-29T00:00:00Z","type":"IMM2","build":"TCOO23A","version":"3.50","role":"Primary","status":"Active"},{"name":"UEFI
+        Backup Firmware/BIOS","date":"2016-09-07T00:00:00Z","type":"UEFI-Backup","build":"TAE125O","version":"2.20","role":"Backup","status":"Inactive"},{"name":"UEFI
+        Firmware/BIOS","date":"2016-09-07T00:00:00Z","type":"UEFI","build":"TAE125O","version":"2.20","role":"Primary","status":"Active"},{"name":"IMM2
+        Backup Firmware","date":"2016-08-29T00:00:00Z","type":"IMM2-Backup","build":"TCOO23A","version":"3.50","role":"Backup","status":"Inactive"}],"powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K12814750M2","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8136","firmware":[],"healthState":"CRITICAL","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":550},"powerState":"Unknown","posID":"","slots":[1],"manufacturer":"EMER","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""}],"ipv4Addresses":["10.243.6.150","169.254.95.118"],"ipv6Addresses":["fd55:faaf:e1ab:2021:42f2:e9ff:fea6:107d","fe80:0:0:0:42f2:e9ff:fea6:107d"],"raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Firmware","build":"0","date":"2016-07-20T00:00:00Z","version":"24.12.0-0033","softwareID":"10140456"}],"description":"ServeRAID
+        M1215","name":"ServeRAID M1215","uuid":"0000000000000000500605B00915C470","diskDrives":[{"model":"ST91000640SS","healthState":"Normal","numberOfBlocks":1953525168,"interfaceType":"SAS","serialNumber":"9XG0JVL3","blockSize":512,"mediaType":"Rotational","diskState":"JBOD","bay":7,"description":"ST91000640SS","manufacturer":"IBM-ESXS","name":"Disk
+        0_9","uuid":"","partNumber":"81Y3818","largestAvailableSize":512,"capacity":1000204886000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"BD23","softwareID":"ST91000640SS"}],"FRU":"81Y9687"}],"storagePools":[],"batteryData":[]}],"drives":[],"memoryModules":[{"model":"DDR4","speed":2133,"manufacturer":"Hynix
+        Semiconductor","capacity":16,"serialNumber":"9032D73E","displayName":"DIMM
+        1","slot":1,"type":"DDR4","partNumber":"HMA42GR7MFR4N-TF","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992CF59","displayName":"DIMM
+        2","slot":2,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992D4EB","displayName":"DIMM
+        3","slot":3,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0E41381F","displayName":"DIMM 4","slot":4,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992DC3D","displayName":"DIMM
+        5","slot":5,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992DBE2","displayName":"DIMM
+        6","slot":6,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0E413681","displayName":"DIMM 7","slot":7,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0E413825","displayName":"DIMM 8","slot":8,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0E4136DF","displayName":"DIMM 9","slot":9,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Micron
+        Technology","capacity":8,"serialNumber":"0D855B12","displayName":"DIMM 10","slot":10,"type":"DDR4","partNumber":"18ASF1G72PZ-2G1A2","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Samsung","capacity":8,"serialNumber":"3992D294","displayName":"DIMM
+        11","slot":11,"type":"DDR4","partNumber":"M393A1G40DB0-CPB","speedMBs":0},{"model":"DDR4","speed":2133,"manufacturer":"Hynix
+        Semiconductor","capacity":16,"serialNumber":"9032D73F","displayName":"DIMM
+        12","slot":12,"type":"DDR4","partNumber":"HMA42GR7MFR4N-TF","speedMBs":0}],"processors":[{"speed":2.3,"manufacturer":"Intel(R)
+        Corporation","family":"INTEL_R_XEON_TM","displayName":"Intel(R) Xeon(R) CPU
+        E5-2650 v3 @ 2.30GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E5-2650
+        v3 @ 2.30GHz","cores":10,"socket":""}],"pciDevices":[{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2016-07-20T00:00:00Z","version":"24.12.0-0033","softwareID":"10140456"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"11","pciDeviceNumber":"0","slotNumber":"1","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M1215","portInfo":{},"uuid":"0000000000000000500605B00915C470","productName":"ServeRAID
+        M1215","partNumber":"N/A","fruSerialNumber":"SV42831792","slotName":"SlotDesig7_Slot
+        1","pciSubID":"456","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5f","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A61078","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"1d49:a01"}],"pciRevision":"1","pciBusNumber":"25","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"a01","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"1d49","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"3","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":4,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A6107B","vnicMode":false}],"peerBay":0,"physicalPortIndex":4}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"1","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":2,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A61079","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"2","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":3,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A6107A","vnicMode":false}],"peerBay":0,"physicalPortIndex":3}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"}],"accessState":"Online","manufacturerId":"LNVO(WIST)","addinCardSlots":0,"driveBays":33,"errorFields":[{"FirmwareData":"NO_CONNECTOR"},{"ChassisMounted":"NO_CONNECTOR"},{"RackPowerCappingPolicy":"FETCH_FAILED"}],"bladeState":0,"activationKeys":[{"keyFeatureType":1,"keyStatus":"VALID","description":"Integrated
+        Management Module Advanced Upgrade","keyUseLimit":0,"keyExpirationDate":"","keyUseCount":0,"uuid":"cc1911fd3eefbf6d","keyIdentiferList":[{"keyIdentifierType":"MT","keyIdentifier":"546406CHKBV"}]}],"uri":"nodes/F812491A398611E4B45040F2E9A61078","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":550,"minimumAllocatedPower":26},"expansionProductType":"","bootOrder":{"uri":"nodes/F812491A398611E4B45040F2E9A61078/bootOrder","bootOrderList":[{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS","Floppy Disk","Hard Disk 1","Hard
+        Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB1","USB2","USB3","USB4","USB5","USB6","USB10","USB11","USB12","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","NIC1","NIC2","NIC3","NIC4","SATA","DSA"]},{"currentBootOrderDevices":["CentOS","CD/DVD
+        Rom","Hard Disk 0","PXE Network"],"bootType":"Permanent","possibleBootOrderDevices":["CentOS","CD/DVD
+        Rom","Hard Disk 0","PXE Network","Floppy Disk","Hard Disk 1","Hard Disk 2","Hard
+        Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI Critical","Embedded
+        Hypervisor","Legacy Only","USB1","USB2","USB3","USB4","USB5","USB6","USB10","USB11","USB12","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","NIC1","NIC2","NIC3","NIC4","SATA","DSA"]},{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]}]},"expansionProducts":[],"slots":[1],"vpdID":"","encapsulation":{"encapsulationMode":"normal"},"secureBootMode":{"possibleValues":["Enabled","Disabled"],"currentValue":"Disabled"},"expansionCardSlots":0,"contact":"","dataHandle":1520517060293,"cmmDisplayName":"Management
+        Controller UUID-F812491A398611E4B45040F2E9A61078","backedBy":"real","complexID":-1,"memorySlots":12,"cmmHealthState":"Normal","subSlots":[],"excludedHealthState":"Warning","processorSlots":1,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config","OOB
+        Option Firmware Update"],"productId":"4D4F00","hasOS":false,"ports":[{"ioModuleBay":0,"portNumber":1},{"ioModuleBay":0,"portNumber":2},{"ioModuleBay":0,"portNumber":3},{"ioModuleBay":0,"portNumber":4}],"embeddedHypervisorPresence":false,"posID":"","subType":"","partitionID":-1,"flashStorage":[],"userDefinedName":"cmm-ys21","securityDescriptor":{"managedAuthSupported":true,"publicAccess":false,"uri":"nodes/f812491a398611e4b45040f2e9a61078","roleGroups":[],"managedAuthEnabled":true,"storedCredentials":{"description":"Credentials
+        for cmm-ys21","id":"352","userName":"USERID"}},"logicalID":-1,"primary":false,"fans":[{"name":"Fan
+        1","healthState":"Normal","status":"OK","description":"Logical Device for
+        fan / cooling device 1","speed":3807,"slots":1},{"name":"Fan 2","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 2","speed":3807,"slots":2}],"addinCards":[{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2016-07-20T00:00:00Z","version":"24.12.0-0033","softwareID":"10140456"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"11","pciDeviceNumber":"0","slotNumber":"1","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M1215","portInfo":{},"uuid":"0000000000000000500605B00915C470","productName":"ServeRAID
+        M1215","partNumber":"N/A","fruSerialNumber":"SV42831792","slotName":"SlotDesig7_Slot
+        1","pciSubID":"456","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5f","vpdID":"1000","class":"Mass
+        storage controller"}],"physicalID":0,"faceplateIDs":[{"name":"front panel
+        board 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0},{"name":"drive
+        backplane 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0},{"name":"system
+        board 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0}],"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"m2Presence":false,"onboardPciDevices":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A61078","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"3","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":4,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A6107B","vnicMode":false}],"peerBay":0,"physicalPortIndex":4}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"1d49:a01"}],"pciRevision":"1","pciBusNumber":"25","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"a01","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"1d49","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"1","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":2,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A61079","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.2a","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.2a","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"2","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":3,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9A6107A","vnicMode":false}],"peerBay":0,"physicalPortIndex":3}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"}],"ipInterfaces":[{"name":"eth0","label":"unknown","IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.150","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:42f2:e9ff:fea6:107d","prefix":64,"type":"INUSE"},{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:42f2:e9ff:fea6:107d","prefix":64,"type":"INUSE"}],"IPv6statelessEnabled":true,"IPv6staticEnabled":false}],"isConnectionTrusted":"true","isScalable":false,"isITME":false}}],"switchList":[],"storageList":[],"placeholderList":[],"UUID":"B5C61140-DDA1-4102-8838-A32C89372826"},{"cabinetName":"SueThinkAgile
+        Solution","height":42,"room":"basement","location":"Rochester","chassisList":[],"complexList":[],"nodeList":[],"switchList":[{"itemName":"NE2572","itemUUID":"00000000000010008000542AA2D3CB00","itemLocationRoom":"basement","itemLocationRack":"SueThinkAgile
+        Solution","itemLocation":"Rochester","itemLowerUnit":41,"itemType":"SWITCH","itemHeight":1,"itemSubType":"","itemInventory":{"name":"NE2572","uuid":"00000000000010008000542AA2D3CB00","accessState":"Offline","overallHealthState":"Critical","type":"Rackswitch","hostname":"NE2572","description":"48*25
+        GbE SFP+, 6*100 GbE QSFP+","dnsHostnames":[],"domainName":"","FRU":"","fruSerialNumber":"","ipv4Addresses":["10.241.107.248"],"ipv6Addresses":["fe80:0:0:0:562a:a2ff:fed3:cb"],"macAddresses":["2A:A2:D3:CB:00:00"],"machineType":"7159","manufacturer":"LNVO","manufacturerId":"","model":"xxx","partNumber":"SC57A24361","posID":"","powerState":"Unknown","productId":"","productName":"Lenovo
+        ThinkSystem NE2572 RackSwitch","protectedMode":"Unknown","serialNumber":"ABCDEFGHUJKL","stackMode":"none","vpdID":"","backedBy":"real","cmmDisplayName":"NE2572","cmmHealthState":"Critical","dataHandle":1519674286005,"elapsedTimeMillisecs":"867296622","errorFields":[],"firmware":[{"name":"Uboot","date":"","type":"Boot
+        ROM","build":"","version":"0.0.0.0","role":"","status":"N/A"},{"name":"Active
+        Image","date":"","type":"Main Image","build":"","version":"10.4.2.0","role":"","status":"Active"},{"name":"Standby
+        Image","date":"","type":"Main Image","build":"","version":"0.0.0.0","role":"","status":"Non-Active"}],"ipInterfaces":[{"name":"unknown","label":"unknown","IPv4enabled":false,"IPv4DHCPmode":"UNKNOWN","IPv6enabled":false,"IPv6DHCPenabled":false,"IPv4assignments":[{"id":0,"subnet":"127.0.0.1","gateway":"0.0.0.0","address":"10.241.107.248","type":"UNKNOWN"}],"IPv6assignments":[],"IPv6statelessEnabled":false,"IPv6staticEnabled":false}],"leds":[],"ntpPushEnabled":false,"ntpPushFrequency":0,"parent":{"uuid":"D9E74889-5929-45EC-83EC-60038EEA23C3","uri":"chassis/D9E74889-5929-45EC-83EC-60038EEA23C3"},"portDataSetTimestamp":"02:44:41","uri":"switches/00000000000010008000542AA2D3CB00","userDescription":"","userDefinedName":"NE2572","securityDescriptor":{"managedAuthSupported":false,"publicAccess":false,"uri":"switches/00000000000010008000542aa2d3cb00","roleGroups":[],"managedAuthEnabled":false},"applyPending":"No","contact":"","cpuUtilization":"N/A","entitleSerialNumber":"<EMPTY>","fans":[{"fanName":"Fan
+        1","fanSpeed":"4800 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        2","fanSpeed":"5250 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        3","fanSpeed":"4800 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        4","fanSpeed":"5250 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        5","fanSpeed":"4800 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        6","fanSpeed":"5400 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        7","fanSpeed":"4950 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        8","fanSpeed":"5250 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        10","fanSpeed":"5400 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        9","fanSpeed":"4950 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        11","fanSpeed":"4800 RPM (23 PWM)","fanState":"Front-to-Back"},{"fanName":"Fan
+        12","fanSpeed":"5250 RPM (23 PWM)","fanState":"Front-to-Back"}],"height":1,"location":{"lowestRackUnit":41,"location":"Rochester","rack":"SueThinkAgile
+        Solution","room":"basement"},"manufacturingDate":"0308 (WWYY)","memoryUtilization":"","mgmtProcIPaddress":"10.241.107.248","panicDump":"Yes","ports":[{"configuredStatus":"up","interfaceIndex":"410001","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/1","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410002","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/2","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410003","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/3","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410004","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/4","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410005","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/5","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410006","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/6","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410007","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/7","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410008","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/8","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410009","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/9","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410010","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/10","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410011","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/11","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410012","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/12","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410013","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/13","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410014","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/14","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410015","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/15","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410016","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/16","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410017","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/17","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410018","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/18","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410019","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/19","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410020","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/20","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410021","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/21","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410022","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/22","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410023","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/23","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410024","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/24","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410025","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/25","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410026","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/26","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410027","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/27","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410028","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/28","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410029","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/29","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410030","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/30","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410031","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/31","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410032","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/32","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410033","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/33","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410034","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/34","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410035","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/35","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410036","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/36","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410037","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/37","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410038","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/38","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410039","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/39","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410040","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/40","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410041","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/41","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410042","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/42","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410043","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/43","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410044","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/44","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410045","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/45","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410046","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/46","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410047","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/47","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410048","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"25000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/48","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410049","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/49","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410053","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/50","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410057","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/51","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410061","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/52","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410065","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/53","PVID":"default"},{"configuredStatus":"up","interfaceIndex":"410069","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"100000","portState":"down","tagPVID":"","vLAN":"access","port":"Ethernet1/54","PVID":"default"}],"powerSupply":"Power
+        Supply 1: Off;Power Supply 2: on.","resetReason":"1","savePending":"No","stackRole":"none","sysObjectID":"1.3.6.1.4.1.19046.1.7.41","temperatureSensors":[{"sensorName":"
+        Ambient","sensorState":" 34 C"},{"sensorName":" CPU","sensorState":" 38 C"},{"sensorName":"Hot
+        Spot","sensorState":" 42 C"}],"upTime":"9 days, 03:10:35","isConnectionTrusted":"true","OS":"CNOS"}}],"storageList":[],"placeholderList":[],"UUID":"D9E74889-5929-45EC-83EC-60038EEA23C3"},{"cabinetName":"STANDALONE_OBJECT_NAME","height":42,"room":"","location":"","chassisList":[],"complexList":[{"slots":[1,1],"complexID":"7936DD182C5311E3A8D6000AF7256738","partitionCount":0,"uuid":"7936DD182C5311E3A8D6000AF7256738","nodeCount":1,"orphanNodes":[{"name":"cmm-dt1.labs.lenovo.com","uuid":"7936DD182C5311E3A8D6000AF7256738","status":{"message":"managed","name":"MANAGED"},"hostname":"IMM2-6cae8b4b4f15","overallHealthState":"Normal","productName":"Lenovo
+        System x3850 X6","type":"Rack-Tower Server","manufacturer":" IBM(CLCN)","machineType":"6241","model":"AC1","mgmtProcIPaddress":"10.243.6.17","arch":"x86","serialNumber":"23Y6458","partNumber":"00D0188     ","FRU":"None","fruSerialNumber":"None","domainName":"labs.lenovo.com","FQDN":"cmm-dt1.labs.lenovo.com","powerStatus":8,"userDescription":"","macAddress":"6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16","hostMacAddresses":"00:0A:F7:25:67:38,00:0A:F7:25:67:39","tlsVersion":{"possibleValues":["unsupported","TLS_12","TLS_11","TLS_10"],"currentValue":"TLS_12"},"nist":{"possibleValues":["Nist_800_131A_Strict","unsupported","Compatibility"],"currentValue":"Compatibility"},"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"lanOverUsb":"enabled","description":"Chassis","mgmtProcType":"IMM2","isRemotePresenceEnabled":true,"height":4,"leds":[{"name":"CPU
+        3 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM
+        10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 10Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CMOS Batt
+        Error","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU 3
+        DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        15","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"PS","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        12DIMM 16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"Check
+        Log","state":"Off","color":"Yellow","location":"FrontPanel"},{"name":"CPU
+        3 DIMM 24","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 14Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 20","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"OVER
+        SPEC","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        3 DIMM 11","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"DASD","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        1 DIMM 16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        4 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"ML2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 12","state":"Off","color":"Yellow","location":"FRU"},{"name":"BMC Heartbeat","state":"Blinking","color":"Green","location":"Planar"},{"name":"PCI
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"SysBrd","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN
+        2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        11","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        24","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book 4 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        2 DIMM 12","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"TEMP","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        5","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        20","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        2 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"Book
+        1 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 12Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"Fault","state":"Off","color":"Yellow","location":"FrontRearPanel"},{"name":"CPU
+        2 DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4
+        DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI
+        8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 20","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book 2 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        3 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        4 DIMM 11","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 13Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"Power","state":"On","color":"Green","location":"FrontRearPanel"},{"name":"CPU
+        4 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        12","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"MEM","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"NMI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CNFG","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        3 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 15","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        10PEC","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        11Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        24","state":"Off","color":"Yellow","location":"FRU"},{"name":"LINK","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        2 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        20","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 15","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Identify","state":"Off","color":"Blue","location":"FrontRearPanel"},{"name":"CPU
+        1 DIMM 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        1 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        4 DIMM 10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        15Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 11DIMM
+        16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        4 DIMM 24","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 9","state":"Off","color":"Yellow","location":"FRU"}],"expansionCards":[],"firmware":[{"name":"UEFI
+        Backup Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI-Backup","build":"A9E143HUS","version":"4.30","role":"Backup","status":"Inactive"},{"name":"IMM2
+        Backup Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2-Backup","build":"TCOO39A","version":"4.70","role":"Backup","status":"Inactive"},{"name":"DSA
+        Diagnostic Software","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2","role":"Primary","status":"Active"},{"name":"UEFI
+        Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"A9E143HUS","version":"4.30","role":"Primary","status":"Active"},{"name":"IMM2
+        Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70","role":"Primary","status":"Active"}],"powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K115136V11L","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 2","leds":[],"description":"","name":"Power Supply 2","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[3],"manufacturer":"DELT","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""},{"model":"","manufacturerId":"","serialNumber":"K115136V11E","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[2],"manufacturer":"DELT","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""}],"ipv4Addresses":["10.243.6.17","169.254.95.118"],"ipv6Addresses":["fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","fe80:0:0:0:6eae:8bff:fe4b:4f15"],"raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Firmware","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"description":"ServeRAID
+        M5210","name":"ServeRAID M5210","uuid":"0000000000000000500605B006E6ED5B","diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631","largestAvailableSize":512,"capacity":300000000000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"B56T","softwareID":"ST300MM0006"}],"FRU":"42D0628"}],"storagePools":[{"name":"Pool_0","arrayUid":"0","description":"0000000000000000500605B006E6ED5B_Storage
+        Pool_M5210_0000000000000000500605B006E6ED5B_c:Pool:0","arrayStatus":"Offline","totalManagedSpace":298999349248,"remainingSpace":0,"raidLevel":0,"storageVolumes":[{"name":"GenericR0_0","bootable":true,"description":"Volume
+        0 0000000000000000500605B006E6ED5B_0","blockSize":512,"numberOfBlocks":583983104,"primaryPartition":0,"stripeSize":65536,"volumeStatus":"Dynamic
+        Reconfig","volumeID":"6","volumeUID":"0","driveIndex":0,"removable":false,"health":"Unknown","LUN":-1}],"diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631","largestAvailableSize":512,"capacity":300000000000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"B56T","softwareID":"ST300MM0006"}],"FRU":"42D0628"}]}],"batteryData":[]}],"drives":[],"memoryModules":[{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65F9","displayName":"CPU 1 DIMM
+        9","slot":9,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FA","displayName":"CPU 1 DIMM
+        15","slot":15,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FE","displayName":"CPU 2 DIMM
+        9","slot":9,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF6603","displayName":"CPU 2 DIMM
+        15","slot":15,"type":"DDR3","partNumber":"Unknown","speedMBs":12800}],"processors":[{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15,"socket":"Socket 1"},{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":2,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15,"socket":"Socket 2"}],"pciDevices":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"7","pciDeviceNumber":"0","slotNumber":"12","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B006E6ED5B","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"0:0"}],"pciRevision":"0","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"0","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"0","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"}],"accessState":"Offline","manufacturerId":" IBM(CLCN)","addinCardSlots":0,"driveBays":17,"errorFields":[{"FirmwareData":"NO_CONNECTOR"},{"ChassisMounted":"NO_CONNECTOR"}],"bladeState":255,"activationKeys":[],"uri":"nodes/7936DD182C5311E3A8D6000AF7256738","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":1710,"minimumAllocatedPower":26},"expansionProductType":"","bootOrder":{"uri":"nodes/7936DD182C5311E3A8D6000AF7256738/bootOrder","bootOrderList":[{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS Linux","Windows Boot Manager","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom"],"bootType":"Permanent","possibleBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]}]},"expansionProducts":[],"slots":[1],"vpdID":"","encapsulation":{"encapsulationMode":"normal"},"secureBootMode":{"possibleValues":["Enabled","Disabled"],"currentValue":"Disabled"},"expansionCardSlots":0,"contact":"","dataHandle":1520459083510,"cmmDisplayName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","backedBy":"real","complexID":1,"memorySlots":4,"cmmHealthState":"Normal","subSlots":[],"excludedHealthState":"Normal","processorSlots":2,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config"],"productId":"4D4F00","hasOS":false,"ports":[{"ioModuleBay":0,"portNumber":49},{"ioModuleBay":0,"portNumber":50}],"embeddedHypervisorPresence":false,"posID":"","subType":"","partitionID":-1,"flashStorage":[],"userDefinedName":"","securityDescriptor":{"managedAuthSupported":true,"publicAccess":false,"uri":"nodes/7936dd182c5311e3a8d6000af7256738","roleGroups":[],"managedAuthEnabled":true,"storedCredentials":{"description":"Credentials
+        for null","id":"353","userName":"USERID"}},"logicalID":0,"primary":false,"powerCappingPolicy":{"cappingACorDCMode":"DC","minimumHardCapLevel":434100,"cappingPolicy":"OFF","maxPowerCap":533000,"minimumPowerCappingHotPlugLevel":754000,"powerCappingAllocUnit":"watts*10^-3","maximumPowerCappingHotPlugLevel":854000,"currentPowerCap":0,"minPowerCap":-1},"fans":[{"name":"Fan
+        1","healthState":"Normal","status":"OK","description":"Logical Device for
+        fan / cooling device 1","speed":3440,"slots":1},{"name":"Fan 4","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 4","speed":3440,"slots":4},{"name":"Fan 2","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 2","speed":3440,"slots":2},{"name":"Fan 9","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 9","speed":3440,"slots":9},{"name":"Fan 7","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 7","speed":3440,"slots":7},{"name":"Fan 6","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 6","speed":3440,"slots":6},{"name":"Fan 10","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 10","speed":3440,"slots":10},{"name":"Fan
+        8","healthState":"Warning","status":"Degraded","description":"Logical Device
+        for fan / cooling device 8","speed":3440,"slots":8},{"name":"Fan 3","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 3","speed":3440,"slots":3},{"name":"Fan 5","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 5","speed":3440,"slots":5}],"addinCards":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"7","pciDeviceNumber":"0","slotNumber":"12","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B006E6ED5B","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"}],"physicalID":0,"faceplateIDs":[{"name":"drive backplane 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0},{"name":"I/O
+        module 5","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0}],"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"m2Presence":false,"onboardPciDevices":[{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"0:0"}],"pciRevision":"0","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"0","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"0","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"}],"ipInterfaces":[{"name":"eth0","label":"unknown","IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.17","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"},{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"}],"IPv6statelessEnabled":true,"IPv6staticEnabled":false}],"parentComplexID":"7936DD182C5311E3A8D6000AF7256738","isConnectionTrusted":"true","isScalable":true,"isITME":false}],"partition":[],"location":{"lowestRackUnit":0,"location":"","rack":"","room":""}}],"nodeList":[{"itemName":"Management
+        Controller UUID-FC3058CADF8B11D48C9B9B1B1B1B1B57","itemUUID":"FC3058CADF8B11D48C9B9B1B1B1B1B57","itemLocationRoom":"","itemLocationRack":"","itemLocation":"","itemLowerUnit":0,"itemType":"SERVER","itemHeight":1,"itemSubType":"","complexNodeCount":-1,"nodeCount":-1,"physicalID":-1,"itemInventory":{"name":"DaAn1.labs.lenovo.com","uuid":"FC3058CADF8B11D48C9B9B1B1B1B1B57","status":{"message":"managed","name":"MANAGED"},"hostname":"IMM2-40f2e9b8163d","overallHealthState":"Normal","productName":"IBM
+        System x3550 M5","type":"Rack-Tower Server","manufacturer":" IBM(WIST)","machineType":"5463","model":"45Z","mgmtProcIPaddress":"10.243.6.68","arch":"x86","serialNumber":"KVD0152","partNumber":"00KC903     ","FRU":"None","fruSerialNumber":"None","domainName":"labs.lenovo.com","FQDN":"DaAn1.labs.lenovo.com","powerStatus":8,"userDescription":"","macAddress":"40:F2:E9:B8:16:3D,40:F2:E9:B8:16:3E","hostMacAddresses":"40:F2:E9:B8:16:38,40:F2:E9:B8:16:39,40:F2:E9:B8:16:3A,40:F2:E9:B8:16:3B","tlsVersion":{"possibleValues":["unsupported","TLS_12","TLS_11","TLS_10"],"currentValue":"TLS_12"},"nist":{"possibleValues":["Nist_800_131A_Strict","unsupported","Compatibility"],"currentValue":"Compatibility"},"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"lanOverUsb":"enabled","description":"Chassis","mgmtProcType":"IMM2","isRemotePresenceEnabled":true,"height":1,"leds":[{"name":"DIMM
+        13","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 2","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        21","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 15","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        9","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN 3","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        4","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 23","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU
+        2","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 18","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        7","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN 5","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        16","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN 2","state":"Off","color":"Yellow","location":"Planar"},{"name":"Check
+        Log","state":"Off","color":"Yellow","location":"FrontPanel"},{"name":"DIMM
+        11","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        7","state":"Off","color":"Yellow","location":"Planar"},{"name":"Identify","state":"Off","color":"Blue","location":"FrontRearPanel"},{"name":"Battery","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        22","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 14","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        3","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 12","state":"Off","color":"Yellow","location":"Planar"},{"name":"Power","state":"Blinking","color":"Green","location":"FrontRearPanel"},{"name":"SysBrd
+        Fault","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU 1","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        24","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 5","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN
+        4","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 19","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU
+        Mismatch Ctlr","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"DIMM 17","state":"Off","color":"Yellow","location":"Planar"},{"name":"Fault","state":"Off","color":"Yellow","location":"FrontRearPanel"},{"name":"FAN
+        6","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 6","state":"Off","color":"Yellow","location":"Planar"},{"name":"PCI
+        1","state":"Off","color":"Yellow","location":"FRU"},{"name":"Internal RAID","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN
+        8","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 8","state":"Off","color":"Yellow","location":"Planar"},{"name":"IMM2
+        Heartbeat","state":"Blinking","color":"Green","location":"Planar"},{"name":"DIMM
+        1","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM 20","state":"Off","color":"Yellow","location":"Planar"},{"name":"DIMM
+        10","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN 1","state":"Off","color":"Yellow","location":"Planar"},{"name":"SDRAID
+        Error","state":"Off","color":"Yellow","location":"Planar"}],"expansionCards":[],"firmware":[{"name":"UEFI
+        Backup Firmware/BIOS","date":"2017-04-10T00:00:00Z","type":"UEFI-Backup","build":"TBE129J","version":"2.40","role":"Backup","status":"Inactive"},{"name":"UEFI
+        Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"TBE133J","version":"2.60","role":"Primary","status":"Active"},{"name":"IMM2
+        Backup Firmware","date":"2017-10-26T00:00:00Z","type":"IMM2-Backup","build":"TCOO61T","version":"9.00","role":"Backup","status":"Inactive"},{"name":"DSA
+        Diagnostic Software","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2","role":"Primary","status":"Active"},{"name":"IMM2
+        Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70","role":"Primary","status":"Active"}],"powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":0},"powerState":"Unknown","posID":"","slots":[1],"manufacturer":"","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""}],"ipv4Addresses":["10.243.6.68","169.254.95.118"],"ipv6Addresses":["fd55:faaf:e1ab:2021:42f2:e9ff:feb8:163d","fe80:0:0:0:42f2:e9ff:feb8:163d"],"raidSettings":[],"drives":[],"memoryModules":[{"model":"DDR4","speed":2133,"manufacturer":"Hynix
+        Semiconductor","capacity":4,"serialNumber":"103D4F3B","displayName":"DIMM
+        4","slot":4,"type":"DDR4","partNumber":"HMA451R7MFR8N-TFTD","speedMBs":16000}],"processors":[{"speed":2.3,"manufacturer":"Intel(R)
+        Corporation","family":"INTEL_R_XEON_TM","displayName":"Intel(R) Xeon(R) CPU
+        E5-2650 v3 @ 2.30GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E5-2650
+        v3 @ 2.30GHz","cores":10,"socket":"Socket 1"}],"pciDevices":[{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"1d49:a01"}],"pciRevision":"1","pciBusNumber":"20","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"a01","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"1d49","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B81638","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"2","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":3,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B8163A","vnicMode":false}],"peerBay":0,"physicalPortIndex":3}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"3","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":4,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B8163B","vnicMode":false}],"peerBay":0,"physicalPortIndex":4}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"1","pciDeviceNumber":"0","slotNumber":"4","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B008E547C0","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV42103710","slotName":"SlotDesig4_Slot
+        4","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"1","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":2,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B81639","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"}],"accessState":"Online","manufacturerId":" IBM(WIST)","addinCardSlots":0,"driveBays":0,"errorFields":[{"HealthState":"FATAL_EXCEPTION"},{"HealthSummary":"FATAL_EXCEPTION"},{"FirmwareData":"NO_CONNECTOR"},{"NetworkInterfaceData":"FATAL_EXCEPTION"},{"ChassisMounted":"NO_CONNECTOR"},{"PhysicalAndLocation":"FETCH_FAILED"},{"ServerSlots":"FATAL_EXCEPTION"},{"ServerExpansionHardware":"FATAL_EXCEPTION"},{"RackCPU":"FETCH_FAILED"},{"BootOrder":"FETCH_FAILED"},{"FlashDimm":"FETCH_FAILED"},{"ServerFirmwareData":"FETCH_FAILED"},{"RackPowerCappingPolicy":"FETCH_FAILED"}],"bladeState":0,"activationKeys":[{"keyFeatureType":1,"keyStatus":"VALID","description":"IBM
+        Integrated Management Module Advanced Upgrade","keyUseLimit":0,"keyExpirationDate":"","keyUseCount":0,"uuid":"bcf7e81e99c7b67f","keyIdentiferList":[{"keyIdentifierType":"MT","keyIdentifier":"5463KVD0152"}]}],"uri":"nodes/FC3058CADF8B11D48C9B9B1B1B1B1B57","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":0,"minimumAllocatedPower":0},"expansionProductType":"","bootOrder":{"uri":"nodes/FC3058CADF8B11D48C9B9B1B1B1B1B57/bootOrder","bootOrderList":[{"currentBootOrderDevices":["CentOS
+        Linux","Hard Disk 0","CentOS","CD/DVD Rom","PXE Network"],"bootType":"Permanent","possibleBootOrderDevices":["CentOS
+        Linux","Hard Disk 0","CentOS","CD/DVD Rom","PXE Network","Floppy Disk","Hard
+        Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","IMM1","IMM2","USB1","USB2","USB3","USB4","USB5","USB6","SdRaid","USB8","Slot4","Slot1","Slot2","Slot2","Slot3","NIC1","NIC2","NIC3","NIC4","CD/DVD","SATA
+        Port 0","SATA Port 1","SATA Port 2","SATA Port 3","sSATA Port 0","sSATA Port
+        1","sSATA Port 2","sSATA Port 3","DSA"]},{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]},{"currentBootOrderDevices":["PXE Network","CD/DVD Rom","Hard Disk
+        0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE Network","CD/DVD
+        Rom","Hard Disk 0","CentOS Linux","CentOS","Floppy Disk","Hard Disk 1","Hard
+        Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","IMM1","IMM2","USB1","USB2","USB3","USB4","USB5","USB6","SdRaid","USB8","Slot4","Slot1","Slot2","Slot2","Slot3","NIC1","NIC2","NIC3","NIC4","CD/DVD","SATA
+        Port 0","SATA Port 1","SATA Port 2","SATA Port 3","sSATA Port 0","sSATA Port
+        1","sSATA Port 2","sSATA Port 3","DSA"]}]},"expansionProducts":[],"slots":[1],"vpdID":"","encapsulation":{"encapsulationMode":"normal"},"secureBootMode":{"possibleValues":["Enabled","Disabled"],"currentValue":"Disabled"},"expansionCardSlots":0,"contact":"","dataHandle":1520530055801,"cmmDisplayName":"Management
+        Controller UUID-FC3058CADF8B11D48C9B9B1B1B1B1B57","backedBy":"real","complexID":-1,"memorySlots":0,"cmmHealthState":"Normal","subSlots":[],"excludedHealthState":"Normal","processorSlots":0,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config","OOB
+        Option Firmware Update"],"productId":"4D4F00","hasOS":false,"ports":[{"ioModuleBay":0,"portNumber":1},{"ioModuleBay":0,"portNumber":2},{"ioModuleBay":0,"portNumber":3},{"ioModuleBay":0,"portNumber":4}],"embeddedHypervisorPresence":false,"posID":"","subType":"","partitionID":-1,"flashStorage":[],"userDefinedName":"","securityDescriptor":{"managedAuthSupported":true,"publicAccess":false,"uri":"nodes/fc3058cadf8b11d48c9b9b1b1b1b1b57","roleGroups":[],"managedAuthEnabled":true,"storedCredentials":{"description":"Credentials
+        for SN#KVD0152","id":"360","userName":"USERID"}},"logicalID":-1,"primary":false,"fans":[{"name":"Fan
+        5","healthState":"Normal","status":"OK","description":"Logical Device for
+        fan / cooling device 5","speed":6966,"slots":5},{"name":"Fan 7","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 7","speed":6966,"slots":7},{"name":"Fan 2","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 2","speed":6966,"slots":2},{"name":"Fan 3","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 3","speed":6966,"slots":3},{"name":"Fan 6","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 6","speed":6966,"slots":6},{"name":"Fan 1","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 1","speed":6966,"slots":1},{"name":"Fan 4","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 4","speed":6966,"slots":4},{"name":"Fan 8","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 8","speed":6966,"slots":8}],"addinCards":[{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"1","pciDeviceNumber":"0","slotNumber":"4","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B008E547C0","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV42103710","slotName":"SlotDesig4_Slot
+        4","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"}],"physicalID":0,"faceplateIDs":[],"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"m2Presence":false,"onboardPciDevices":[{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"1d49:a01"}],"pciRevision":"1","pciBusNumber":"20","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"a01","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"1d49","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"2","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":3,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B8163A","vnicMode":false}],"peerBay":0,"physicalPortIndex":3}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B81638","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"3","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":4,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B8163B","vnicMode":false}],"peerBay":0,"physicalPortIndex":4}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"101404D1"}],"pciRevision":"1","pciBusNumber":"22","pciDeviceNumber":"0","pciFunctionNumber":"1","name":"Broadcom
+        NetXtreme Gigabit Ethernet Controller","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":2,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"40F2E9B81639","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"pciSubID":"4d1","fodUniqueID":"11SBCM957190123456789","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":false,"posID":"1657","vpdID":"14e4","class":"Network
+        controller"}],"ipInterfaces":[{"name":"eth0","label":"unknown","IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.68","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:42f2:e9ff:feb8:163d","prefix":64,"type":"INUSE"},{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:42f2:e9ff:feb8:163d","prefix":64,"type":"INUSE"}],"IPv6statelessEnabled":true,"IPv6staticEnabled":false}],"isConnectionTrusted":"true","isScalable":false,"isITME":false}},{"itemName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","itemUUID":"7936DD182C5311E3A8D6000AF7256738","itemLocationRoom":"","itemLocationRack":"","itemLocation":"","itemLowerUnit":0,"itemType":"SERVER","itemHeight":4,"itemSubType":"","complexID":"7936DD182C5311E3A8D6000AF7256738","complexNodeCount":1,"complexNodeUUIDs":["7936DD182C5311E3A8D6000AF7256738"],"nodeCount":1,"physicalID":0,"itemInventory":{"name":"cmm-dt1.labs.lenovo.com","uuid":"7936DD182C5311E3A8D6000AF7256738","status":{"message":"managed","name":"MANAGED"},"hostname":"IMM2-6cae8b4b4f15","overallHealthState":"Normal","productName":"Lenovo
+        System x3850 X6","type":"Rack-Tower Server","manufacturer":" IBM(CLCN)","machineType":"6241","model":"AC1","mgmtProcIPaddress":"10.243.6.17","arch":"x86","serialNumber":"23Y6458","partNumber":"00D0188     ","FRU":"None","fruSerialNumber":"None","domainName":"labs.lenovo.com","FQDN":"cmm-dt1.labs.lenovo.com","powerStatus":8,"userDescription":"","macAddress":"6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16","hostMacAddresses":"00:0A:F7:25:67:38,00:0A:F7:25:67:39","tlsVersion":{"possibleValues":["unsupported","TLS_12","TLS_11","TLS_10"],"currentValue":"TLS_12"},"nist":{"possibleValues":["Nist_800_131A_Strict","unsupported","Compatibility"],"currentValue":"Compatibility"},"bootMode":{"possibleValues":["UEFI
+        Mode","Legacy Mode"],"currentValue":"UEFI Mode"},"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"lanOverUsb":"enabled","description":"Chassis","mgmtProcType":"IMM2","isRemotePresenceEnabled":true,"height":4,"leds":[{"name":"CPU
+        3 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM
+        10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 10Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CMOS Batt
+        Error","state":"Off","color":"Yellow","location":"Planar"},{"name":"CPU 3
+        DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        15","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"PS","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        12DIMM 16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"Check
+        Log","state":"Off","color":"Yellow","location":"FrontPanel"},{"name":"CPU
+        3 DIMM 24","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 14Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 20","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"OVER
+        SPEC","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        3 DIMM 11","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"DASD","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        1 DIMM 16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        4 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"ML2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 12","state":"Off","color":"Yellow","location":"FRU"},{"name":"BMC Heartbeat","state":"Blinking","color":"Green","location":"Planar"},{"name":"PCI
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"SysBrd","state":"Off","color":"Yellow","location":"Planar"},{"name":"FAN
+        2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        11","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        24","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book 4 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        2 DIMM 12","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 13","state":"Off","color":"Yellow","location":"FRU"},{"name":"TEMP","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        5","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        20","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        2 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"Book
+        1 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 12Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"Fault","state":"Off","color":"Yellow","location":"FrontRearPanel"},{"name":"CPU
+        2 DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4
+        DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI
+        8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 20","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book 2 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        3 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        4 DIMM 11","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 13Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"Power","state":"On","color":"Green","location":"FrontRearPanel"},{"name":"CPU
+        4 DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 14","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        12","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        1 DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"MEM","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"NMI","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CNFG","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"PCI
+        9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        3 Board4","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 19","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 15","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        10PEC","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        11Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        24","state":"Off","color":"Yellow","location":"FRU"},{"name":"LINK","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        2 DIMM 6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        20","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        4 DIMM 18","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 8","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM
+        10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2 DIMM 15","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 5","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"Identify","state":"Off","color":"Blue","location":"FrontRearPanel"},{"name":"CPU
+        1 DIMM 3","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1
+        DIMM 21","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM 9","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 22","state":"Off","color":"Yellow","location":"FRU"},{"name":"Book
+        1 Attention","state":"Off","color":"Amber","location":"FRU"},{"name":"CPU
+        4 DIMM 10","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 2
+        DIMM 7","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM
+        15Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 11DIMM
+        16Ctlr","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3 DIMM 17","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        2 DIMM 16","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU","state":"Off","color":"Yellow","location":"LightPathCard"},{"name":"CPU
+        4 DIMM 24","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 3
+        DIMM 4","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 4 DIMM
+        2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 2","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU
+        3 DIMM 23","state":"Off","color":"Yellow","location":"FRU"},{"name":"PCI 1","state":"Off","color":"Yellow","location":"FRU"},{"name":"FAN
+        6","state":"Off","color":"Yellow","location":"FRU"},{"name":"CPU 1 DIMM 9","state":"Off","color":"Yellow","location":"FRU"}],"expansionCards":[],"firmware":[{"name":"UEFI
+        Backup Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI-Backup","build":"A9E143HUS","version":"4.30","role":"Backup","status":"Inactive"},{"name":"IMM2
+        Backup Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2-Backup","build":"TCOO39A","version":"4.70","role":"Backup","status":"Inactive"},{"name":"DSA
+        Diagnostic Software","date":"2017-10-11T00:00:00Z","type":"DSA","build":"DSALB1A","version":"10.2","role":"Primary","status":"Active"},{"name":"UEFI
+        Firmware/BIOS","date":"2018-01-26T00:00:00Z","type":"UEFI","build":"A9E143HUS","version":"4.30","role":"Primary","status":"Active"},{"name":"IMM2
+        Firmware","date":"2018-01-19T00:00:00Z","type":"IMM2","build":"TCOO39A","version":"4.70","role":"Primary","status":"Active"}],"powerSupplies":[{"model":"","manufacturerId":"","serialNumber":"K115136V11L","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 2","leds":[],"description":"","name":"Power Supply 2","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[3],"manufacturer":"DELT","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""},{"model":"","manufacturerId":"","serialNumber":"K115136V11E","inputVoltageIsAC":true,"inputVoltageMin":-1,"type":"PowerSupply","dataHandle":0,"cmmDisplayName":"Power
+        Supply 1","leds":[],"description":"","name":"Power Supply 1","cmmHealthState":"Unknown","userDescription":"","manufactureDate":"","partNumber":"94Y8066","firmware":[],"healthState":"GOOD","machineType":"","hardwareRevision":"","parent":{"uuid":"","uri":"chassis/"},"uri":"powerSupply/","productId":"","powerAllocation":{"totalInputPower":0,"totalOutputPower":900},"powerState":"Unknown","posID":"","slots":[2],"manufacturer":"DELT","uuid":"","productName":"","fruSerialNumber":"","inputVoltageMax":-1,"FRU":"","vpdID":""}],"ipv4Addresses":["10.243.6.17","169.254.95.118"],"ipv6Addresses":["fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","fe80:0:0:0:6eae:8bff:fe4b:4f15"],"raidSettings":[{"firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Firmware","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"description":"ServeRAID
+        M5210","name":"ServeRAID M5210","uuid":"0000000000000000500605B006E6ED5B","diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631","largestAvailableSize":512,"capacity":300000000000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"B56T","softwareID":"ST300MM0006"}],"FRU":"42D0628"}],"storagePools":[{"name":"Pool_0","arrayUid":"0","description":"0000000000000000500605B006E6ED5B_Storage
+        Pool_M5210_0000000000000000500605B006E6ED5B_c:Pool:0","arrayStatus":"Offline","totalManagedSpace":298999349248,"remainingSpace":0,"raidLevel":0,"storageVolumes":[{"name":"GenericR0_0","bootable":true,"description":"Volume
+        0 0000000000000000500605B006E6ED5B_0","blockSize":512,"numberOfBlocks":583983104,"primaryPartition":0,"stripeSize":65536,"volumeStatus":"Dynamic
+        Reconfig","volumeID":"6","volumeUID":"0","driveIndex":0,"removable":false,"health":"Unknown","LUN":-1}],"diskDrives":[{"model":"ST300MM0006","healthState":"Normal","numberOfBlocks":585937500,"interfaceType":"SAS","serialNumber":"S0K09V6W","blockSize":512,"mediaType":"Rotational","diskState":"Online","bay":0,"description":"ST300MM0006","manufacturer":"IBM-ESXS","name":"Disk
+        0_0","uuid":"","partNumber":"42D0631","largestAvailableSize":512,"capacity":300000000000,"m2Location":"","firmware":[{"revision":"0","classifications":[10],"status":"Active","name":"Drive","role":"Primary","type":"Firmware","build":"0","date":"","version":"B56T","softwareID":"ST300MM0006"}],"FRU":"42D0628"}]}],"batteryData":[]}],"drives":[],"memoryModules":[{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65F9","displayName":"CPU 1 DIMM
+        9","slot":9,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FA","displayName":"CPU 1 DIMM
+        15","slot":15,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF65FE","displayName":"CPU 2 DIMM
+        9","slot":9,"type":"DDR3","partNumber":"Unknown","speedMBs":12800},{"model":"DDR3","speed":1600,"manufacturer":"Micron
+        Technology","capacity":4,"serialNumber":"3AAF6603","displayName":"CPU 2 DIMM
+        15","slot":15,"type":"DDR3","partNumber":"Unknown","speedMBs":12800}],"processors":[{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":1,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15,"socket":"Socket 1"},{"speed":2.2,"manufacturer":"Intel(R)
+        Corporation","family":"PENTIUM_R_4","displayName":"Intel(R) Xeon(R) CPU E7-8880L
+        v2 @ 2.20GHz","slot":2,"productVersion":"Intel(R) Xeon(R) CPU E7-8880L v2
+        @ 2.20GHz","cores":15,"socket":"Socket 2"}],"pciDevices":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"7","pciDeviceNumber":"0","slotNumber":"12","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B006E6ED5B","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"0:0"}],"pciRevision":"0","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"0","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"0","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"}],"accessState":"Offline","manufacturerId":" IBM(CLCN)","addinCardSlots":0,"driveBays":17,"errorFields":[{"FirmwareData":"NO_CONNECTOR"},{"ChassisMounted":"NO_CONNECTOR"}],"bladeState":255,"activationKeys":[],"uri":"nodes/7936DD182C5311E3A8D6000AF7256738","vnicMode":"disabled","powerAllocation":{"maximumAllocatedPower":1710,"minimumAllocatedPower":26},"expansionProductType":"","bootOrder":{"uri":"nodes/7936DD182C5311E3A8D6000AF7256738/bootOrder","bootOrderList":[{"currentBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0"],"bootType":"WakeOnLAN","possibleBootOrderDevices":["PXE
+        Network","CD/DVD Rom","Hard Disk 0","CentOS Linux","Windows Boot Manager","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom"],"bootType":"Permanent","possibleBootOrderDevices":["Hard
+        Disk 0","CentOS Linux","Windows Boot Manager","PXE Network","CD/DVD Rom","Floppy
+        Disk","Hard Disk 1","Hard Disk 2","Hard Disk 3","Hard Disk 4","USB Storage","Diagnostics","iSCSI","iSCSI
+        Critical","Embedded Hypervisor","Legacy Only","USB0","USB1","USB2","USB3","USB4","USB5","USB6","USB7","DSA","Slot16","Slot17","Slot18","Slot19","Slot12","Slot11","Slot10","Slot1","Slot2","Slot3","Slot4","Slot5","Slot6","Slot7","Slot8","Slot9","IMM1","IMM2"]},{"currentBootOrderDevices":["None"],"bootType":"SingleUse","possibleBootOrderDevices":["None","PXE
+        Network","Hard Disk 0","Diagnostics","CD/DVD Rom","Boot To F1","Hypervisor","Floppy
+        Disk"]}]},"expansionProducts":[],"slots":[1],"vpdID":"","encapsulation":{"encapsulationMode":"normal"},"secureBootMode":{"possibleValues":["Enabled","Disabled"],"currentValue":"Disabled"},"expansionCardSlots":0,"contact":"","dataHandle":1520459083510,"cmmDisplayName":"Management
+        Controller UUID-7936DD182C5311E3A8D6000AF7256738","backedBy":"real","complexID":1,"memorySlots":4,"cmmHealthState":"Normal","subSlots":[],"excludedHealthState":"Normal","processorSlots":2,"pciCapabilities":["Raid
+        Link","OOB PCIe","Raid Link Config","Raid Link Alert","OOB PCIe Config"],"productId":"4D4F00","hasOS":false,"ports":[{"ioModuleBay":0,"portNumber":49},{"ioModuleBay":0,"portNumber":50}],"embeddedHypervisorPresence":false,"posID":"","subType":"","partitionID":-1,"flashStorage":[],"userDefinedName":"","securityDescriptor":{"managedAuthSupported":true,"publicAccess":false,"uri":"nodes/7936dd182c5311e3a8d6000af7256738","roleGroups":[],"managedAuthEnabled":true,"storedCredentials":{"description":"Credentials
+        for null","id":"353","userName":"USERID"}},"logicalID":0,"primary":false,"powerCappingPolicy":{"cappingACorDCMode":"DC","minimumHardCapLevel":434100,"cappingPolicy":"OFF","maxPowerCap":533000,"minimumPowerCappingHotPlugLevel":754000,"powerCappingAllocUnit":"watts*10^-3","maximumPowerCappingHotPlugLevel":854000,"currentPowerCap":0,"minPowerCap":-1},"fans":[{"name":"Fan
+        1","healthState":"Normal","status":"OK","description":"Logical Device for
+        fan / cooling device 1","speed":3440,"slots":1},{"name":"Fan 4","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 4","speed":3440,"slots":4},{"name":"Fan 2","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 2","speed":3440,"slots":2},{"name":"Fan 9","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 9","speed":3440,"slots":9},{"name":"Fan 7","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 7","speed":3440,"slots":7},{"name":"Fan 6","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 6","speed":3440,"slots":6},{"name":"Fan 10","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 10","speed":3440,"slots":10},{"name":"Fan
+        8","healthState":"Warning","status":"Degraded","description":"Logical Device
+        for fan / cooling device 8","speed":3440,"slots":8},{"name":"Fan 3","healthState":"Normal","status":"OK","description":"Logical
+        Device for fan / cooling device 3","speed":3440,"slots":3},{"name":"Fan 5","healthState":"Warning","status":"Degraded","description":"Logical
+        Device for fan / cooling device 5","speed":3440,"slots":5}],"addinCards":[{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"1","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":50,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256739","vnicMode":false}],"peerBay":0,"physicalPortIndex":2}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"},{"firmware":[{"revision":"0","classifications":[13],"status":"Active","name":"MegaRAID
+        Controller Firmware","role":"Primary","type":"Software Bundle","build":"0","date":"2017-09-07T00:00:00Z","version":"24.21.0-0020","softwareID":"10140454"}],"slotSupportsHotPlug":"false","pciRevision":"2","pciBusNumber":"7","pciDeviceNumber":"0","slotNumber":"12","pciFunctionNumber":"0","manufacturer":"IBM","name":"ServeRAID
+        M5210","portInfo":{},"uuid":"0000000000000000500605B006E6ED5B","productName":"ServeRAID
+        M5210","partNumber":"N/A","fruSerialNumber":"SV334P0606","slotName":"SlotDesig7_Slot
+        12 (Pri Storage)","pciSubID":"454","fodUniqueID":"N/A","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"N/A","posID":"5d","vpdID":"1000","class":"Mass
+        storage controller"},{"firmware":[{"revision":"0","classifications":[33024],"status":"Active","name":"17.4.4.8-c","role":"Primary","type":"VPD-V0","build":"0","date":"","version":"17.4.4.8-c","softwareID":"10140450"}],"slotSupportsHotPlug":"false","pciRevision":"0","pciBusNumber":"145","pciDeviceNumber":"0","slotNumber":"7","pciFunctionNumber":"0","manufacturer":"IBM","name":"Broadcom
+        2-port 1GbE NIC Card for IBM","portInfo":{"physicalPorts":[{"portType":"ETHERNET","portNumber":49,"logicalPorts":[{"portType":"ETHERNET","portNumber":1,"logicalPortIndex":1,"addresses":"000AF7256738","vnicMode":false}],"peerBay":0,"physicalPortIndex":1}]},"uuid":"00000000000000000000000AF7256738","productName":"Broadcom
+        2-port 1GbE NIC Card for IBM","partNumber":"90Y9372","fruSerialNumber":"Y0502037P0ES","slotName":"SlotDesig6_Slot
+        7","pciSubID":"450","fodUniqueID":"11S90Y9372Y0502037P0ES","isAgentless":true,"pciSubVendorID":"1014","isAddOnCard":true,"FRU":"90Y9373","posID":"165f","vpdID":"14e4","class":"Network
+        controller"}],"physicalID":0,"faceplateIDs":[{"name":"drive backplane 1","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0},{"name":"I/O
+        module 5","vpdID":0,"posID":0,"productId":0,"entityId":0,"deviceId":0}],"lanOverUsbPortForwardingModes":[{"state":"disabled","type":"DSA","externalIPAddress":""},{"state":"disabled","type":"OSDeploy","externalIPAddress":""}],"m2Presence":false,"onboardPciDevices":[{"firmware":[{"revision":"0","classifications":[0],"status":"Active","name":"PCIFirmware","role":"Primary","type":"","build":"0","date":"","version":"","softwareID":"0:0"}],"pciRevision":"0","pciBusNumber":"27","pciDeviceNumber":"0","pciFunctionNumber":"0","name":"","portInfo":{},"pciSubID":"0","fodUniqueID":"","isAgentless":false,"pciSubVendorID":"0","isAddOnCard":false,"posID":"534","vpdID":"102b","class":"Display
+        controller"}],"ipInterfaces":[{"name":"eth0","label":"unknown","IPv4enabled":true,"IPv4DHCPmode":"STATIC_ONLY","IPv6enabled":true,"IPv6DHCPenabled":true,"IPv4assignments":[{"id":0,"subnet":"255.255.240.0","gateway":"0.0.0.0","address":"10.243.6.17","type":"INUSE"}],"IPv6assignments":[{"id":0,"scope":"Global","gateway":"0:0:0:0:0:0:0:0","source":"Stateless","address":"fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"},{"id":0,"scope":"LinkLocal","gateway":"0:0:0:0:0:0:0:0","source":"Other","address":"fe80:0:0:0:6eae:8bff:fe4b:4f15","prefix":64,"type":"INUSE"}],"IPv6statelessEnabled":true,"IPv6staticEnabled":false}],"parentComplexID":"7936DD182C5311E3A8D6000AF7256738","isConnectionTrusted":"true","isScalable":true,"isITME":false}}],"switchList":[{"itemName":"ThinkAgile-VX-NE1032-SW02","itemUUID":"00000000000010008000A48CDB984C00","itemLocationRoom":"","itemLocationRack":"","itemLocation":"","itemLowerUnit":0,"itemType":"SWITCH","itemHeight":1,"itemSubType":"","itemInventory":{"name":"ThinkAgile-VX-NE1032-SW02","uuid":"00000000000010008000A48CDB984C00","accessState":"Online","overallHealthState":"Non-Critical","type":"Rackswitch","hostname":"ThinkAgile-VX-NE1032-SW02","description":"32*10
+        GbE SFP+","dnsHostnames":[],"domainName":"","FRU":"","fruSerialNumber":"","ipv4Addresses":["10.243.4.78"],"ipv6Addresses":[],"macAddresses":["A4:8C:DB:98:4C:00"],"machineType":"7159","manufacturer":"LNVO","manufacturerId":"","model":"HD1","partNumber":"00YL949     ","posID":"","powerState":"On","productId":"","productName":"Lenovo
+        ThinkSystem NE1032 RackSwitch","protectedMode":"Unknown","serialNumber":"Y056DH79E047","stackMode":"none","vpdID":"","backedBy":"real","cmmDisplayName":"ThinkAgile-VX-NE1032-SW02","cmmHealthState":"Non-Critical","dataHandle":1520541131020,"elapsedTimeMillisecs":"297198","errorFields":[],"firmware":[{"name":"Uboot","date":"","type":"Boot
+        ROM","build":"","version":"10.4.2.0","role":"","status":"N/A"},{"name":"Active
+        Image","date":"","type":"Main Image","build":"","version":"10.4.2.0","role":"","status":"Active"},{"name":"Standby
+        Image","date":"","type":"Main Image","build":"","version":"10.4.2.0","role":"","status":"Non-Active"}],"ipInterfaces":[{"name":"unknown","label":"unknown","IPv4enabled":false,"IPv4DHCPmode":"UNKNOWN","IPv6enabled":false,"IPv6DHCPenabled":false,"IPv4assignments":[{"id":0,"subnet":"127.0.0.1","gateway":"0.0.0.0","address":"10.243.4.78","type":"UNKNOWN"}],"IPv6assignments":[],"IPv6statelessEnabled":false,"IPv6staticEnabled":false}],"leds":[],"ntpPushEnabled":false,"ntpPushFrequency":0,"parent":{},"portDataSetTimestamp":"03:32:08","uri":"switches/00000000000010008000A48CDB984C00","userDescription":"","userDefinedName":"ThinkAgile-VX-NE1032-SW02","securityDescriptor":{"managedAuthSupported":false,"publicAccess":false,"uri":"switches/00000000000010008000a48cdb984c00","roleGroups":[],"managedAuthEnabled":false},"applyPending":"No","contact":"","cpuUtilization":"N/A","entitleSerialNumber":"MM41941","fans":[{"fanName":"Fan
+        1","fanSpeed":"1782 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        2","fanSpeed":"1914 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        3","fanSpeed":"1782 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        4","fanSpeed":"1914 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        5","fanSpeed":"1848 RPM (23 PWM)","fanState":"Back-to-Front"},{"fanName":"Fan
+        6","fanSpeed":"1914 RPM (23 PWM)","fanState":"Back-to-Front"}],"height":1,"location":{"lowestRackUnit":0,"location":"","rack":"","room":""},"manufacturingDate":"3817
+        (WWYY)","memoryUtilization":"","mgmtProcIPaddress":"10.243.4.78","panicDump":"Yes","ports":[{"configuredStatus":"up","interfaceIndex":"410001","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e6:47:50","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/1","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410002","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/2","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410003","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e6:47:18","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/3","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410004","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/4","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410005","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e3:23:f0","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/5","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410006","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/6","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410007","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e3:2d:c9","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/7","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410008","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/8","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410009","operationalStatus":"up","peerMacAddress":"7c:d3:0a:e2:ff:20","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/9","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410010","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/10","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410011","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/11","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410012","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/12","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410013","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/13","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410014","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/14","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410015","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/15","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410016","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/16","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410017","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/17","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410018","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/18","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410019","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/19","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410020","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/20","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410021","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/21","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410022","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/22","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410023","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/23","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410024","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/24","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410025","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/25","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410026","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/26","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410027","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/27","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410028","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/28","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410029","operationalStatus":"down","peerMacAddress":"","portName":"","portSpeed":"10000","portState":"down","tagPVID":"","vLAN":"trunk","port":"Ethernet1/29","PVID":"\"Lenovo-Network-VLAN546\""},{"configuredStatus":"up","interfaceIndex":"410030","operationalStatus":"up","peerMacAddress":"a4:8c:db:b3:40:00","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/30","PVID":"\"ESXi-Mgmt-Network-VLAN20\""},{"configuredStatus":"up","interfaceIndex":"410031","operationalStatus":"up","peerMacAddress":"a4:8c:db:98:4b:20","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/31","PVID":"\"ISL-Network-VLAN2001\""},{"configuredStatus":"up","interfaceIndex":"410032","operationalStatus":"up","peerMacAddress":"a4:8c:db:98:4b:21","portName":"","portSpeed":"10000","portState":"up","tagPVID":"","vLAN":"trunk","port":"Ethernet1/32","PVID":"\"ISL-Network-VLAN2001\""}],"powerSupply":"Power
+        Supply 1: on;Power Supply 2: on.","resetReason":"1","savePending":"No","stackRole":"none","sysObjectID":"1.3.6.1.4.1.19046.1.7.32","temperatureSensors":[{"sensorName":"
+        MAC Temp","sensorState":" 34 C"},{"sensorName":" HotSpot1 Temp","sensorState":"
+        33 C"},{"sensorName":"Inlet Temp","sensorState":" 27 C"},{"sensorName":" Exhaust
+        Temp","sensorState":" 30 C"},{"sensorName":" HotSpot2 Temp","sensorState":"
+        30 C"}],"upTime":"1 day, 15:48:54","isConnectionTrusted":"true","OS":"CNOS"}}],"storageList":[],"placeholderList":[],"UUID":"STANDALONE_OBJECT_UUID"}]}'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:03 GMT
+- request:
+    method: get
+    uri: https://10.243.6.103/patterns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.5.9 (ManageIQ/master)
+      Authorization:
+      - Basic bHhjYzpQYXNzdzByZA==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 08 Mar 2018 20:40:03 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=15550200; includeSubDomains;
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - default-src 'self' ; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src
+        'self' 'unsafe-inline'; worker-src 'self' blob:; child-src 'self' blob:; img-src
+        'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.0.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Content-Length:
+      - '610'
+    body:
+      encoding: UTF-8
+      string: '{"identifier":"id","label":"name","items":[{"formFactor":"r","userDefined":true,"serverType":"IMMv2","name":"cmm_ys21_pattern","inUse":false,"description":"Pattern
+        created from server: cmm-ys21\nLearned on: Feb 22, 2018 10:42:39 AM","id":"53","referencedBy":[],"type":"Server","nodeType":"sysx","uri":"/config/template/53"},{"formFactor":"r","userDefined":true,"serverType":"IMMv2","name":"new_cmm_ys21_pattern","inUse":true,"description":"Pattern
+        created from server: cmm-ys21\nLearned on: Feb 22, 2018 11:07:21 AM","id":"62","referencedBy":[],"type":"Server","nodeType":"sysx","uri":"/config/template/62"}]}
+
+'
+    http_version: 
+  recorded_at: Thu, 08 Mar 2018 20:40:03 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
This PR adds a test case for testing a full refresh. In particular, it attempts to recreate the _guest_devices_ table problem described in Bug 1542710.