### PR TITLE
Leaving the disk capacity blank if the LXCA doesn't provide this information

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/physical_server_parser.rb
@@ -57,7 +57,7 @@ module ManageIQ::Providers::Lenovo
               total_disk_cap += disk['capacity'] unless disk['capacity'].nil?
             end
           end
-          total_disk_cap
+          total_disk_cap.positive? ? total_disk_cap : nil
         end
 
         def get_memory_info(node)

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -86,7 +86,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       computer_system = physical_server[:computer_system]
       hardware = computer_system[:hardware]
 
-      expect(hardware[:disk_capacity]).to eq(0)
+      expect(hardware[:disk_capacity]).to be_nil
     end
   end
 


### PR DESCRIPTION
**Actual Result:**
When the LXCA doesn't provide this information, the disk capacity is set to 0, what could provide a wrong impression to use.
![disk-capacity](https://user-images.githubusercontent.com/8550928/37520916-9779a318-28fd-11e8-8654-106ce6ee7255.png)
**Expected Result:**
Leave this field blank to represent the lack of information.
![image](https://user-images.githubusercontent.com/8550928/37521028-f5dc554a-28fd-11e8-86b4-339181dd91ae.png)
