### PR TITLE
Fixing bug in the calculate of physical server total memory

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/parser.rb
@@ -125,7 +125,8 @@ module ManageIQ::Providers::Lenovo
     end
 
     def get_memory_info(node)
-      node.memoryModules&.reduce(0) { |total, mem| total + mem['capacity'] }
+      total_memory_gigabytes = node.memoryModules&.reduce(0) { |total, mem| total + mem['capacity'] }
+      total_memory_gigabytes * 1024 # convert to megabytes
     end
 
     def get_total_cores(node)

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -66,6 +66,12 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(child_device[:device_name]).to eq("Physical Port 1")
     end
 
+    it 'will retrieve the amout of memory in MB' do
+      physical_server = @result[:physical_servers][0]
+      memory_amount = physical_server[:computer_system][:hardware][:memory_mb]
+      expect(memory_amount).to eq(16_384)
+    end
+
     it 'will retrieve disk capacity from a physical server' do
       physical_server_with_disk = @result[:physical_servers][0]
 


### PR DESCRIPTION
Bug Fix
======
Once the LXCA treat the memory amount in GB and the MiQ treat as MB, it needs to be converted on parse.

**Actual result**
On LXCA:
![error_in_lxca](https://user-images.githubusercontent.com/8550928/37462646-75621412-2831-11e8-910d-4627cd027cb5.png)
On MiQ:
![error_in_miq](https://user-images.githubusercontent.com/8550928/37462670-89c67b14-2831-11e8-98fa-84a0b38389ff.png)

**After this PR fix:**
On MiQ:
![error_fix_miq](https://user-images.githubusercontent.com/8550928/37462762-ce6446b6-2831-11e8-886f-06127d1dd8ba.png)
