### PR TITLE
Refactoring parse addin cards structure

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/network_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/network_device_parser.rb
@@ -1,0 +1,149 @@
+require_relative 'component_parser'
+
+module ManageIQ::Providers::Lenovo
+  module Parsers
+    class NetworkDeviceParser < ComponentParser
+      class << self
+        #
+        # @param component - component that has network devices to be parseds
+        #
+        def parse_network_devices(component)
+          all_devices = select_network_devices(component)
+
+          distinct_devices = distinct_network_devices(all_devices)
+
+          distinct_devices.map do |device|
+            parsed_device = parse_device(device)
+            parsed_device[:child_devices] = parse_child_devices(device, all_devices)
+            parsed_device
+          end
+        end
+
+        private
+
+        #
+        # Selects all network devices.
+        #   The network devices could be in `pciDevices` or `addinCards` prop
+        #
+        # @return a list with all network devices of the component
+        #   (it could have duplicated entries if the entry is in both properties)
+        #
+        def select_network_devices(component)
+          pci_devices = component.try(:pciDevices).try(:select) { |device| network_device?(device) }
+          addin_cards = component.try(:addinCards).try(:select) { |device| network_device?(device) }
+
+          devices = []
+          devices.concat(pci_devices) if pci_devices.present?
+          devices.concat(addin_cards) if addin_cards.present?
+          devices
+        end
+
+        #
+        # Distincts the network devices by pciSubID property (remove duplicated entries)
+        #
+        def distinct_network_devices(devices)
+          devices.uniq { |device| mount_uuid(device) }
+        end
+
+        #
+        # Verifies if a device is a network device by it name or it class
+        #
+        def network_device?(device)
+          device_name = (device["productName"] ? device["productName"] : device["name"]).try(:downcase)
+          device["class"] == "Network controller" || device_name =~ /nic/ || device_name =~ /ethernet/
+        end
+
+        def parse_device(device)
+          {
+            :uid_ems                => mount_uuid(device),
+            :device_name            => device["productName"] ? device["productName"] : device["name"],
+            :device_type            => "ethernet",
+            :firmwares              => parse_device_firmware(device),
+            :manufacturer           => device["manufacturer"],
+            :field_replaceable_unit => device["FRU"],
+            :location               => device['slotNumber'] ? "Bay #{device['slotNumber']}" : nil,
+          }
+        end
+
+        def parse_device_firmware(device)
+          device_fw = []
+
+          firmware = device["firmware"]
+          unless firmware.nil?
+            device_fw = firmware.map do |fw|
+              parse_firmware(fw)
+            end
+          end
+
+          device_fw
+        end
+
+        def parse_child_devices(device, all_devices)
+          ports = all_devices.select { |device_with_port| device["pciSubID"] == device_with_port["pciSubID"] }
+
+          parsed_ports = []
+
+          ports.each do |port|
+            device_parced_ports = parse_ports(port)
+            parsed_ports.concat(device_parced_ports) if device_parced_ports.present?
+          end
+
+          parsed_ports.uniq { |port| port[:device_name] }
+        end
+
+        def parse_ports(port)
+          port_info = port["portInfo"]
+          physical_ports = port_info["physicalPorts"]
+          physical_ports&.map do |physical_port|
+            parsed_physical_port = parse_physical_port(physical_port)
+            logical_ports = physical_port["logicalPorts"]
+            parsed_logical_port = parse_logical_port(logical_ports[0])
+            parsed_logical_port[:uid_ems] = mount_uuid(port, true, physical_port['physicalPortIndex'])
+            parsed_logical_port.merge!(parsed_physical_port)
+            parsed_logical_port
+          end
+        end
+
+        def parse_physical_port(port)
+          {
+            :device_type => "physical_port",
+            :device_name => "Physical Port #{port['physicalPortIndex']}"
+          }
+        end
+
+        def parse_logical_port(port)
+          {
+            :address => format_mac_address(port["addresses"])
+          }
+        end
+
+        def format_mac_address(mac_address)
+          mac_address.scan(/\w{2}/).join(":")
+        end
+
+        def parse_firmware(firmware)
+          {
+            :name         => "#{firmware["role"]} #{firmware["name"]}-#{firmware["status"]}",
+            :build        => firmware["build"],
+            :version      => firmware["version"],
+            :release_date => firmware["date"],
+          }
+        end
+
+        #
+        # Mounts the uuid for the devices
+        #   For those devices that hasn't an uuid this method uses others properties to mount one
+        #
+        # @param device       - device that needs an uuid
+        # @param child_device - if the device is a child device, it uuid will be the same
+        # @param port_number  - number of the port of the child device that will be concat to the uuid
+        #
+        def mount_uuid(device, child_device = false, port_number = nil)
+          uuid = device["uuid"] || "#{device['pciBusNumber']}#{device['pciDeviceNumber']}"
+          return uuid + port_number.to_s if child_device
+          uuid
+        end
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/physical_server_parser.rb
@@ -1,4 +1,5 @@
 require_relative 'component_parser'
+require_relative 'network_device_parser'
 
 module ManageIQ::Providers::Lenovo
   module Parsers
@@ -74,7 +75,7 @@ module ManageIQ::Providers::Lenovo
         end
 
         def get_guest_devices(node)
-          guest_devices = get_addin_cards(node)
+          guest_devices = NetworkDeviceParser.parse_network_devices(node)
           guest_devices << parse_management_device(node)
         end
 
@@ -87,85 +88,6 @@ module ManageIQ::Providers::Lenovo
           }
         end
 
-        def get_addin_cards(node)
-          parsed_addin_cards = []
-
-          cards_to_parse = select_cards_to_parse(node)
-
-          # For each of the node's addin cards, parse the addin card and then see
-          # if it is already in the list of parsed addin cards. If it is, see if
-          # all of its ports are already in the existing parsed addin card entry.
-          # If it's not, then add the port to the existing addin card entry and
-          # don't add the card again to the list of parsed addin cards.
-          # This is needed because xclarity_client seems to represent each port
-          # as a separate addin card. The code below ensures that each addin
-          # card is represented by a single addin card with multiple ports.
-          cards_to_parse.each do |node_addin_card|
-            next unless get_device_type(node_addin_card) == "ethernet"
-
-            add_card = true
-            parsed_node_addin_card = parse_addin_cards(node_addin_card)
-
-            parsed_addin_cards.each do |addin_card|
-              next unless parsed_node_addin_card[:device_name] == addin_card[:device_name] ||
-                          parsed_node_addin_card[:location] == addin_card[:location]
-
-              parsed_node_addin_card[:child_devices].each do |parsed_port|
-                card_found = false
-                add_card = false
-                addin_card[:child_devices].each do |port|
-                  if parsed_port[:device_name] == port[:device_name]
-                    card_found = true
-                  end
-                end
-                unless card_found
-                  addin_card[:child_devices].push(parsed_port)
-                end
-              end
-            end
-
-            if add_card
-              parsed_addin_cards.push(parsed_node_addin_card)
-            end
-          end
-
-          parsed_addin_cards
-        end
-
-        def select_cards_to_parse(component)
-          pci_devices = component.try(:pciDevices)
-          addin_cards = component.try(:addinCards)
-
-          devices = []
-          devices.concat(pci_devices) if pci_devices.present?
-          devices.concat(addin_cards) if addin_cards.present?
-          devices
-        end
-
-        def get_device_type(card)
-          device_type = ""
-
-          unless card["name"].nil?
-            card_name = card["name"].downcase
-            if card["class"] == "Network controller" || card_name.include?("nic") || card_name.include?("ethernet")
-              device_type = "ethernet"
-            end
-          end
-          device_type
-        end
-
-        def parse_addin_cards(addin_card)
-          {
-            :device_name            => addin_card["productName"],
-            :device_type            => get_device_type(addin_card),
-            :firmwares              => get_guest_device_firmware(addin_card),
-            :manufacturer           => addin_card["manufacturer"],
-            :field_replaceable_unit => addin_card["FRU"],
-            :location               => "Bay #{addin_card['slotNumber']}",
-            :child_devices          => get_guest_device_ports(addin_card)
-          }
-        end
-
         def parse_management_device(node)
           {
             :device_type => "management",
@@ -174,60 +96,11 @@ module ManageIQ::Providers::Lenovo
           }
         end
 
-        def get_guest_device_firmware(card)
-          device_fw = []
-
-          unless card.nil?
-            firmware = card["firmware"]
-            unless firmware.nil?
-              device_fw = firmware.map do |fw|
-                parse_firmware(fw)
-              end
-            end
-          end
-
-          device_fw
-        end
-
-        def get_guest_device_ports(card)
-          device_ports = []
-
-          unless card.nil?
-            port_info = card["portInfo"]
-            physical_ports = port_info["physicalPorts"]
-            physical_ports&.each do |physical_port|
-              parsed_physical_port = parse_physical_port(physical_port)
-              logical_ports = physical_port["logicalPorts"]
-              parsed_logical_port = parse_logical_port(logical_ports[0])
-              device_ports.push(parsed_logical_port.merge(parsed_physical_port))
-            end
-          end
-
-          device_ports
-        end
-
-        def parse_physical_port(port)
-          {
-            :device_type => "physical_port",
-            :device_name => "Physical Port #{port['physicalPortIndex']}"
-          }
-        end
-
         def parse_management_network(node)
           {
             :ipaddress   => node.mgmtProcIPaddress,
             :ipv6address => node.ipv6Addresses.nil? ? node.ipv6Addresses : node.ipv6Addresses.join(", ")
           }
-        end
-
-        def parse_logical_port(port)
-          {
-            :address => format_mac_address(port["addresses"])
-          }
-        end
-
-        def format_mac_address(mac_address)
-          mac_address.scan(/\w{2}/).join(":")
         end
       end
     end


### PR DESCRIPTION
__This PR is able to:__
- Move the addin cards parse code to another class (`NetworkDeviceParser`)
- Fix the bug https://bugzilla.redhat.com/show_bug.cgi?id=1563796 parsing the uuid for the network devices and its ports.

__Depends on:__
~https://github.com/ManageIQ/manageiq-providers-lenovo/pull/145~ - Merged