### PR TITLE
Parsing pci_device and vlan info to ports

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/network_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/network_device_parser.rb
@@ -110,7 +110,9 @@ module ManageIQ::Providers::Lenovo
 
       def parse_logical_port(port)
         {
-          :address => format_mac_address(port["addresses"])
+          :address      => format_mac_address(port["addresses"]),
+          :vlan_enabled => port["vnicMode"],
+          :vlan_key     => port["logicalPortIndex"],
         }
       end
 


### PR DESCRIPTION
This adds some vlan info to ports (guest_devices) and parse pciDevices of a Node

Did some refactor on AddinCards to use the same method to parse PciDevices as well, because they have the same fields.

Basically I am parsing the new info added to the schema on ManageIQ/manageiq-schema#165
:vlan_enabled            => port["vnicMode"], 
:vlan_key                => port["logicalPortIndex"],

Depends on: ManageIQ/manageiq-schema#165