### PR TITLE
Parse Physical Chassis

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser.rb
@@ -34,8 +34,12 @@ module ManageIQ::Providers::Lenovo
       PhysicalSwitchParser.parse_physical_switch(switch)
     end
 
-    def parse_physical_server(node, compliance, rack = nil)
-      PhysicalServerParser.parse_physical_server(node, compliance, rack)
+    def parse_physical_chassis(node, rack = nil)
+      PhysicalChassisParser.parse_physical_chassis(node, rack)
+    end
+
+    def parse_physical_server(node, compliance, rack = nil, chassis = nil)
+      PhysicalServerParser.parse_physical_server(node, compliance, rack, chassis)
     end
 
     def parse_config_pattern(config_pattern)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/parser_dictionary_constants.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/parser_dictionary_constants.rb
@@ -23,9 +23,10 @@ module ManageIQ::Providers::Lenovo
     }.freeze
 
     MIQ_TYPES = {
-      "physical_server" => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer",
-      "physical_switch" => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch",
-      "template"        => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::Template",
+      "physical_server"  => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer",
+      "physical_switch"  => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch",
+      "physical_chassis" => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis",
+      "template"         => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::Template",
     }.freeze
 
     PROPERTIES_MAP = {
@@ -61,6 +62,40 @@ module ManageIQ::Providers::Lenovo
     PHYSICAL_SWITCH_PORT = {
       :peer_mac_address => 'peerMacAddress',
       :vlan_key         => 'PVID',
+    }.freeze
+
+    PHYSICAL_CHASSIS = {
+      :name                         => 'name',
+      :uid_ems                      => 'uuid',
+      :ems_ref                      => 'uuid',
+      :overall_health_state         => 'overallHealthState',
+      :management_module_slot_count => 'mmSlots',
+      :switch_slot_count            => 'switchSlots',
+      :fan_slot_count               => 'fanSlots',
+      :blade_slot_count             => 'bladeSlots',
+      :powersupply_slot_count       => 'powerSupplySlots',
+      :asset_detail                 => {
+        :product_name     => 'productName',
+        :manufacturer     => 'manufacturer',
+        :machine_type     => 'machineType',
+        :model            => 'model',
+        :serial_number    => 'serialNumber',
+        :contact          => 'contact',
+        :description      => 'description',
+        :location         => 'location.location',
+        :room             => 'location.room',
+        :rack_name        => 'location.rack',
+        :lowest_rack_unit => 'location.lowestRackUnit',
+      },
+      :computer_system              => {
+        :hardware => {
+          :guest_devices => '',
+        },
+      },
+    }.freeze
+
+    PHYSICAL_CHASSIS_NETWORK = {
+      :ipaddress => 'mgmtProcIPaddress',
     }.freeze
 
     PHYSICAL_SERVER = {

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
@@ -1,0 +1,45 @@
+module ManageIQ::Providers::Lenovo
+  class PhysicalInfraManager::Parser::PhysicalChassisParser < PhysicalInfraManager::Parser::ComponentParser
+    class << self
+      #
+      # Parse a chassis hash to a hash with physical racks data
+      #
+      # @param [Hash] chassis_hash - hash containing physical chassis raw data
+      # @param [Hash] rack - parsed physical rack data
+      #
+      # @return [Hash] containing the physical server information
+      #
+      def parse_physical_chassis(chassis_hash, rack)
+        chassis = XClarityClient::Chassi.new(chassis_hash)
+        result = parse(chassis, parent::ParserDictionaryConstants::PHYSICAL_CHASSIS)
+
+        result[:physical_rack]              = rack if rack
+        result[:vendor]                     = "lenovo"
+        result[:type]                       = parent::ParserDictionaryConstants::MIQ_TYPES["physical_chassis"]
+        result[:health_state]               = parent::ParserDictionaryConstants::HEALTH_STATE_MAP[chassis.cmmHealthState.nil? ? chassis.cmmHealthState : chassis.cmmHealthState.downcase]
+        result[:location_led_state]         = find_loc_led_state(chassis.leds)
+        result[:computer_system][:hardware] = get_hardwares(chassis)
+
+        return chassis.uuid, result
+      end
+
+      private
+
+      def find_loc_led_state(leds)
+        identification_led = leds.to_a.find { |led| parent::ParserDictionaryConstants::PROPERTIES_MAP[:led_identify_name].include?(led["name"]) }
+        identification_led.try(:[], "state")
+      end
+
+      def get_hardwares(chassis)
+        parsed_chassi_network = parse(chassis, parent::ParserDictionaryConstants::PHYSICAL_CHASSIS_NETWORK)
+
+        {
+          :guest_devices => [{
+            :device_type => "management",
+            :network     => parsed_chassi_network
+          }]
+        }
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_rack_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_rack_parser.rb
@@ -5,7 +5,6 @@ module ManageIQ::Providers::Lenovo
       # Parse a rack object to a hash with its data
       #
       # @param cab [XClarity::PhysicalRack] a rack object
-      # @param physical_servers [Hash] a already parsed physical_servers that belong to cab
       #
       # @return [Integer, Hash] PhysicalRack UUID and a parsed hash from PhysicalRack and every components inside it
       #

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
@@ -4,16 +4,19 @@ module ManageIQ::Providers::Lenovo
       #
       # parse a node object to a hash with physical servers data
       #
-      # @param [XClarityClient::Node] node - object containing physical server data
+      # @param [Hash] node_hash - hash containing physical server raw data
+      # @param [Hash] rack - parsed physical rack data
+      # @param [Hash] chassis - parsed physical chassis data
       #
       # @return [Hash] containing the physical server information
       #
-      def parse_physical_server(node, compliance, rack = nil)
+      def parse_physical_server(node_hash, compliance, rack = nil, chassis = nil)
+        node = XClarityClient::Node.new(node_hash)
         result = parse(node, parent::ParserDictionaryConstants::PHYSICAL_SERVER)
 
         # Keep track of the rack where this server is in, if it is in any rack
         result[:physical_rack]              = rack if rack
-
+        result[:physical_chassis]           = chassis if chassis
         result[:ems_compliance_name]        = compliance[:policy_name]
         result[:ems_compliance_status]      = compliance[:status]
         result[:vendor]                     = "lenovo"

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers
+  class Lenovo::PhysicalInfraManager::PhysicalChassis < ::PhysicalChassis
+  end
+end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -53,7 +53,8 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
   it 'will parse the legacy inventory' do
     result = refresher.parse_legacy_inventory(ems)
 
-    expect(result[:physical_servers].size).to eq(2)
+    expect(result[:physical_servers].size).to eq(3)
+    expect(result[:physical_chassis].size).to eq(1)
     expect(result[:physical_racks].size).to eq(1)
   end
 

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/mock_cabinet.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/mock_cabinet.yml
@@ -48,2842 +48,6992 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{
-                 "cabinetList": [
-                   {
-                     "storageList": [],
-                     "cabinetName": "cabinet71",
-                     "height": 42,
-                     "complexList": [],
-                     "chassisList": [],
-                     "location": "",
-                     "UUID": "096F8C92-08D4-4A24-ABD8-FE56D482F8C4",
-                     "nodeList": [
-                       {
-                         "itemParentUUID": null,
-                         "itemName": "Management Controller UUID-7936DD182C5311E3A8D6000AF7256738",
-                         "complexNodeCount": 1,
-                         "itemLowerUnit": 0,
-                         "itemType": "SERVER",
-                         "itemUUID": "7936DD182C5311E3A8D6000AF7256738",
-                         "itemSubType": "",
-                         "itemHeight": 4,
-                         "itemInventory": {
-                           "accessState": "Online",
-                           "arch": "x86",
-                           "manufacturerId": " IBM(CLCN)",
-                           "location": {
-                             "lowestRackUnit": 0,
-                             "location": "",
-                             "rack": "",
-                             "room": ""
-                           },
-                           "addinCardSlots": 0,
-                           "serialNumber": "23Y6458",
-                           "driveBays": 17,
-                           "macAddress": "6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16",
-                           "type": "Rack-Tower Server",
-                           "lanOverUsb": "enabled",
-                           "onboardPciDevices": [
-                             {
-                               "pciSubID": "0",
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     0
-                                   ],
-                                   "status": "Active",
-                                   "name": "PCIFirmware",
-                                   "role": "Primary",
-                                   "softwareID": "0:0",
-                                   "type": "",
-                                   "build": "0",
-                                   "date": "",
-                                   "version": ""
-                                 }
-                               ],
-                               "fodUniqueID": "",
-                               "pciRevision": "0",
-                               "isAgentless": false,
-                               "pciBusNumber": "27",
-                               "pciSubVendorID": "0",
-                               "isAddOnCard": false,
-                               "pciDeviceNumber": "0",
-                               "posID": "534",
-                               "pciFunctionNumber": "0",
-                               "name": "",
-                               "portInfo": {},
-                               "vpdID": "102b"
-                             }
-                           ],
-                           "height": 4,
-                           "leds": [
-                             {
-                               "color": "Yellow",
-                               "location": "FrontRearPanel",
-                               "name": "Fault",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Blue",
-                               "location": "FrontRearPanel",
-                               "name": "Identify",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FrontPanel",
-                               "name": "Check Log",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "CNFG",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "CPU",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "PS",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "DASD",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "FAN",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "MEM",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "NMI",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "OVER SPEC",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "TEMP",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "PCI",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "LightPathCard",
-                               "name": "LINK",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 1",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 2",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 3",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 5",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 6",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 7",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 8",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 9",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "FAN 10PEC",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 1",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 2",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 3",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 5",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 6",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 7",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 8",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 9",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 10Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 11Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 12Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 13Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 14Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 15Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 16Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 1",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 2",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 3",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 5",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 6",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 7",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 8",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 9",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "ML2",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 11DIMM 16Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 12DIMM 16Ctlr",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "Planar",
-                               "name": "SysBrd",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "Planar",
-                               "name": "CMOS Batt Error",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Green",
-                               "location": "FrontRearPanel",
-                               "name": "Power",
-                               "state": "Blinking"
-                             },
-                             {
-                               "color": "Green",
-                               "location": "Planar",
-                               "name": "BMC Heartbeat",
-                               "state": "Blinking"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 17",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 18",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 19",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 20",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 21",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 22",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 23",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 1 DIMM 24",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 1",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 2",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 3",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 5",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 6",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 7",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 8",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 9",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 10",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 11",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 12",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 13",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 14",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 15",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 16",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 17",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 18",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 19",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 20",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 21",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 22",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 23",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 2 DIMM 24",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 1",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 2",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 3",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 5",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 6",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 7",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 8",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 9",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 10",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 11",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 12",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 13",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 14",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 15",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 16",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 17",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 18",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 19",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 20",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 21",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 22",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 23",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 3 DIMM 24",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 1",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 2",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 3",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 5",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 6",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 7",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 8",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 9",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 10",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 11",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 12",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 13",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 14",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 15",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 16",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 17",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 18",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 19",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 20",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 21",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 22",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 23",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "CPU 4 DIMM 24",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "Book 1 Board4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "Book 2 Board4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "Book 3 Board4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "Book 4 Board4",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Amber",
-                               "location": "FRU",
-                               "name": "Book 1 Attention",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Amber",
-                               "location": "FRU",
-                               "name": "Book 2 Attention",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Amber",
-                               "location": "FRU",
-                               "name": "Book 3 Attention",
-                               "state": "Off"
-                             },
-                             {
-                               "color": "Amber",
-                               "location": "FRU",
-                               "name": "Book 4 Attention",
-                               "state": "Off"
-                             }
-                           ],
-                           "description": "Chassis",
-                           "mgmtProcIPaddress": "10.243.6.17",
-                           "expansionCards": [],
-                           "errorFields": [
-                             {
-                               "FirmwareData": "NO_CONNECTOR"
-                             },
-                             {
-                               "ChassisMounted": "NO_CONNECTOR"
-                             }
-                           ],
-                           "FQDN": "cmm-dt1.labs.lenovo.com",
-                           "ipInterfaces": [
-                             {
-                               "IPv4enabled": true,
-                               "IPv4DHCPmode": "STATIC_ONLY",
-                               "IPv6enabled": true,
-                               "IPv6DHCPenabled": true,
-                               "IPv4assignments": [
-                                 {
-                                   "id": 0,
-                                   "subnet": "255.255.240.0",
-                                   "gateway": "0.0.0.0",
-                                   "address": "10.243.6.17",
-                                   "type": "INUSE"
-                                 }
-                               ],
-                               "IPv6assignments": [
-                                 {
-                                   "id": 0,
-                                   "scope": "Global",
-                                   "gateway": "0:0:0:0:0:0:0:0",
-                                   "source": "Stateless",
-                                   "address": "fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15",
-                                   "prefix": 64,
-                                   "type": "INUSE"
-                                 },
-                                 {
-                                   "id": 0,
-                                   "scope": "LinkLocal",
-                                   "gateway": "0:0:0:0:0:0:0:0",
-                                   "source": "Other",
-                                   "address": "fe80:0:0:0:6eae:8bff:fe4b:4f15",
-                                   "prefix": 64,
-                                   "type": "INUSE"
-                                 }
-                               ],
-                               "name": "eth0",
-                               "IPv6statelessEnabled": true,
-                               "label": "unknown",
-                               "IPv6staticEnabled": false
-                             }
-                           ],
-                           "firmware": [
-                             {
-                               "status": "Active",
-                               "name": "UEFI Firmware/BIOS",
-                               "role": "Primary",
-                               "date": "2017-02-21T00:00:00Z",
-                               "type": "UEFI",
-                               "build": "A9E139GUS",
-                               "version": "4.10"
-                             },
-                             {
-                               "status": "Inactive",
-                               "name": "UEFI Backup Firmware/BIOS",
-                               "role": "Backup",
-                               "date": "2017-02-21T00:00:00Z",
-                               "type": "UEFI-Backup",
-                               "build": "A9E139GUS",
-                               "version": "4.10"
-                             },
-                             {
-                               "status": "Active",
-                               "name": "DSA Diagnostic Software",
-                               "role": "Primary",
-                               "date": "2016-06-07T00:00:00Z",
-                               "type": "DSA",
-                               "build": "DSALA7J",
-                               "version": "10.2"
-                             },
-                             {
-                               "status": "Active",
-                               "name": "IMM2 Firmware",
-                               "role": "Primary",
-                               "date": "2016-12-05T00:00:00Z",
-                               "type": "IMM2",
-                               "build": "TCOO59G",
-                               "version": "9.00"
-                             },
-                             {
-                               "status": "Inactive",
-                               "name": "IMM2 Backup Firmware",
-                               "role": "Backup",
-                               "date": "2016-12-05T00:00:00Z",
-                               "type": "IMM2-Backup",
-                               "build": "TCOO59G",
-                               "version": "9.00"
-                             }
-                           ],
-                           "bladeState": 0,
-                           "activationKeys": [],
-                           "status": {
-                             "message": "managed",
-                             "name": "MANAGED"
-                           },
-                           "powerCappingPolicy": {
-                             "cappingACorDCMode": "DC",
-                             "minimumHardCapLevel": 439100,
-                             "cappingPolicy": "OFF",
-                             "maxPowerCap": 533000,
-                             "minimumPowerCappingHotPlugLevel": 759000,
-                             "powerCappingAllocUnit": "watts*10^-3",
-                             "maximumPowerCappingHotPlugLevel": 854000,
-                             "currentPowerCap": 0,
-                             "minPowerCap": 130000
-                           },
-                           "hostname": "IMM2-6cae8b4b4f15",
-                           "powerSupplies": [
-                             {
-                               "model": "",
-                               "manufacturerId": "",
-                               "serialNumber": "Unknown",
-                               "inputVoltageIsAC": true,
-                               "inputVoltageMin": -1,
-                               "type": "PowerSupply",
-                               "dataHandle": 0,
-                               "cmmDisplayName": "Power Supply 1",
-                               "leds": [],
-                               "description": "",
-                               "name": "Power Supply 1",
-                               "userDescription": "",
-                               "manufactureDate": "",
-                               "partNumber": "Unknown",
-                               "firmware": [],
-                               "healthState": "GOOD",
-                               "machineType": "",
-                               "hardwareRevision": "",
-                               "FRU": "",
-                               "uri": "powerSupply/",
-                               "productId": "",
-                               "powerAllocation": {
-                                 "totalInputPower": 0,
-                                 "totalOutputPower": 900
-                               },
-                               "powerState": "Unknown",
-                               "posID": "",
-                               "slots": [
-                                 2
-                               ],
-                               "manufacturer": "Unknown",
-                               "vpdID": "",
-                               "uuid": "",
-                               "productName": "",
-                               "fruSerialNumber": "",
-                               "inputVoltageMax": -1
-                             },
-                             {
-                               "model": "",
-                               "manufacturerId": "",
-                               "serialNumber": "K115136V11E",
-                               "inputVoltageIsAC": true,
-                               "inputVoltageMin": -1,
-                               "type": "PowerSupply",
-                               "dataHandle": 0,
-                               "cmmDisplayName": "Power Supply 2",
-                               "leds": [],
-                               "description": "",
-                               "name": "Power Supply 2",
-                               "userDescription": "",
-                               "manufactureDate": "",
-                               "partNumber": "94Y8066",
-                               "firmware": [],
-                               "healthState": "GOOD",
-                               "machineType": "",
-                               "hardwareRevision": "",
-                               "FRU": "",
-                               "uri": "powerSupply/",
-                               "productId": "",
-                               "powerAllocation": {
-                                 "totalInputPower": 0,
-                                 "totalOutputPower": 900
-                               },
-                               "powerState": "Unknown",
-                               "posID": "",
-                               "slots": [
-                                 3
-                               ],
-                               "manufacturer": "DELT",
-                               "vpdID": "",
-                               "uuid": "",
-                               "productName": "",
-                               "fruSerialNumber": "",
-                               "inputVoltageMax": -1
-                             }
-                           ],
-                           "parentComplexID": "7936DD182C5311E3A8D6000AF7256738",
-                           "FRU": "None",
-                           "uri": "node/7936DD182C5311E3A8D6000AF7256738",
-                           "vnicMode": "disabled",
-                           "powerAllocation": {
-                             "maximumAllocatedPower": 1710,
-                             "minimumAllocatedPower": 26
-                           },
-                           "expansionProductType": "",
-                           "powerStatus": 5,
-                           "bootOrder": {
-                             "uri": "node/7936DD182C5311E3A8D6000AF7256738/bootOrder",
-                             "bootOrderList": [
-                               {
-                                 "currentBootOrderDevices": [
-                                   "None"
-                                 ],
-                                 "bootType": "SingleUse",
-                                 "possibleBootOrderDevices": [
-                                   "None",
-                                   "PXE Network",
-                                   "Hard Disk 0",
-                                   "Diagnostics",
-                                   "CD/DVD Rom",
-                                   "Boot To F1",
-                                   "Hypervisor",
-                                   "Floppy Disk"
-                                 ]
-                               },
-                               {
-                                 "currentBootOrderDevices": [
-                                   "CentOS Linux",
-                                   "Hard Disk 0",
-                                   "Windows Boot Manager",
-                                   "PXE Network",
-                                   "CD/DVD Rom"
-                                 ],
-                                 "bootType": "Permanent",
-                                 "possibleBootOrderDevices": [
-                                   "CentOS Linux",
-                                   "Hard Disk 0",
-                                   "Windows Boot Manager",
-                                   "PXE Network",
-                                   "CD/DVD Rom",
-                                   "Floppy Disk",
-                                   "Hard Disk 1",
-                                   "Hard Disk 2",
-                                   "Hard Disk 3",
-                                   "Hard Disk 4",
-                                   "USB Storage",
-                                   "Diagnostics",
-                                   "iSCSI",
-                                   "iSCSI Critical",
-                                   "Embedded Hypervisor",
-                                   "Legacy Only",
-                                   "USB0",
-                                   "USB1",
-                                   "USB2",
-                                   "USB3",
-                                   "USB4",
-                                   "USB5",
-                                   "USB6",
-                                   "USB7",
-                                   "DSA",
-                                   "Slot16",
-                                   "Slot17",
-                                   "Slot18",
-                                   "Slot19",
-                                   "Slot12",
-                                   "Slot11",
-                                   "Slot10",
-                                   "Slot1",
-                                   "Slot2",
-                                   "Slot3",
-                                   "Slot4",
-                                   "Slot5",
-                                   "Slot6",
-                                   "Slot7",
-                                   "Slot8",
-                                   "Slot9",
-                                   "IMM1",
-                                   "IMM2"
-                                 ]
-                               },
-                               {
-                                 "currentBootOrderDevices": [
-                                   "PXE Network",
-                                   "CD/DVD Rom",
-                                   "Hard Disk 0"
-                                 ],
-                                 "bootType": "WakeOnLAN",
-                                 "possibleBootOrderDevices": [
-                                   "PXE Network",
-                                   "CD/DVD Rom",
-                                   "Hard Disk 0",
-                                   "CentOS Linux",
-                                   "Windows Boot Manager",
-                                   "Floppy Disk",
-                                   "Hard Disk 1",
-                                   "Hard Disk 2",
-                                   "Hard Disk 3",
-                                   "Hard Disk 4",
-                                   "USB Storage",
-                                   "Diagnostics",
-                                   "iSCSI",
-                                   "iSCSI Critical",
-                                   "Embedded Hypervisor",
-                                   "Legacy Only",
-                                   "USB0",
-                                   "USB1",
-                                   "USB2",
-                                   "USB3",
-                                   "USB4",
-                                   "USB5",
-                                   "USB6",
-                                   "USB7",
-                                   "DSA",
-                                   "Slot16",
-                                   "Slot17",
-                                   "Slot18",
-                                   "Slot19",
-                                   "Slot12",
-                                   "Slot11",
-                                   "Slot10",
-                                   "Slot1",
-                                   "Slot2",
-                                   "Slot3",
-                                   "Slot4",
-                                   "Slot5",
-                                   "Slot6",
-                                   "Slot7",
-                                   "Slot8",
-                                   "Slot9",
-                                   "IMM1",
-                                   "IMM2"
-                                 ]
-                               }
-                             ]
-                           },
-                           "expansionProducts": [],
-                           "ipv6Addresses": [
-                             "fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15",
-                             "fe80:0:0:0:6eae:8bff:fe4b:4f15"
-                           ],
-                           "slots": [
-                             1
-                           ],
-                           "manufacturer": " IBM(CLCN)",
-                           "addinCards": [
-                             {
-                               "pciSubID": "454",
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     13
-                                   ],
-                                   "status": "Active",
-                                   "name": "MegaRAID Controller Firmware",
-                                   "role": "Primary",
-                                   "softwareID": "10140454",
-                                   "type": "Software Bundle",
-                                   "build": "0",
-                                   "date": "2016-07-20T00:00:00Z",
-                                   "version": "24.12.0-0033"
-                                 }
-                               ],
-                               "slotSupportsHotPlug": "false",
-                               "fodUniqueID": "N/A",
-                               "pciRevision": "2",
-                               "isAgentless": true,
-                               "pciBusNumber": "7",
-                               "pciSubVendorID": "1014",
-                               "isAddOnCard": true,
-                               "FRU": "N/A",
-                               "pciDeviceNumber": "0",
-                               "slotNumber": "12",
-                               "posID": "5d",
-                               "pciFunctionNumber": "0",
-                               "manufacturer": "IBM",
-                               "name": "ServeRAID M5210",
-                               "portInfo": {},
-                               "vpdID": "1000",
-                               "productName": "ServeRAID M5210",
-                               "partNumber": "N/A",
-                               "fruSerialNumber": "SV334P0606",
-                               "slotName": "SlotDesig7_Slot 12 (Pri Storage)"
-                             },
-                             {
-                               "pciSubID": "450",
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     33024
-                                   ],
-                                   "status": "Active",
-                                   "name": "17.4.4.2a",
-                                   "role": "Primary",
-                                   "softwareID": "10140450",
-                                   "type": "VPD-V0",
-                                   "build": "0",
-                                   "date": "",
-                                   "version": "17.4.4.2a"
-                                 }
-                               ],
-                               "slotSupportsHotPlug": "false",
-                               "fodUniqueID": "11S90Y9372Y0502037P0ES",
-                               "pciRevision": "0",
-                               "isAgentless": true,
-                               "pciBusNumber": "145",
-                               "pciSubVendorID": "1014",
-                               "isAddOnCard": true,
-                               "FRU": "90Y9373",
-                               "pciDeviceNumber": "0",
-                               "slotNumber": "7",
-                               "posID": "165f",
-                               "pciFunctionNumber": "0",
-                               "manufacturer": "IBM",
-                               "name": "Broadcom 2-port 1GbE NIC Card for IBM",
-                               "portInfo": {
-                                 "physicalPorts": [
-                                   {
-                                     "portType": "ETHERNET",
-                                     "portNumber": 49,
-                                     "logicalPorts": [
-                                       {
-                                         "portType": "ETHERNET",
-                                         "portNumber": 1,
-                                         "logicalPortIndex": 1,
-                                         "addresses": "000AF7256738",
-                                         "vnicMode": false
-                                       }
-                                     ],
-                                     "peerBay": 0,
-                                     "physicalPortIndex": 1
-                                   }
-                                 ]
-                               },
-                               "vpdID": "14e4",
-                               "productName": "Broadcom 2-port 1GbE NIC Card for IBM",
-                               "partNumber": "90Y9372",
-                               "fruSerialNumber": "Y0502037P0ES",
-                               "slotName": "SlotDesig6_Slot 7"
-                             },
-                             {
-                               "pciSubID": "450",
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     33024
-                                   ],
-                                   "status": "Active",
-                                   "name": "17.4.4.2a",
-                                   "role": "Primary",
-                                   "softwareID": "10140450",
-                                   "type": "VPD-V0",
-                                   "build": "0",
-                                   "date": "",
-                                   "version": "17.4.4.2a"
-                                 }
-                               ],
-                               "slotSupportsHotPlug": "false",
-                               "fodUniqueID": "11S90Y9372Y0502037P0ES",
-                               "pciRevision": "0",
-                               "isAgentless": true,
-                               "pciBusNumber": "145",
-                               "pciSubVendorID": "1014",
-                               "isAddOnCard": true,
-                               "FRU": "90Y9373",
-                               "pciDeviceNumber": "0",
-                               "slotNumber": "7",
-                               "posID": "165f",
-                               "pciFunctionNumber": "1",
-                               "manufacturer": "IBM",
-                               "name": "Broadcom 2-port 1GbE NIC Card for IBM",
-                               "portInfo": {
-                                 "physicalPorts": [
-                                   {
-                                     "portType": "ETHERNET",
-                                     "portNumber": 50,
-                                     "logicalPorts": [
-                                       {
-                                         "portType": "ETHERNET",
-                                         "portNumber": 1,
-                                         "logicalPortIndex": 1,
-                                         "addresses": "000AF7256739",
-                                         "vnicMode": false
-                                       }
-                                     ],
-                                     "peerBay": 0,
-                                     "physicalPortIndex": 2
-                                   }
-                                 ]
-                               },
-                               "vpdID": "14e4",
-                               "productName": "Broadcom 2-port 1GbE NIC Card for IBM",
-                               "partNumber": "90Y9372",
-                               "fruSerialNumber": "Y0502037P0ES",
-                               "slotName": "SlotDesig6_Slot 7"
-                             }
-                           ],
-                           "parentPartitionUUID": "",
-                           "raidSettings": [
-                             {
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     10
-                                   ],
-                                   "status": "Active",
-                                   "name": "MegaRAID Controller Firmware",
-                                   "role": "Primary",
-                                   "type": "Firmware",
-                                   "build": "0",
-                                   "date": "2017-06-15T00:00:00Z",
-                                   "version": "24.21.0-0016",
-                                   "softwareID": "101404AC"
-                                 }
-                               ],
-                               "description": "ServeRAID M1210e",
-                               "name": "ServeRAID M1210e",
-                               "uuid": "000000000000000050050760670002AC",
-                               "diskDrives": [
-                                 {
-                                   "model": "ST300MM0006",
-                                   "healthState": "Normal",
-                                   "numberOfBlocks": 585937500,
-                                   "interfaceType": "SAS",
-                                   "serialNumber": "S0K2QNGE",
-                                   "blockSize": 512,
-                                   "mediaType": "Rotational",
-                                   "diskState": "Online",
-                                   "bay": 0,
-                                   "description": "ST300MM0006",
-                                   "manufacturer": "IBM-ESXS",
-                                   "name": "Disk 0_e",
-                                   "uuid": "",
-                                   "partNumber": "00AJ100",
-                                   "largestAvailableSize": 512,
-                                   "capacity": 300000000000,
-                                   "m2Location": "",
-                                   "softwareData": [
-                                     {
-                                       "revision": "0",
-                                       "classifications": [
-                                         10
-                                       ],
-                                       "status": "Active",
-                                       "name": "Drive",
-                                       "role": "Primary",
-                                       "type": "Firmware",
-                                       "build": "0",
-                                       "date": "",
-                                       "version": "B56T",
-                                       "softwareID": "ST300MM0006"
-                                     }
-                                   ],
-                                   "FRU": "00AJ097"
-                                 }
-                               ],
-                               "storagePools": [
-                                 {
-                                   "name": "Pool_0",
-                                   "arrayUid": "0",
-                                   "description": "000000000000000050050760670002AC_Storage Pool_M1210e_000000000000000050050760670002AC_30:Pool:0",
-                                   "arrayStatus": "Offline",
-                                   "totalManagedSpace": 298999349248,
-                                   "remainingSpace": 0,
-                                   "raidLevel": 0,
-                                   "storageVolumes": [
-                                     {
-                                       "name": "GenericR0_0",
-                                       "bootable": true,
-                                       "description": "Volume 0 000000000000000050050760670002AC_0",
-                                       "blockSize": 512,
-                                       "numberOfBlocks": 583983104,
-                                       "primaryPartition": 0,
-                                       "stripeSize": 65536,
-                                       "volumeStatus": "Dynamic Reconfig",
-                                       "volumeID": "104",
-                                       "volumeUID": "0",
-                                       "driveIndex": 0,
-                                       "removable": false,
-                                       "health": "Unknown",
-                                       "LUN": -1
-                                     }
-                                   ],
-                                   "diskDrives": [
-                                     {
-                                       "model": "ST300MM0006",
-                                       "healthState": "Normal",
-                                       "numberOfBlocks": 585937500,
-                                       "interfaceType": "SAS",
-                                       "serialNumber": "S0K2QNGE",
-                                       "blockSize": 512,
-                                       "mediaType": "Rotational",
-                                       "diskState": "Online",
-                                       "bay": 0,
-                                       "description": "ST300MM0006",
-                                       "manufacturer": "IBM-ESXS",
-                                       "name": "Disk 0_e",
-                                       "uuid": "",
-                                       "partNumber": "00AJ100",
-                                       "largestAvailableSize": 512,
-                                       "capacity": 300000000000,
-                                       "m2Location": "",
-                                       "softwareData": [
-                                         {
-                                           "revision": "0",
-                                           "classifications": [
-                                             10
-                                           ],
-                                           "status": "Active",
-                                           "name": "Drive",
-                                           "role": "Primary",
-                                           "type": "Firmware",
-                                           "build": "0",
-                                           "date": "",
-                                           "version": "B56T",
-                                           "softwareID": "ST300MM0006"
-                                         }
-                                       ],
-                                       "FRU": "00AJ097"
-                                     }
-                                   ]
-                                 }
-                               ],
-                               "batteryData": []
-                             }
-                           ],
-                           "vpdID": "",
-                           "uuid": "7936DD182C5311E3A8D6000AF7256738",
-                           "isConnectionTrusted": "true",
-                           "memoryModules": [
-                             {
-                               "model": "DDR3",
-                               "speed": 1600,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 4,
-                               "serialNumber": "3AAF65F9",
-                               "displayName": "CPU 1 DIMM 9",
-                               "slot": 9,
-                               "type": "DDR3",
-                               "partNumber": "Unknown"
-                             },
-                             {
-                               "model": "DDR3",
-                               "speed": 1600,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 4,
-                               "serialNumber": "3AAF65FA",
-                               "displayName": "CPU 1 DIMM 15",
-                               "slot": 15,
-                               "type": "DDR3",
-                               "partNumber": "Unknown"
-                             },
-                             {
-                               "model": "DDR3",
-                               "speed": 1600,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 4,
-                               "serialNumber": "3AAF65FE",
-                               "displayName": "CPU 2 DIMM 9",
-                               "slot": 9,
-                               "type": "DDR3",
-                               "partNumber": "Unknown"
-                             },
-                             {
-                               "model": "DDR3",
-                               "speed": 1600,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 4,
-                               "serialNumber": "3AAF6603",
-                               "displayName": "CPU 2 DIMM 15",
-                               "slot": 15,
-                               "type": "DDR3",
-                               "partNumber": "Unknown"
-                             }
-                           ],
-                           "partitionEnabled": false,
-                           "fruSerialNumber": "None",
-                           "secureBootMode": {
-                             "possibleValues": [
-                               "Disabled",
-                               "Enabled"
-                             ],
-                             "currentValue": "Disabled"
-                           },
-                           "encapsulation": {
-                             "encapsulationMode": "normal"
-                           },
-                           "tlsVersion": {
-                             "possibleValues": [
-                               "TLS_10",
-                               "TLS_11",
-                               "TLS_12",
-                               "unsupported"
-                             ],
-                             "currentValue": "TLS_10"
-                           },
-                           "model": "AC1",
-                           "isScalable": true,
-                           "expansionCardSlots": 0,
-                           "fans": [],
-                           "isITME": false,
-                           "hostMacAddresses": "00:0A:F7:25:67:38,00:0A:F7:25:67:39",
-                           "contact": "",
-                           "dataHandle": 1496851623453,
-                           "ipv4Addresses": [
-                             "10.243.6.17",
-                             "169.254.95.118"
-                           ],
-                           "cmmDisplayName": "Management Controller UUID-7936DD182C5311E3A8D6000AF7256738",
-                           "backedBy": "real",
-                           "complexID": 1,
-                           "name": "17dspncsvdm",
-                           "memorySlots": 0,
-                           "drives": [],
-                           "cmmHealthState": "Normal",
-                           "userDescription": "",
-                           "subSlots": [],
-                           "partNumber": "00D0188     ",
-                           "excludedHealthState": "Normal",
-                           "machineType": "6241",
-                           "isRemotePresenceEnabled": true,
-                           "pciDevices": [
-                             {
-                               "pciSubID": "454",
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     13
-                                   ],
-                                   "status": "Active",
-                                   "name": "MegaRAID Controller Firmware",
-                                   "role": "Primary",
-                                   "softwareID": "10140454",
-                                   "type": "Software Bundle",
-                                   "build": "0",
-                                   "date": "2016-07-20T00:00:00Z",
-                                   "version": "24.12.0-0033"
-                                 }
-                               ],
-                               "slotSupportsHotPlug": "false",
-                               "fodUniqueID": "N/A",
-                               "pciRevision": "2",
-                               "isAgentless": true,
-                               "pciBusNumber": "7",
-                               "pciSubVendorID": "1014",
-                               "isAddOnCard": true,
-                               "FRU": "N/A",
-                               "pciDeviceNumber": "0",
-                               "slotNumber": "12",
-                               "posID": "5d",
-                               "pciFunctionNumber": "0",
-                               "manufacturer": "IBM",
-                               "name": "ServeRAID M5210",
-                               "portInfo": {},
-                               "vpdID": "1000",
-                               "productName": "ServeRAID M5210",
-                               "partNumber": "N/A",
-                               "fruSerialNumber": "SV334P0606",
-                               "slotName": "SlotDesig7_Slot 12 (Pri Storage)"
-                             },
-                             {
-                               "pciSubID": "0",
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     0
-                                   ],
-                                   "status": "Active",
-                                   "name": "PCIFirmware",
-                                   "role": "Primary",
-                                   "softwareID": "0:0",
-                                   "type": "",
-                                   "build": "0",
-                                   "date": "",
-                                   "version": ""
-                                 }
-                               ],
-                               "fodUniqueID": "",
-                               "pciRevision": "0",
-                               "isAgentless": false,
-                               "pciBusNumber": "27",
-                               "pciSubVendorID": "0",
-                               "isAddOnCard": false,
-                               "pciDeviceNumber": "0",
-                               "posID": "534",
-                               "pciFunctionNumber": "0",
-                               "name": "",
-                               "portInfo": {},
-                               "vpdID": "102b"
-                             },
-                             {
-                               "pciSubID": "450",
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     33024
-                                   ],
-                                   "status": "Active",
-                                   "name": "17.4.4.2a",
-                                   "role": "Primary",
-                                   "softwareID": "10140450",
-                                   "type": "VPD-V0",
-                                   "build": "0",
-                                   "date": "",
-                                   "version": "17.4.4.2a"
-                                 }
-                               ],
-                               "slotSupportsHotPlug": "false",
-                               "fodUniqueID": "11S90Y9372Y0502037P0ES",
-                               "pciRevision": "0",
-                               "isAgentless": true,
-                               "pciBusNumber": "145",
-                               "pciSubVendorID": "1014",
-                               "isAddOnCard": true,
-                               "FRU": "90Y9373",
-                               "pciDeviceNumber": "0",
-                               "slotNumber": "7",
-                               "posID": "165f",
-                               "pciFunctionNumber": "0",
-                               "manufacturer": "IBM",
-                               "name": "Broadcom 2-port 1GbE NIC Card for IBM",
-                               "portInfo": {
-                                 "physicalPorts": [
-                                   {
-                                     "portType": "ETHERNET",
-                                     "portNumber": 49,
-                                     "logicalPorts": [
-                                       {
-                                         "portType": "ETHERNET",
-                                         "portNumber": 1,
-                                         "logicalPortIndex": 1,
-                                         "addresses": "000AF7256738",
-                                         "vnicMode": false
-                                       }
-                                     ],
-                                     "peerBay": 0,
-                                     "physicalPortIndex": 1
-                                   }
-                                 ]
-                               },
-                               "vpdID": "14e4",
-                               "productName": "Broadcom 2-port 1GbE NIC Card for IBM",
-                               "partNumber": "90Y9372",
-                               "fruSerialNumber": "Y0502037P0ES",
-                               "slotName": "SlotDesig6_Slot 7"
-                             },
-                             {
-                               "pciSubID": "450",
-                               "firmware": [
-                                 {
-                                   "revision": "0",
-                                   "classifications": [
-                                     33024
-                                   ],
-                                   "status": "Active",
-                                   "name": "17.4.4.2a",
-                                   "role": "Primary",
-                                   "softwareID": "10140450",
-                                   "type": "VPD-V0",
-                                   "build": "0",
-                                   "date": "",
-                                   "version": "17.4.4.2a"
-                                 }
-                               ],
-                               "slotSupportsHotPlug": "false",
-                               "fodUniqueID": "11S90Y9372Y0502037P0ES",
-                               "pciRevision": "0",
-                               "isAgentless": true,
-                               "pciBusNumber": "145",
-                               "pciSubVendorID": "1014",
-                               "isAddOnCard": true,
-                               "FRU": "90Y9373",
-                               "pciDeviceNumber": "0",
-                               "slotNumber": "7",
-                               "posID": "165f",
-                               "pciFunctionNumber": "1",
-                               "manufacturer": "IBM",
-                               "name": "Broadcom 2-port 1GbE NIC Card for IBM",
-                               "portInfo": {
-                                 "physicalPorts": [
-                                   {
-                                     "portType": "ETHERNET",
-                                     "portNumber": 50,
-                                     "logicalPorts": [
-                                       {
-                                         "portType": "ETHERNET",
-                                         "portNumber": 1,
-                                         "logicalPortIndex": 1,
-                                         "addresses": "000AF7256739",
-                                         "vnicMode": false
-                                       }
-                                     ],
-                                     "peerBay": 0,
-                                     "physicalPortIndex": 2
-                                   }
-                                 ]
-                               },
-                               "vpdID": "14e4",
-                               "productName": "Broadcom 2-port 1GbE NIC Card for IBM",
-                               "partNumber": "90Y9372",
-                               "fruSerialNumber": "Y0502037P0ES",
-                               "slotName": "SlotDesig6_Slot 7"
-                             }
-                           ],
-                           "domainName": "",
-                           "processors": [
-                             {
-                               "speed": 2.2,
-                               "manufacturer": "Intel(R) Corporation",
-                               "family": "PENTIUM_R_4",
-                               "displayName": "Intel(R) Xeon(R) CPU E7-8880L v2 @ 2.20GHz",
-                               "slot": 1,
-                               "productVersion": "Intel(R) Xeon(R) CPU E7-8880L v2 @ 2.20GHz",
-                               "cores": 15
-                             },
-                             {
-                               "speed": 2.2,
-                               "manufacturer": "Intel(R) Corporation",
-                               "family": "PENTIUM_R_4",
-                               "displayName": "Intel(R) Xeon(R) CPU E7-8880L v2 @ 2.20GHz",
-                               "slot": 2,
-                               "productVersion": "Intel(R) Xeon(R) CPU E7-8880L v2 @ 2.20GHz",
-                               "cores": 15
-                             }
-                           ],
-                           "processorSlots": 0,
-                           "pciCapabilities": [
-                             "Raid Link",
-                             "OOB PCIe",
-                             "Raid Link Config",
-                             "Raid Link Alert",
-                             "OOB PCIe Config"
-                           ],
-                           "productId": "4D4F00",
-                           "hasOS": false,
-                           "lanOverUsbPortForwardingModes": [
-                             {
-                               "state": "disabled",
-                               "type": "DSA",
-                               "externalIPAddress": ""
-                             },
-                             {
-                               "state": "disabled",
-                               "type": "OSDeploy",
-                               "externalIPAddress": ""
-                             }
-                           ],
-                           "bootMode": {
-                             "possibleValues": [
-                               "UEFI Mode",
-                               "Legacy Mode"
-                             ],
-                             "currentValue": "UEFI Mode"
-                           },
-                           "ports": [
-                             {
-                               "ioModuleBay": 0,
-                               "portNumber": 49
-                             },
-                             {
-                               "ioModuleBay": 0,
-                               "portNumber": 50
-                             }
-                           ],
-                           "embeddedHypervisorPresence": false,
-                           "posID": "",
-                           "nist": {
-                             "possibleValues": [
-                               "Compatibility",
-                               "Nist_800_131A_Strict",
-                               "unsupported"
-                             ],
-                             "currentValue": "Compatibility"
-                           },
-                           "overallHealthState": "Normal",
-                           "subType": "",
-                           "partitionID": -1,
-                           "physicalID": 0,
-                           "flashStorage": [],
-                           "productName": "Lenovo System x3850 X6"
-                         },
-                         "complexNodeUUIDs": [
-                           "7936DD182C5311E3A8D6000AF7256738"
-                         ],
-                         "complexID": "7936DD182C5311E3A8D6000AF7256738",
-                         "itemLocationRack": "",
-                         "physicalID": 0,
-                         "nodeCount": 1,
-                         "itemLocation": "",
-                         "itemLocationRoom": ""
-                       }
-                     ],
-                     "placeholderList": [],
-                     "switchList": [],
-                     "room": ""
-                   },
-                   {
-                     "storageList": [],
-                     "cabinetName": "STANDALONE_OBJECT_NAME",
-                     "height": 42,
-                     "complexList": [],
-                     "chassisList": [],
-                     "location": "",
-                     "UUID": "STANDALONE_OBJECT_UUID",
-                     "nodeList": [
-                       {
-                         "itemParentUUID": null,
-                         "itemName": "SERVER-A59D5B36821111E1A9F5E41F13ED4F6A",
-                         "itemLowerUnit": 0,
-                         "itemType": "SERVER",
-                         "itemLocationRack": "",
-                         "itemSubType": "LegacyServer",
-                         "itemUUID": "A59D5B36821111E1A9F5E41F13ED4F6A",
-                         "itemInventory": {
-                           "accessState": "Pending",
-                           "arch": "x86_64",
-                           "manufacturerId": "",
-                           "location": {
-                             "lowestRackUnit": 0,
-                             "location": "",
-                             "rack": "",
-                             "room": ""
-                           },
-                           "addinCardSlots": 0,
-                           "serialNumber": "06ARFA2",
-                           "driveBays": 0,
-                           "macAddress": "e4:1f:13:ed:4f:6f",
-                           "type": "Rack-Tower Server",
-                           "lanOverUsb": "disabled",
-                           "height": 1,
-                           "leds": [
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Front Panel",
-                               "name": "Check Log",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Front Panel",
-                               "name": "Fault",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Attention",
-                               "color": "Blue",
-                               "location": "Front Panel",
-                               "name": "Identify",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Health",
-                               "color": "Green",
-                               "location": "Front Panel",
-                               "name": "Power",
-                               "state": "On"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "BOARD",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "Battery",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "CONFIG",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "CPU",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "CPU 1",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "CPU 2",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 1",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 10",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 11",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 12",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 13",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 14",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 15",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 16",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 17",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 18",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 19",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 2",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 20",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 21",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 22",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 23",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 24",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 3",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 4",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 5",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 6",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 7",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 8",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "DIMM 9",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "FAN",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "FAN 1",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "FAN 2",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "FAN 3",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "FAN 4",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "FAN 5",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "FAN 6",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "HDD",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Health",
-                               "color": "Green",
-                               "location": "System Board",
-                               "name": "IMM2 Heartbeat",
-                               "state": "Blink"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "Internal RAID",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Health",
-                               "color": "Green",
-                               "location": "Lightpath Card",
-                               "name": "LINK",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "MEM",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "Mezz Card Error",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "NMI",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "OVER SPEC",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "PCI",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 1",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "FRU",
-                               "name": "PCI 2",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "PS",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Status",
-                               "color": "Green",
-                               "location": "FRU",
-                               "name": "Power",
-                               "state": "On"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "System Board",
-                               "name": "SysBrd Fault",
-                               "state": "Off"
-                             },
-                             {
-                               "conditions": "Warning",
-                               "color": "Yellow",
-                               "location": "Lightpath Card",
-                               "name": "TEMP",
-                               "state": "Off"
-                             }
-                           ],
-                           "description": "chassis System x3550 M4",
-                           "mgmtProcIPaddress": "10.243.9.111",
-                           "expansionCards": [],
-                           "errorFields": [],
-                           "FQDN": "ratchetimm1.labs.lenovo.com",
-                           "ipInterfaces": [],
-                           "firmware": [
-                             {
-                               "status": "ACTIVE",
-                               "name": "IMM",
-                               "role": "",
-                               "date": "",
-                               "type": "IMM",
-                               "build": "",
-                               "version": "1AOO72H-5.60"
-                             },
-                             {
-                               "status": "ACTIVE",
-                               "name": "Preboot DSA",
-                               "role": "",
-                               "date": "",
-                               "type": "Preboot DSA",
-                               "build": "",
-                               "version": "DSYTD8G-9.54"
-                             },
-                             {
-                               "status": "ACTIVE",
-                               "name": "UEFI",
-                               "role": "",
-                               "date": "",
-                               "type": "UEFI",
-                               "build": "",
-                               "version": "D7E152CUS-2.11"
-                             }
-                           ],
-                           "bladeState": 0,
-                           "activationKeys": [],
-                           "status": {
-                             "message": "managed",
-                             "name": "MANAGED"
-                           },
-                           "powerCappingPolicy": {
-                             "cappingACorDCMode": "UNKNOWN",
-                             "minimumHardCapLevel": -1,
-                             "cappingPolicy": "UNKNOWN",
-                             "maxPowerCap": -1,
-                             "minimumPowerCappingHotPlugLevel": -1,
-                             "powerCappingAllocUnit": "watts",
-                             "maximumPowerCappingHotPlugLevel": -1,
-                             "currentPowerCap": 0,
-                             "minPowerCap": -1
-                           },
-                           "hostname": "IMM-e41f13ed4f6f",
-                           "powerSupplies": [
-                             {
-                               "model": "43X3313",
-                               "manufacturerId": "EMER",
-                               "serialNumber": " K1181227068",
-                               "inputVoltageIsAC": false,
-                               "inputVoltageMin": 0,
-                               "type": "PowerSupply",
-                               "dataHandle": 0,
-                               "cmmDisplayName": null,
-                               "leds": [
-                                 {
-                                   "color": "Green",
-                                   "location": "FRU",
-                                   "name": "IN",
-                                   "state": "On"
-                                 },
-                                 {
-                                   "color": "Green",
-                                   "location": "FRU",
-                                   "name": "OUT",
-                                   "state": "On"
-                                 },
-                                 {
-                                   "color": "Amber",
-                                   "location": "FRU",
-                                   "name": "FAULT",
-                                   "state": "Off"
-                                 }
-                               ],
-                               "description": "Power Supply 1",
-                               "name": " K1181227068",
-                               "userDescription": null,
-                               "manufactureDate": "2011-12-02",
-                               "partNumber": null,
-                               "firmware": [],
-                               "healthState": "GOOD",
-                               "machineType": null,
-                               "hardwareRevision": null,
-                               "FRU": null,
-                               "uri": "powerSupply/null",
-                               "productId": null,
-                               "powerAllocation": {
-                                 "totalInputPower": 0,
-                                 "totalOutputPower": 0
-                               },
-                               "powerState": null,
-                               "posID": null,
-                               "slots": [
-                                 0
-                               ],
-                               "manufacturer": null,
-                               "vpdID": null,
-                               "uuid": null,
-                               "productName": null,
-                               "fruSerialNumber": null,
-                               "inputVoltageMax": 0
-                             }
-                           ],
-                           "FRU": "",
-                           "thinkServerFru": [],
-                           "uri": "node/A59D5B36821111E1A9F5E41F13ED4F6A",
-                           "vnicMode": "disabled",
-                           "powerAllocation": {
-                             "maximumAllocatedPower": 0,
-                             "minimumAllocatedPower": 0
-                           },
-                           "expansionProductType": "",
-                           "powerStatus": 8,
-                           "bootOrder": {
-                             "uri": "node/A59D5B36821111E1A9F5E41F13ED4F6A/bootOrder",
-                             "bootOrderList": [
-                               {
-                                 "currentBootOrderDevices": [
-                                   "default"
-                                 ],
-                                 "bootType": "SingleUse",
-                                 "possibleBootOrderDevices": [
-                                   "setup",
-                                   "network",
-                                   "hd",
-                                   "cd",
-                                   "default"
-                                 ]
-                               }
-                             ]
-                           },
-                           "expansionProducts": [],
-                           "ipv6Addresses": [
-                             "fe80::e61f:13ff:feed:4f6f"
-                           ],
-                           "slots": [
-                             1
-                           ],
-                           "manufacturer": " IBM",
-                           "raidSettings": [],
-                           "vpdID": "",
-                           "uuid": "A59D5B36821111E1A9F5E41F13ED4F6A",
-                           "isConnectionTrusted": "true",
-                           "memoryModules": [
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "39170a03",
-                               "displayName": "DIMM 1",
-                               "slot": 1,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "1a8c3c13",
-                               "displayName": "DIMM 2",
-                               "slot": 2,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "d673191b",
-                               "displayName": "DIMM 4",
-                               "slot": 4,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "1a8c3c0a",
-                               "displayName": "DIMM 5",
-                               "slot": 5,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "354074cd",
-                               "displayName": "DIMM 8",
-                               "slot": 8,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "d673192d",
-                               "displayName": "DIMM 9",
-                               "slot": 9,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "d673192e",
-                               "displayName": "DIMM 11",
-                               "slot": 11,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "354074c3",
-                               "displayName": "DIMM 12",
-                               "slot": 12,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "354074c7",
-                               "displayName": "DIMM 13",
-                               "slot": 13,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "1a8c3c82",
-                               "displayName": "DIMM 14",
-                               "slot": 14,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "d67318fb",
-                               "displayName": "DIMM 16",
-                               "slot": 16,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "1a8c3c75",
-                               "displayName": "DIMM 17",
-                               "slot": 17,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "d67318f3",
-                               "displayName": "DIMM 20",
-                               "slot": 20,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "d67318ff",
-                               "displayName": "DIMM 21",
-                               "slot": 21,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "d67318ef",
-                               "displayName": "DIMM 23",
-                               "slot": 23,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             },
-                             {
-                               "model": "",
-                               "voltage": null,
-                               "speed": 12800,
-                               "manufacturer": "Micron Technology",
-                               "capacity": 8,
-                               "serialNumber": "35407515",
-                               "displayName": "DIMM 24",
-                               "slot": 24,
-                               "type": "DDR3 SDRAM",
-                               "partNumber": "36JSF1G72PZ-1G6M1 "
-                             }
-                           ],
-                           "fruSerialNumber": "Y015UN23X06L",
-                           "secureBootMode": {
-                             "possibleValues": [],
-                             "currentValue": ""
-                           },
-                           "tlsVersion": {
-                             "possibleValues": [
-                               "TLS_10",
-                               "TLS_11",
-                               "TLS_12",
-                               "unsupported"
-                             ],
-                             "currentValue": "unsupported"
-                           },
-                           "model": "AC1",
-                           "isScalable": false,
-                           "expansionCardSlots": 0,
-                           "fans": [],
-                           "isITME": false,
-                           "hostMacAddresses": "",
-                           "contact": "",
-                           "dataHandle": 0,
-                           "ipv4Addresses": [
-                             "10.243.9.111"
-                           ],
-                           "cmmDisplayName": "",
-                           "backedBy": "real",
-                           "complexID": -1,
-                           "name": "IMM-e41f13ed4f6f",
-                           "memorySlots": 0,
-                           "drives": [],
-                           "cmmHealthState": "Normal",
-                           "userDescription": "",
-                           "subSlots": [],
-                           "partNumber": null,
-                           "excludedHealthState": "Normal",
-                           "machineType": "7914",
-                           "isRemotePresenceEnabled": false,
-                           "pciDevices": [],
-                           "domainName": "",
-                           "processors": [
-                             {
-                               "speed": 2.7,
-                               "manufacturer": "Intel(R) Corporation",
-                               "family": "Intel(R) Xeon(R) processor",
-                               "displayName": "",
-                               "slot": 1,
-                               "productVersion": "Intel(R) Xeon(R) CPU E5-2680 0 @ 2.70GHz",
-                               "cores": 8
-                             },
-                             {
-                               "speed": 2.7,
-                               "manufacturer": "Intel(R) Corporation",
-                               "family": "Intel(R) Xeon(R) processor",
-                               "displayName": "",
-                               "slot": 2,
-                               "productVersion": "Intel(R) Xeon(R) CPU E5-2680 0 @ 2.70GHz",
-                               "cores": 8
-                             }
-                           ],
-                           "processorSlots": 0,
-                           "pciCapabilities": [],
-                           "productId": "",
-                           "hasOS": false,
-                           "bootMode": {
-                             "possibleValues": [
-                               "uefi",
-                               "bios"
-                             ],
-                             "currentValue": "unspecified"
-                           },
-                           "ports": [],
-                           "embeddedHypervisorPresence": false,
-                           "posID": "",
-                           "nist": {
-                             "possibleValues": [
-                               "Compatibility",
-                               "Nist_800_131A_Strict",
-                               "Nist_800_131A_Custom",
-                               "unsupported"
-                             ],
-                             "currentValue": "unsupported"
-                           },
-                           "overallHealthState": "Normal",
-                           "subType": "LegacyServer",
-                           "partitionID": -1,
-                           "flashStorage": [],
-                           "productName": "System x3550 M4"
-                         },
-                         "itemLocation": "",
-                         "itemHeight": 1,
-                         "itemLocationRoom": ""
-                       }
-                     ],
-                     "placeholderList": [],
-                     "switchList": [],
-                     "room": ""
-                   }
-                 ]
-               }'
+      string:  '{
+                  "cabinetList": [{
+                    "storageList": [],
+                    "cabinetName": "cabinet71",
+                    "height": 42,
+                    "complexList": [],
+                    "chassisList": [{
+                      "itemName": "SN#Y034BG16E02C",
+                      "itemUUID": "9841028B07714FD09D9297C6D1A4943E",
+                      "itemParentUUID": "",
+                      "itemLocationRoom": "",
+                      "itemLocationRack": "",
+                      "itemLocation": "",
+                      "itemLowerUnit": 0,
+                      "itemType": "CHASSIS",
+                      "itemHeight": 10,
+                      "itemSubType": "BladeCenter-X",
+                      "itemInventory": {
+                        "name": "SN#Y034BG16E02C",
+                        "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                        "status": {
+                          "message": "MANAGED",
+                          "name": "MANAGED"
+                        },
+                        "accessState": "Online",
+                        "overallHealthState": "Warning",
+                        "hostname": "MM5CF3FC25D8EF",
+                        "productName": "IBM Chassis Midplane",
+                        "displayName": "SN#Y034BG16E02C",
+                        "type": "Chassis",
+                        "manufacturer": "IBM",
+                        "machineType": "7893",
+                        "model": "92X",
+                        "mgmtProcIPaddress": "10.243.14.175",
+                        "serialNumber": "100080A",
+                        "partNumber": "88Y6660",
+                        "domainName": "",
+                        "FQDN": "",
+                        "userDescription": "",
+                        "description": "Lenovo Flex System Chassis",
+                        "location": {
+                          "lowestRackUnit": 0,
+                          "location": "No Location Configured",
+                          "rack": "",
+                          "room": ""
+                        },
+                        "height": 10,
+                        "powerAllocation": {
+                          "midPlaneCardMaximumAllocatedPower": 38,
+                          "remainingOutputPower": 4794,
+                          "totalInputPower": 11434,
+                          "allocatedOutputPower": 3622,
+                          "totalOutputPower": 8416,
+                          "midPlaneCardMinimumAllocatedPower": 38
+                        },
+                        "manufacturerId": "20301",
+                        "productId": "336",
+                        "vpdID": "336",
+                        "posID": "14",
+                        "cmmHealthState": "Non-Critical",
+                        "powerSupplySlots": 6,
+                        "fanSlots": 10,
+                        "passThroughModules": [],
+                        "switchSlots": 4,
+                        "leds": [{
+                          "name": "Location",
+                          "state": "Off",
+                          "color": "Blue",
+                          "location": "FrontPanel"
+                        }, {
+                          "name": "FAULT",
+                          "state": "Off",
+                          "color": "Amber",
+                          "location": "FrontPanel"
+                        }, {
+                          "name": "Information",
+                          "state": "On",
+                          "color": "Amber",
+                          "location": "FrontPanel"
+                        }],
+                        "errorFields": [],
+                        "powerSupplies": [{
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "inputVoltageIsAC": true,
+                          "inputVoltageMin": -1,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Power Supply 01",
+                          "leds": [{
+                            "name": "OUT",
+                            "state": "Off",
+                            "color": "Green",
+                            "location": "Planar"
+                          }, {
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "Planar"
+                          }, {
+                            "name": "IN",
+                            "state": "Off",
+                            "color": "Green",
+                            "location": "Planar"
+                          }],
+                          "description": "2100W Power Supply",
+                          "name": "Power Supply 01",
+                          "cmmHealthState": "Non-Critical",
+                          "userDescription": "",
+                          "manufactureDate": "4712",
+                          "partNumber": "69Y5828",
+                          "firmware": [{
+                            "name": "Power Supply Firmware",
+                            "date": "",
+                            "type": "Power Supply Firmware",
+                            "build": "",
+                            "version": "5",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "healthState": "NA",
+                          "machineType": "",
+                          "hardwareRevision": "2.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "powerSupply/BBF1B00932194346AA51BD75333FCB22",
+                          "productId": "304",
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "71",
+                          "slots": [
+                            1
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "BBF1B00932194346AA51BD75333FCB22",
+                          "productName": "IBM Flex System Enterprise Chassis 2100W Power Module",
+                          "fruSerialNumber": "ZK10812BL00S",
+                          "inputVoltageMax": -1,
+                          "FRU": "69Y5829",
+                          "vpdID": "128"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "inputVoltageIsAC": true,
+                          "inputVoltageMin": 200,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Power Supply 03",
+                          "leds": [{
+                            "name": "OUT",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }, {
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "Planar"
+                          }, {
+                            "name": "IN",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }],
+                          "description": "2100W Power Supply",
+                          "name": "Power Supply 03",
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "4312",
+                          "partNumber": "69Y5828",
+                          "firmware": [{
+                            "name": "Power Supply Firmware",
+                            "date": "",
+                            "type": "Power Supply Firmware",
+                            "build": "",
+                            "version": "5",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "healthState": "NA",
+                          "machineType": "",
+                          "hardwareRevision": "2.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "powerSupply/146F3252201D449C81E85D84DA11C557",
+                          "productId": "304",
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "71",
+                          "slots": [
+                            3
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "146F3252201D449C81E85D84DA11C557",
+                          "productName": "IBM Flex System Enterprise Chassis 2100W Power Module",
+                          "fruSerialNumber": "ZK10812AS003",
+                          "inputVoltageMax": 240,
+                          "FRU": "69Y5829",
+                          "vpdID": "128"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "inputVoltageIsAC": true,
+                          "inputVoltageMin": 200,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Power Supply 04",
+                          "leds": [{
+                            "name": "OUT",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }, {
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "Planar"
+                          }, {
+                            "name": "IN",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }],
+                          "description": "2100W Power Supply",
+                          "name": "Power Supply 04",
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "5112",
+                          "partNumber": "69Y5830",
+                          "firmware": [{
+                            "name": "Power Supply Firmware",
+                            "date": "",
+                            "type": "Power Supply Firmware",
+                            "build": "",
+                            "version": "14",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "healthState": "NA",
+                          "machineType": "",
+                          "hardwareRevision": "2.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "powerSupply/6B48B50A4A8611E20002000200020002",
+                          "productId": "303",
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "70",
+                          "slots": [
+                            4
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "6B48B50A4A8611E20002000200020002",
+                          "productName": "IBM Flex System Enterprise Chassis 2100W Power Module",
+                          "fruSerialNumber": "ZK11512CJ006",
+                          "inputVoltageMax": 240,
+                          "FRU": "69Y5831",
+                          "vpdID": "128"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "inputVoltageIsAC": true,
+                          "inputVoltageMin": 200,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Power Supply 05",
+                          "leds": [{
+                            "name": "OUT",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }, {
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "Planar"
+                          }, {
+                            "name": "IN",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }],
+                          "description": "2100W Power Supply",
+                          "name": "Power Supply 05",
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "4212",
+                          "partNumber": "69Y5830",
+                          "firmware": [{
+                            "name": "Power Supply Firmware",
+                            "date": "",
+                            "type": "Power Supply Firmware",
+                            "build": "",
+                            "version": "14",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "healthState": "NA",
+                          "machineType": "",
+                          "hardwareRevision": "2.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "powerSupply/44FFE5051D7511E200A500A500A500A5",
+                          "productId": "303",
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "70",
+                          "slots": [
+                            5
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "44FFE5051D7511E200A500A500A500A5",
+                          "productName": "IBM Flex System Enterprise Chassis 2100W Power Module",
+                          "fruSerialNumber": "ZK11512AG030",
+                          "inputVoltageMax": 240,
+                          "FRU": "69Y5831",
+                          "vpdID": "128"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "inputVoltageIsAC": true,
+                          "inputVoltageMin": 200,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Power Supply 06",
+                          "leds": [{
+                            "name": "OUT",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }, {
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "Planar"
+                          }, {
+                            "name": "IN",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }],
+                          "description": "2100W Power Supply",
+                          "name": "Power Supply 06",
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "4212",
+                          "partNumber": "69Y5830",
+                          "firmware": [{
+                            "name": "Power Supply Firmware",
+                            "date": "",
+                            "type": "Power Supply Firmware",
+                            "build": "",
+                            "version": "14",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "healthState": "NA",
+                          "machineType": "",
+                          "hardwareRevision": "2.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "powerSupply/2407C4851E4711E200F200F200F200F2",
+                          "productId": "303",
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "70",
+                          "slots": [
+                            6
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "2407C4851E4711E200F200F200F200F2",
+                          "productName": "IBM Flex System Enterprise Chassis 2100W Power Module",
+                          "fruSerialNumber": "ZK11512AG00D",
+                          "inputVoltageMax": 240,
+                          "FRU": "69Y5831",
+                          "vpdID": "128"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "inputVoltageIsAC": true,
+                          "inputVoltageMin": 200,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Power Supply 02",
+                          "leds": [{
+                            "name": "OUT",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }, {
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "Planar"
+                          }, {
+                            "name": "IN",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "Planar"
+                          }],
+                          "description": "2100W Power Supply",
+                          "name": "Power Supply 02",
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "4212",
+                          "partNumber": "69Y5830",
+                          "firmware": [{
+                            "name": "Power Supply Firmware",
+                            "date": "",
+                            "type": "Power Supply Firmware",
+                            "build": "",
+                            "version": "14",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "healthState": "NA",
+                          "machineType": "",
+                          "hardwareRevision": "2.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "powerSupply/25D486841E4D11E20048004800480048",
+                          "productId": "303",
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "70",
+                          "slots": [
+                            2
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "25D486841E4D11E20048004800480048",
+                          "productName": "IBM Flex System Enterprise Chassis 2100W Power Module",
+                          "fruSerialNumber": "ZK11512AG02R",
+                          "inputVoltageMax": 240,
+                          "FRU": "69Y5831",
+                          "vpdID": "128"
+                        }],
+                        "uri": "chassis/9841028B07714FD09D9297C6D1A4943E",
+                        "isConnectionTrusted": "true",
+                        "tlsVersion": {
+                          "possibleValues": [
+                            "TLS_12_Server",
+                            "unsupported",
+                            "TLS_12_Server_Client",
+                            "SSL_30"
+                          ],
+                          "currentValue": "TLS_12_Server"
+                        },
+                        "encapsulation": {
+                          "encapsulationMode": "normal"
+                        },
+                        "complex": [{
+                          "slots": [
+                            9,
+                            10
+                          ],
+                          "complexID": "14059BC6",
+                          "partitionCount": 1,
+                          "uuid": "645553F8894011E3A5F36CAE8B704B20",
+                          "nodeCount": 1,
+                          "orphanNodes": [],
+                          "partition": [{
+                            "slots": [
+                              9,
+                              10
+                            ],
+                            "partitionID": 1,
+                            "uuid": "",
+                            "nodes": [{
+                              "name": "ite-nh-1374",
+                              "uuid": "645553F8894011E3A5F36CAE8B704B20",
+                              "status": {
+                                "message": "managed",
+                                "name": "MANAGED"
+                              },
+                              "hostname": "IMM2-6cae8b6f1411",
+                              "overallHealthState": "Normal",
+                              "productName": "IBM Flex System x880 X6 Compute Node with embedded 10Gb Virtual Fabric",
+                              "type": "ITE",
+                              "manufacturer": "IBM",
+                              "machineType": "7903",
+                              "model": "AC1",
+                              "mgmtProcIPaddress": "10.243.13.230",
+                              "arch": "x86",
+                              "serialNumber": "23ZTXN9",
+                              "partNumber": "00AN716",
+                              "FRU": "47C2239",
+                              "fruSerialNumber": "YC30BG3CB010",
+                              "domainName": "",
+                              "FQDN": "10.243.13.230",
+                              "powerStatus": 5,
+                              "userDescription": "",
+                              "macAddress": "6C:AE:8B:6F:14:11,6C:AE:8B:6F:14:12",
+                              "hostMacAddresses": "6C:AE:8B:70:4B:20,6C:AE:8B:70:4B:24,6C:AE:8B:70:4B:28,6C:AE:8B:70:4B:2C",
+                              "tlsVersion": {
+                                "possibleValues": [
+                                  "unsupported",
+                                  "TLS_12",
+                                  "TLS_11",
+                                  "TLS_10"
+                                ],
+                                "currentValue": "Unknown"
+                              },
+                              "nist": {
+                                "possibleValues": [
+                                  "Nist_800_131A_Strict",
+                                  "unsupported",
+                                  "Compatibility"
+                                ],
+                                "currentValue": "Unknown"
+                              },
+                              "bootMode": {
+                                "possibleValues": [
+                                  "UEFI Mode",
+                                  "Legacy Mode"
+                                ],
+                                "currentValue": "UEFI Mode"
+                              },
+                              "location": {
+                                "lowestRackUnit": 0,
+                                "location": "NC",
+                                "rack": "",
+                                "room": ""
+                              },
+                              "lanOverUsb": "enabled",
+                              "description": "IBM Flex System x880 X6 + 10G",
+                              "mgmtProcType": "IMM2",
+                              "isRemotePresenceEnabled": true,
+                              "leds": [{
+                                "name": "DIMM 48",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 13",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 2",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "Fault",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FrontPanel"
+                              }, {
+                                "name": "DIMM 33",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 28",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "Mezz Exp 2",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "DIMM 23",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "SSD6",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "DIMM 38",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 18",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 7",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 34",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "SCALE_LINK",
+                                "state": "Off",
+                                "color": "Green",
+                                "location": "Planar"
+                              }, {
+                                "name": "IMM Fault",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "SAS BP 2 Error",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "Check Log",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FrontPanel"
+                              }, {
+                                "name": "Identification",
+                                "state": "Off",
+                                "color": "Blue",
+                                "location": "FrontPanel"
+                              }, {
+                                "name": "SMP",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 44",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "SCALE",
+                                "state": "Off",
+                                "color": "Unknown",
+                                "location": "Planar"
+                              }, {
+                                "name": "S BRD",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "LightPathCard"
+                              }, {
+                                "name": "DIMM 22",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 39",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "MEM",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "LightPathCard"
+                              }, {
+                                "name": "LP",
+                                "state": "On",
+                                "color": "Green",
+                                "location": "LightPathCard"
+                              }, {
+                                "name": "DIMM 12",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "NMI",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "LightPathCard"
+                              }, {
+                                "name": "Power",
+                                "state": "Blinking",
+                                "color": "Green",
+                                "location": "FrontPanel"
+                              }, {
+                                "name": "Mezz Exp 1",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "DIMM 29",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "SSD7",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "DIMM 5",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "SCALE_ERROR",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 42",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 19",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 32",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "MIS",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "LightPathCard"
+                              }, {
+                                "name": "M5115 Flt",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "DIMM 45",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 25",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 8",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 1",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 35",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "SSD4",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "Mezz Exp 4",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "DIMM 31",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "BMC Heartbeat",
+                                "state": "Blinking",
+                                "color": "Green",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 15",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 21",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 46",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 9",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 4",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 41",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "CPU 2",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 26",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DC Fault",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 36",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "CMOS Batt Errror",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 16",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 11",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 30",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "Mezz Exp 3",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "SSD5",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "ADJ",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "LightPathCard"
+                              }, {
+                                "name": "DIMM 14",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 3",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "CPU 1",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 40",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "SAS BP 1 Error",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 24",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "TEMP",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "LightPathCard"
+                              }, {
+                                "name": "DIMM 37",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 47",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 43",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 17",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "M5115 SCp",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "FRU"
+                              }, {
+                                "name": "DIMM 6",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 27",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 20",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }, {
+                                "name": "DIMM 10",
+                                "state": "Off",
+                                "color": "Yellow",
+                                "location": "Planar"
+                              }],
+                              "expansionCards": [],
+                              "firmware": [{
+                                "name": "UEFI Firmware/BIOS",
+                                "date": "2017-12-30T00:00:00Z",
+                                "type": "UEFI",
+                                "build": "N2E127EUS",
+                                "version": "1.80",
+                                "role": "Primary",
+                                "status": "Active"
+                              }, {
+                                "name": "IMM2 Firmware",
+                                "date": "2018-01-17T00:00:00Z",
+                                "type": "IMM2",
+                                "build": "1AOO81E",
+                                "version": "6.60",
+                                "role": "Primary",
+                                "status": "Active"
+                              }, {
+                                "name": "DSA Diagnostic Software",
+                                "date": "2017-06-23T00:00:00Z",
+                                "type": "DSA",
+                                "build": "DSYTE1W",
+                                "version": "9.65",
+                                "role": "Primary",
+                                "status": "Active"
+                              }, {
+                                "name": "UEFI Backup Firmware/BIOS",
+                                "date": "2016-10-13T00:00:00Z",
+                                "type": "UEFI-Backup",
+                                "build": "N2E121BUS",
+                                "version": "1.50",
+                                "role": "Backup",
+                                "status": "Inactive"
+                              }, {
+                                "name": "IMM2 Backup Firmware",
+                                "date": "2018-01-17T00:00:00Z",
+                                "type": "IMM2-Backup",
+                                "build": "1AOO81E",
+                                "version": "6.60",
+                                "role": "Backup",
+                                "status": "Inactive"
+                              }],
+                              "powerSupplies": [],
+                              "ipv4Addresses": [
+                                "10.243.13.230",
+                                "169.254.95.118"
+                              ],
+                              "ipv6Addresses": [
+                                "fd55:faaf:e1ab:2021:6eae:8bff:fe6f:1411",
+                                "fe80:0:0:0:6eae:8bff:fe6f:1411"
+                              ],
+                              "raidSettings": [],
+                              "drives": [],
+                              "memoryModules": [{
+                                "model": "DDR3",
+                                "speed": 1600,
+                                "manufacturer": "Samsung",
+                                "capacity": 4,
+                                "serialNumber": "019D42AE",
+                                "displayName": "DIMM 25",
+                                "slot": 25,
+                                "type": "DDR3",
+                                "partNumber": "M393B5270QB0-YK0",
+                                "speedMBs": 0
+                              }, {
+                                "model": "DDR3",
+                                "speed": 1600,
+                                "manufacturer": "Samsung",
+                                "capacity": 4,
+                                "serialNumber": "019D430E",
+                                "displayName": "DIMM 28",
+                                "slot": 28,
+                                "type": "DDR3",
+                                "partNumber": "M393B5270QB0-YK0",
+                                "speedMBs": 0
+                              }, {
+                                "model": "DDR3",
+                                "speed": 1600,
+                                "manufacturer": "Samsung",
+                                "capacity": 4,
+                                "serialNumber": "019D4253",
+                                "displayName": "DIMM 45",
+                                "slot": 45,
+                                "type": "DDR3",
+                                "partNumber": "M393B5270QB0-YK0",
+                                "speedMBs": 0
+                              }, {
+                                "model": "DDR3",
+                                "speed": 1600,
+                                "manufacturer": "Samsung",
+                                "capacity": 4,
+                                "serialNumber": "019D4275",
+                                "displayName": "DIMM 48",
+                                "slot": 48,
+                                "type": "DDR3",
+                                "partNumber": "M393B5270QB0-YK0",
+                                "speedMBs": 0
+                              }],
+                              "processors": [{
+                                "speed": 2.3,
+                                "manufacturer": "Intel(R) Corporation",
+                                "family": "PENTIUM_R_4",
+                                "displayName": "Intel(R) Xeon(R) CPU E7-8850 v2 @ 2.30GHz",
+                                "slot": 1,
+                                "productVersion": "Intel(R) Xeon(R) CPU E7-8850 v2 @ 2.30GHz",
+                                "cores": 12,
+                                "socket": ""
+                              }, {
+                                "speed": 2.3,
+                                "manufacturer": "Intel(R) Corporation",
+                                "family": "PENTIUM_R_4",
+                                "displayName": "Intel(R) Xeon(R) CPU E7-8850 v2 @ 2.30GHz",
+                                "slot": 2,
+                                "productVersion": "Intel(R) Xeon(R) CPU E7-8850 v2 @ 2.30GHz",
+                                "cores": 12,
+                                "socket": ""
+                              }],
+                              "pciDevices": [{
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "OneConnect 10G/40G Flash Image",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "",
+                                  "version": "11.1.152.22",
+                                  "softwareID": "10DFE812"
+                                }],
+                                "pciRevision": "10",
+                                "pciBusNumber": "139",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "3",
+                                "name": "N/A",
+                                "portInfo": {
+                                  "physicalPorts": [{
+                                    "portType": "ETHERNET",
+                                    "portNumber": 4,
+                                    "logicalPorts": [{
+                                      "portType": "ETHERNET",
+                                      "portNumber": 1,
+                                      "logicalPortIndex": 1,
+                                      "addresses": "6CAE8B704B2C",
+                                      "vnicMode": false
+                                    }],
+                                    "peerBay": 0,
+                                    "physicalPortIndex": 4
+                                  }]
+                                },
+                                "pciSubID": "e812",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": true,
+                                "pciSubVendorID": "10df",
+                                "isAddOnCard": false,
+                                "posID": "720",
+                                "vpdID": "10df",
+                                "class": "Network controller"
+                              }, {
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "OneConnect 10G/40G Flash Image",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "",
+                                  "version": "11.1.152.22",
+                                  "softwareID": "10DFE812"
+                                }],
+                                "pciRevision": "10",
+                                "pciBusNumber": "139",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "1",
+                                "name": "N/A",
+                                "portInfo": {
+                                  "physicalPorts": [{
+                                    "portType": "ETHERNET",
+                                    "portNumber": 2,
+                                    "logicalPorts": [{
+                                      "portType": "ETHERNET",
+                                      "portNumber": 1,
+                                      "logicalPortIndex": 1,
+                                      "addresses": "6CAE8B704B24",
+                                      "vnicMode": false
+                                    }],
+                                    "peerBay": 2,
+                                    "physicalPortIndex": 2
+                                  }]
+                                },
+                                "pciSubID": "e812",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": true,
+                                "pciSubVendorID": "10df",
+                                "isAddOnCard": false,
+                                "posID": "720",
+                                "vpdID": "10df",
+                                "class": "Network controller"
+                              }, {
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "OneConnect 10G/40G Flash Image",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "",
+                                  "version": "11.1.152.22",
+                                  "softwareID": "10DFE812"
+                                }],
+                                "pciRevision": "10",
+                                "pciBusNumber": "139",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "2",
+                                "name": "N/A",
+                                "portInfo": {
+                                  "physicalPorts": [{
+                                    "portType": "ETHERNET",
+                                    "portNumber": 3,
+                                    "logicalPorts": [{
+                                      "portType": "ETHERNET",
+                                      "portNumber": 1,
+                                      "logicalPortIndex": 1,
+                                      "addresses": "6CAE8B704B28",
+                                      "vnicMode": false
+                                    }],
+                                    "peerBay": 0,
+                                    "physicalPortIndex": 3
+                                  }]
+                                },
+                                "pciSubID": "e812",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": true,
+                                "pciSubVendorID": "10df",
+                                "isAddOnCard": false,
+                                "posID": "720",
+                                "vpdID": "10df",
+                                "class": "Network controller"
+                              }, {
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "OneConnect 10G/40G Flash Image",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "",
+                                  "version": "11.1.152.22",
+                                  "softwareID": "10DFE812"
+                                }],
+                                "pciRevision": "10",
+                                "pciBusNumber": "139",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "0",
+                                "name": "N/A",
+                                "portInfo": {
+                                  "physicalPorts": [{
+                                    "portType": "ETHERNET",
+                                    "portNumber": 1,
+                                    "logicalPorts": [{
+                                      "portType": "ETHERNET",
+                                      "portNumber": 1,
+                                      "logicalPortIndex": 1,
+                                      "addresses": "6CAE8B704B20",
+                                      "vnicMode": false
+                                    }],
+                                    "peerBay": 1,
+                                    "physicalPortIndex": 1
+                                  }]
+                                },
+                                "pciSubID": "e812",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": true,
+                                "pciSubVendorID": "10df",
+                                "isAddOnCard": false,
+                                "posID": "720",
+                                "vpdID": "10df",
+                                "class": "Network controller"
+                              }, {
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "MegaRAID Controller Firmware",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "2017-06-15T00:00:00Z",
+                                  "version": "24.21.0-0016",
+                                  "softwareID": "101404B4"
+                                }],
+                                "slotSupportsHotPlug": "false",
+                                "pciRevision": "2",
+                                "pciBusNumber": "14",
+                                "pciDeviceNumber": "0",
+                                "slotNumber": "0",
+                                "pciFunctionNumber": "0",
+                                "manufacturer": "IBM",
+                                "name": "ServeRAID M1210e",
+                                "portInfo": {},
+                                "uuid": "0000000000000000500507605D0012A4",
+                                "productName": "ServeRAID M1210e",
+                                "partNumber": "N/A",
+                                "fruSerialNumber": "N/A",
+                                "slotName": "",
+                                "pciSubID": "4b4",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": false,
+                                "pciSubVendorID": "1014",
+                                "isAddOnCard": true,
+                                "FRU": "N/A",
+                                "posID": "5f",
+                                "vpdID": "1000",
+                                "class": "Mass storage controller"
+                              }, {
+                                "firmware": [],
+                                "pciRevision": "0",
+                                "pciBusNumber": "9",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "0",
+                                "name": "",
+                                "portInfo": {},
+                                "pciSubID": "0",
+                                "fodUniqueID": "",
+                                "isAgentless": false,
+                                "pciSubVendorID": "0",
+                                "isAddOnCard": false,
+                                "posID": "534",
+                                "vpdID": "102b",
+                                "class": "Display controller"
+                              }],
+                              "accessState": "Online",
+                              "manufacturerId": "20301",
+                              "addinCardSlots": 0,
+                              "driveBays": 8,
+                              "errorFields": [],
+                              "bladeState": 1,
+                              "activationKeys": [],
+                              "uri": "nodes/645553F8894011E3A5F36CAE8B704B20",
+                              "vnicMode": "disabled",
+                              "powerAllocation": {
+                                "maximumAllocatedPower": 296,
+                                "minimumAllocatedPower": 215
+                              },
+                              "expansionProductType": "",
+                              "bootOrder": {
+                                "uri": "nodes/645553F8894011E3A5F36CAE8B704B20/bootOrder",
+                                "bootOrderList": [{
+                                  "currentBootOrderDevices": [
+                                    "Red Hat Enterprise Linux",
+                                    "CD/DVD Rom",
+                                    "Hard Disk 0",
+                                    "PXE Network"
+                                  ],
+                                  "bootType": "Permanent",
+                                  "possibleBootOrderDevices": [
+                                    "Red Hat Enterprise Linux",
+                                    "CD/DVD Rom",
+                                    "Hard Disk 0",
+                                    "PXE Network",
+                                    "Floppy Disk",
+                                    "Hard Disk 1",
+                                    "Hard Disk 2",
+                                    "Hard Disk 3",
+                                    "Hard Disk 4",
+                                    "USB Storage",
+                                    "Diagnostics",
+                                    "iSCSI",
+                                    "iSCSI Critical",
+                                    "Embedded Hypervisor",
+                                    "Legacy Only",
+                                    "IMM1",
+                                    "IMM2",
+                                    "DSA",
+                                    "USB0",
+                                    "USB1",
+                                    "USB2",
+                                    "USB3",
+                                    "USB4",
+                                    "SAS",
+                                    "NIC1",
+                                    "NIC2",
+                                    "NIC3",
+                                    "NIC4",
+                                    "VNIC1",
+                                    "VNIC2",
+                                    "VNIC3",
+                                    "VNIC4",
+                                    "VNIC5",
+                                    "VNIC6",
+                                    "VNIC7",
+                                    "VNIC8",
+                                    "VNIC9",
+                                    "VNIC10",
+                                    "VNIC11",
+                                    "VNIC12",
+                                    "Mezzanine1Device1",
+                                    "Mezzanine1Device2",
+                                    "Mezzanine1Device3",
+                                    "Mezzanine1Device4",
+                                    "Mezzanine1Device5",
+                                    "Mezzanine1Device6",
+                                    "Mezzanine2Device1",
+                                    "Mezzanine2Device2",
+                                    "Mezzanine2Device3",
+                                    "Mezzanine2Device4",
+                                    "Mezzanine2Device5",
+                                    "Mezzanine2Device6",
+                                    "Mezzanine3Device1",
+                                    "Mezzanine3Device2",
+                                    "Mezzanine4Device1",
+                                    "Mezzanine4Device2"
+                                  ]
+                                }, {
+                                  "currentBootOrderDevices": [
+                                    "PXE Network",
+                                    "CD/DVD Rom",
+                                    "Hard Disk 0"
+                                  ],
+                                  "bootType": "WakeOnLAN",
+                                  "possibleBootOrderDevices": [
+                                    "PXE Network",
+                                    "CD/DVD Rom",
+                                    "Hard Disk 0",
+                                    "Red Hat Enterprise Linux",
+                                    "Floppy Disk",
+                                    "Hard Disk 1",
+                                    "Hard Disk 2",
+                                    "Hard Disk 3",
+                                    "Hard Disk 4",
+                                    "USB Storage",
+                                    "Diagnostics",
+                                    "iSCSI",
+                                    "iSCSI Critical",
+                                    "Embedded Hypervisor",
+                                    "Legacy Only",
+                                    "IMM1",
+                                    "IMM2",
+                                    "DSA",
+                                    "USB0",
+                                    "USB1",
+                                    "USB2",
+                                    "USB3",
+                                    "USB4",
+                                    "SAS",
+                                    "NIC1",
+                                    "NIC2",
+                                    "NIC3",
+                                    "NIC4",
+                                    "VNIC1",
+                                    "VNIC2",
+                                    "VNIC3",
+                                    "VNIC4",
+                                    "VNIC5",
+                                    "VNIC6",
+                                    "VNIC7",
+                                    "VNIC8",
+                                    "VNIC9",
+                                    "VNIC10",
+                                    "VNIC11",
+                                    "VNIC12",
+                                    "Mezzanine1Device1",
+                                    "Mezzanine1Device2",
+                                    "Mezzanine1Device3",
+                                    "Mezzanine1Device4",
+                                    "Mezzanine1Device5",
+                                    "Mezzanine1Device6",
+                                    "Mezzanine2Device1",
+                                    "Mezzanine2Device2",
+                                    "Mezzanine2Device3",
+                                    "Mezzanine2Device4",
+                                    "Mezzanine2Device5",
+                                    "Mezzanine2Device6",
+                                    "Mezzanine3Device1",
+                                    "Mezzanine3Device2",
+                                    "Mezzanine4Device1",
+                                    "Mezzanine4Device2"
+                                  ]
+                                }, {
+                                  "currentBootOrderDevices": [
+                                    "None"
+                                  ],
+                                  "bootType": "SingleUse",
+                                  "possibleBootOrderDevices": [
+                                    "None",
+                                    "PXE Network",
+                                    "Hard Disk 0",
+                                    "Diagnostics",
+                                    "CD/DVD Rom",
+                                    "Boot To F1",
+                                    "Hypervisor",
+                                    "Floppy Disk"
+                                  ]
+                                }]
+                              },
+                              "expansionProducts": [],
+                              "slots": [
+                                9,
+                                10
+                              ],
+                              "vpdID": "256",
+                              "partitionEnabled": true,
+                              "encapsulation": {
+                                "encapsulationMode": "notSupported"
+                              },
+                              "secureBootMode": {
+                                "possibleValues": [],
+                                "currentValue": ""
+                              },
+                              "expansionCardSlots": 4,
+                              "contact": "Fred",
+                              "dataHandle": 1522262049452,
+                              "cmmDisplayName": "Node 09",
+                              "backedBy": "real",
+                              "complexID": 335911878,
+                              "memorySlots": 48,
+                              "cmmHealthState": "Normal",
+                              "subSlots": [],
+                              "excludedHealthState": "Normal",
+                              "processorSlots": 2,
+                              "pciCapabilities": [
+                                "Raid Link",
+                                "OOB PCIe"
+                              ],
+                              "productId": "448",
+                              "hasOS": false,
+                              "ports": [{
+                                "ioModuleBay": 1,
+                                "portNumber": 1
+                              }, {
+                                "ioModuleBay": 2,
+                                "portNumber": 2
+                              }, {
+                                "ioModuleBay": 0,
+                                "portNumber": 3
+                              }, {
+                                "ioModuleBay": 0,
+                                "portNumber": 4
+                              }],
+                              "embeddedHypervisorPresence": false,
+                              "posID": "30",
+                              "subType": "Nantahala",
+                              "partitionID": 1,
+                              "flashStorage": [],
+                              "userDefinedName": "ite-nh-1374",
+                              "securityDescriptor": {
+                                "managedAuthSupported": true,
+                                "publicAccess": false,
+                                "uri": "nodes/645553f8894011e3a5f36cae8b704b20",
+                                "roleGroups": [],
+                                "managedAuthEnabled": true
+                              },
+                              "logicalID": 1,
+                              "primary": true,
+                              "parent": {
+                                "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                                "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                              },
+                              "bladeState_health": "GOOD",
+                              "bladeState_string": "ite-nh-1374",
+                              "dnsHostnames": [
+                                "10.243.13.230",
+                                "fd55:faaf:e1ab:2021:6eae:8bff:fe6f:1411"
+                              ],
+                              "addinCards": [],
+                              "faceplateIDs": [{
+                                "name": "front panel board 1",
+                                "vpdID": 0,
+                                "posID": 0,
+                                "productId": 0,
+                                "entityId": 0,
+                                "deviceId": 0
+                              }, {
+                                "name": "system board 1",
+                                "vpdID": 0,
+                                "posID": 0,
+                                "productId": 0,
+                                "entityId": 0,
+                                "deviceId": 0
+                              }],
+                              "lanOverUsbPortForwardingModes": [{
+                                "state": "disabled",
+                                "type": "DSA",
+                                "externalIPAddress": ""
+                              }],
+                              "m2Presence": false,
+                              "onboardPciDevices": [{
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "OneConnect 10G/40G Flash Image",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "",
+                                  "version": "11.1.152.22",
+                                  "softwareID": "10DFE812"
+                                }],
+                                "pciRevision": "10",
+                                "pciBusNumber": "139",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "3",
+                                "name": "N/A",
+                                "portInfo": {
+                                  "physicalPorts": [{
+                                    "portType": "ETHERNET",
+                                    "portNumber": 4,
+                                    "logicalPorts": [{
+                                      "portType": "ETHERNET",
+                                      "portNumber": 1,
+                                      "logicalPortIndex": 1,
+                                      "addresses": "6CAE8B704B2C",
+                                      "vnicMode": false
+                                    }],
+                                    "peerBay": 0,
+                                    "physicalPortIndex": 4
+                                  }]
+                                },
+                                "pciSubID": "e812",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": true,
+                                "pciSubVendorID": "10df",
+                                "isAddOnCard": false,
+                                "posID": "720",
+                                "vpdID": "10df",
+                                "class": "Network controller"
+                              }, {
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "OneConnect 10G/40G Flash Image",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "",
+                                  "version": "11.1.152.22",
+                                  "softwareID": "10DFE812"
+                                }],
+                                "pciRevision": "10",
+                                "pciBusNumber": "139",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "1",
+                                "name": "N/A",
+                                "portInfo": {
+                                  "physicalPorts": [{
+                                    "portType": "ETHERNET",
+                                    "portNumber": 2,
+                                    "logicalPorts": [{
+                                      "portType": "ETHERNET",
+                                      "portNumber": 1,
+                                      "logicalPortIndex": 1,
+                                      "addresses": "6CAE8B704B24",
+                                      "vnicMode": false
+                                    }],
+                                    "peerBay": 2,
+                                    "physicalPortIndex": 2
+                                  }]
+                                },
+                                "pciSubID": "e812",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": true,
+                                "pciSubVendorID": "10df",
+                                "isAddOnCard": false,
+                                "posID": "720",
+                                "vpdID": "10df",
+                                "class": "Network controller"
+                              }, {
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "OneConnect 10G/40G Flash Image",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "",
+                                  "version": "11.1.152.22",
+                                  "softwareID": "10DFE812"
+                                }],
+                                "pciRevision": "10",
+                                "pciBusNumber": "139",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "2",
+                                "name": "N/A",
+                                "portInfo": {
+                                  "physicalPorts": [{
+                                    "portType": "ETHERNET",
+                                    "portNumber": 3,
+                                    "logicalPorts": [{
+                                      "portType": "ETHERNET",
+                                      "portNumber": 1,
+                                      "logicalPortIndex": 1,
+                                      "addresses": "6CAE8B704B28",
+                                      "vnicMode": false
+                                    }],
+                                    "peerBay": 0,
+                                    "physicalPortIndex": 3
+                                  }]
+                                },
+                                "pciSubID": "e812",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": true,
+                                "pciSubVendorID": "10df",
+                                "isAddOnCard": false,
+                                "posID": "720",
+                                "vpdID": "10df",
+                                "class": "Network controller"
+                              }, {
+                                "firmware": [{
+                                  "revision": "0",
+                                  "classifications": [
+                                    13
+                                  ],
+                                  "status": "Active",
+                                  "name": "OneConnect 10G/40G Flash Image",
+                                  "role": "Primary",
+                                  "type": "Software Bundle",
+                                  "build": "0",
+                                  "date": "",
+                                  "version": "11.1.152.22",
+                                  "softwareID": "10DFE812"
+                                }],
+                                "pciRevision": "10",
+                                "pciBusNumber": "139",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "0",
+                                "name": "N/A",
+                                "portInfo": {
+                                  "physicalPorts": [{
+                                    "portType": "ETHERNET",
+                                    "portNumber": 1,
+                                    "logicalPorts": [{
+                                      "portType": "ETHERNET",
+                                      "portNumber": 1,
+                                      "logicalPortIndex": 1,
+                                      "addresses": "6CAE8B704B20",
+                                      "vnicMode": false
+                                    }],
+                                    "peerBay": 1,
+                                    "physicalPortIndex": 1
+                                  }]
+                                },
+                                "pciSubID": "e812",
+                                "fodUniqueID": "N/A",
+                                "isAgentless": true,
+                                "pciSubVendorID": "10df",
+                                "isAddOnCard": false,
+                                "posID": "720",
+                                "vpdID": "10df",
+                                "class": "Network controller"
+                              }, {
+                                "firmware": [],
+                                "pciRevision": "0",
+                                "pciBusNumber": "9",
+                                "pciDeviceNumber": "0",
+                                "pciFunctionNumber": "0",
+                                "name": "",
+                                "portInfo": {},
+                                "pciSubID": "0",
+                                "fodUniqueID": "",
+                                "isAgentless": false,
+                                "pciSubVendorID": "0",
+                                "isAddOnCard": false,
+                                "posID": "534",
+                                "vpdID": "102b",
+                                "class": "Display controller"
+                              }],
+                              "ipInterfaces": [{
+                                "name": "eth0",
+                                "label": "unknown",
+                                "IPv4enabled": true,
+                                "IPv4DHCPmode": "STATIC_ONLY",
+                                "IPv6enabled": true,
+                                "IPv6DHCPenabled": true,
+                                "IPv4assignments": [{
+                                  "id": 0,
+                                  "subnet": "255.255.224.0",
+                                  "gateway": "0.0.0.0",
+                                  "address": "10.243.13.230",
+                                  "type": "INUSE"
+                                }],
+                                "IPv6assignments": [{
+                                  "id": 0,
+                                  "scope": "Unknown",
+                                  "gateway": "0:0:0:0:0:0:0:0",
+                                  "source": "Unknown",
+                                  "address": "fe80:0:0:0:6eae:8bff:fe6f:1411",
+                                  "prefix": 64,
+                                  "type": "UNKNOWN"
+                                }, {
+                                  "id": 0,
+                                  "scope": "Global",
+                                  "gateway": "0:0:0:0:0:0:0:0",
+                                  "source": "Stateless",
+                                  "address": "fd55:faaf:e1ab:2021:6eae:8bff:fe6f:1411",
+                                  "prefix": 64,
+                                  "type": "INUSE"
+                                }],
+                                "IPv6statelessEnabled": true,
+                                "IPv6staticEnabled": false
+                              }],
+                              "parentComplexID": "14059BC6",
+                              "parentPartitionUUID": "645553F8894011E3A5F36CAE8B704B20",
+                              "isConnectionTrusted": "true",
+                              "isScalable": true,
+                              "isITME": false
+                            }]
+                          }]
+                        }],
+                        "energyPolicies": {
+                          "powerRedundancyMode": 4,
+                          "powerCappingPolicy": {
+                            "cappingPolicy": "OFF",
+                            "maxPowerCap": 8416,
+                            "powerCappingAllocUnit": "watts",
+                            "currentPowerCap": 0,
+                            "minPowerCap": 3622
+                          },
+                          "acousticAttenuationMode": "Off",
+                          "hotAirRecirculation": {
+                            "chassisBay": [{
+                              "sensorValue": 26,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 2,
+                              "sensorName": "Inlet Temp"
+                            }, {
+                              "sensorValue": 24.5,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 9,
+                              "sensorName": "Inlet 2 Temp"
+                            }, {
+                              "sensorValue": 26,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 5,
+                              "sensorName": "Inlet 2 Temp"
+                            }, {
+                              "sensorValue": 26,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 7,
+                              "sensorName": "Inlet 2 Temp"
+                            }, {
+                              "sensorValue": 25.5,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 5,
+                              "sensorName": "Inlet 1 Temp"
+                            }, {
+                              "sensorValue": 27,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 1,
+                              "sensorName": "Inlet Temp"
+                            }, {
+                              "sensorValue": 25,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 7,
+                              "sensorName": "Inlet 1 Temp"
+                            }, {
+                              "sensorValue": 29,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 0,
+                              "sensorName": "Chassis Ambient"
+                            }, {
+                              "sensorValue": 24,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 9,
+                              "sensorName": "Inlet 1 Temp"
+                            }, {
+                              "sensorValue": 27,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 3,
+                              "sensorName": "Inlet Temp"
+                            }, {
+                              "sensorValue": 26,
+                              "isExceeded": "N",
+                              "subSlot": -1,
+                              "slot": 4,
+                              "sensorName": "Inlet Temp"
+                            }],
+                            "maxVariation": 5,
+                            "isEnabled": true
+                          }
+                        },
+                        "fans": [{
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 03",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "Fan Module",
+                          "name": "Fan 03",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "3111",
+                          "partNumber": "88Y6671",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/CFCE24617D9D43CC9E81C9D2708AADFD",
+                          "productId": "341",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "10",
+                          "slots": [
+                            3
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "CFCE24617D9D43CC9E81C9D2708AADFD",
+                          "productName": "",
+                          "fruSerialNumber": "YK10GM17R032",
+                          "FRU": "81Y2910",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 07",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "Fan Module",
+                          "name": "Fan 07",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "2911",
+                          "partNumber": "88Y6671",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/8916BCFD09994DC0852F2AE459C8C1A5",
+                          "productId": "341",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "10",
+                          "slots": [
+                            7
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "8916BCFD09994DC0852F2AE459C8C1A5",
+                          "productName": "",
+                          "fruSerialNumber": "YK10GM17E013",
+                          "FRU": "81Y2910",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 10",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "40mm fan module",
+                          "name": "Fan 10",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "4311",
+                          "partNumber": "88Y6708",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "5.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/4A0345C753D44328AD4C489BA106C4A2",
+                          "productId": "339",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "8",
+                          "slots": [
+                            10
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "4A0345C753D44328AD4C489BA106C4A2",
+                          "productName": "IBM Flex System Enterprise Chassis 40mm Fan Module",
+                          "fruSerialNumber": "YK10GM1AL021",
+                          "FRU": "81Y2911",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 01",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "Fan Module",
+                          "name": "Fan 01",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "2911",
+                          "partNumber": "88Y6671",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/3F6CFF94E4BA4FDC90547CD917A8823F",
+                          "productId": "341",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "10",
+                          "slots": [
+                            1
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "3F6CFF94E4BA4FDC90547CD917A8823F",
+                          "productName": "",
+                          "fruSerialNumber": "YK10GM17E011",
+                          "FRU": "81Y2910",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 06",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "Fan Module",
+                          "name": "Fan 06",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "2911",
+                          "partNumber": "88Y6671",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/F56E4753FC5C4986B0B1E40778838C5E",
+                          "productId": "341",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "10",
+                          "slots": [
+                            6
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "F56E4753FC5C4986B0B1E40778838C5E",
+                          "productName": "",
+                          "fruSerialNumber": "YK10GM17E014",
+                          "FRU": "81Y2910",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 09",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "Fan Module",
+                          "name": "Fan 09",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "3211",
+                          "partNumber": "88Y6671",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/5A6BB1C84CFE4202A993A99502F995AE",
+                          "productId": "341",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "10",
+                          "slots": [
+                            9
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "5A6BB1C84CFE4202A993A99502F995AE",
+                          "productName": "",
+                          "fruSerialNumber": "YK10GM182005",
+                          "FRU": "81Y2910",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 08",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "Fan Module",
+                          "name": "Fan 08",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "3211",
+                          "partNumber": "88Y6671",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/0DB202EE8C5A4C979738EC4863080B0C",
+                          "productId": "341",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "10",
+                          "slots": [
+                            8
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "0DB202EE8C5A4C979738EC4863080B0C",
+                          "productName": "",
+                          "fruSerialNumber": "YK10GM182003",
+                          "FRU": "81Y2910",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 04",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "Fan Module",
+                          "name": "Fan 04",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "3111",
+                          "partNumber": "88Y6671",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/EF3B2F01CC2D45548553EE602BB2E3FE",
+                          "productId": "341",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "10",
+                          "slots": [
+                            4
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "EF3B2F01CC2D45548553EE602BB2E3FE",
+                          "productName": "",
+                          "fruSerialNumber": "YK10GM17R048",
+                          "FRU": "81Y2910",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 05",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "IBM Fan Pack",
+                          "name": "Fan 05",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "2611",
+                          "partNumber": "88Y6670",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/D507E9FCB40A49438C5D325398AC2614",
+                          "productId": "339",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "8",
+                          "slots": [
+                            5
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "D507E9FCB40A49438C5D325398AC2614",
+                          "productName": "40mm Fan Pack for Switch Cooling",
+                          "fruSerialNumber": "YK10GM16P043",
+                          "FRU": "81Y2911",
+                          "vpdID": "373"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "Fan",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan 02",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "Fan Module",
+                          "name": "Fan 02",
+                          "errorFields": [],
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "manufactureDate": "2911",
+                          "partNumber": "88Y6671",
+                          "firmware": [{
+                            "name": "Fan Controller",
+                            "date": "",
+                            "type": "Fan Controller",
+                            "build": "",
+                            "version": "226",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "hardwareRevision": "4.0",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "fan/405D0D58BAF04EEBB1FC4835D1362128",
+                          "productId": "341",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 0,
+                            "minimumAllocatedPower": 0
+                          },
+                          "powerState": "Unknown",
+                          "posID": "10",
+                          "slots": [
+                            2
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "405D0D58BAF04EEBB1FC4835D1362128",
+                          "productName": "",
+                          "fruSerialNumber": "YK10GM17E012",
+                          "FRU": "81Y2910",
+                          "vpdID": "373"
+                        }],
+                        "bladeSlots": 14,
+                        "contact": "No Contact Configured",
+                        "dataHandle": 1522324963818,
+                        "fanMuxes": [{
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "machineType": "",
+                          "status": "Normal",
+                          "hardwareRevision": "5.3",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "serialNumber": "",
+                          "type": "FanMux",
+                          "uri": "fanMux/2DF97BC434D611E3A6D6F7AC269DD74E",
+                          "productId": "338",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan Logic 01",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "manufacturer": "IBM",
+                          "slots": [
+                            1
+                          ],
+                          "description": "fan logic card",
+                          "name": "Fan Logic 01",
+                          "uuid": "2DF97BC434D611E3A6D6F7AC269DD74E",
+                          "cmmHealthState": "Normal",
+                          "manufactureDate": "4311",
+                          "productName": "IBM Flex System Enterprise Chassis Fan Logic Card",
+                          "fruSerialNumber": "Y031BG16P0DG",
+                          "partNumber": "49Y3276",
+                          "FRU": "94Y5805"
+                        }, {
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "machineType": "",
+                          "status": "Normal",
+                          "hardwareRevision": "5.3",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "serialNumber": "",
+                          "type": "FanMux",
+                          "uri": "fanMux/9771153D34D611E3A4A19875E55C1C6A",
+                          "productId": "338",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Fan Logic 02",
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "manufacturer": "IBM",
+                          "slots": [
+                            2
+                          ],
+                          "description": "fan logic card",
+                          "name": "Fan Logic 02",
+                          "uuid": "9771153D34D611E3A4A19875E55C1C6A",
+                          "cmmHealthState": "Normal",
+                          "manufactureDate": "4311",
+                          "productName": "IBM Flex System Enterprise Chassis Fan Logic Card",
+                          "fruSerialNumber": "Y031BG16P0FD",
+                          "partNumber": "49Y3276",
+                          "FRU": "94Y5805"
+                        }],
+                        "switches": [{
+                          "name": "IO Module 01",
+                          "uuid": "1B33D6D2036E86614567A897DC7A6200",
+                          "accessState": "Online",
+                          "overallHealthState": "Normal",
+                          "type": "Switch",
+                          "hostname": "",
+                          "description": "EN4093R 10Gb Ethernet Switch",
+                          "dnsHostnames": [
+                            "10.243.14.165",
+                            "fd55:faaf:e1ab:2021:aa97:dcff:fe7a:62ef"
+                          ],
+                          "FRU": "95Y3312",
+                          "fruSerialNumber": "Y010CM3BH087",
+                          "ipv4Addresses": [
+                            "10.243.14.165"
+                          ],
+                          "ipv6Addresses": [
+                            "fd55:faaf:e1ab:2021:aa97:dcff:fe7a:62ef",
+                            "fe80:0:0:0:aa97:dcff:fe7a:62ef"
+                          ],
+                          "macAddresses": [
+                            "A8:97:DC:7A:62:EF"
+                          ],
+                          "machineType": "",
+                          "manufacturer": "IBM",
+                          "manufacturerId": "20301",
+                          "model": "",
+                          "partNumber": "95Y3311",
+                          "posID": "33",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 100,
+                            "minimumAllocatedPower": 100
+                          },
+                          "powerState": "On",
+                          "productId": "471",
+                          "productName": "IBM Flex System Fabric EN4093R 10Gb Scalable Switch",
+                          "protectedMode": "False",
+                          "serialNumber": "",
+                          "slots": [
+                            1
+                          ],
+                          "stackMode": "Standby",
+                          "vpdID": "304",
+                          "attachedNodes": [
+                            "645553F8894011E3A5F36CAE8B704B20",
+                            "FA261DA6A6D411E2BE4A0090FA0D2ABA",
+                            "E6C27EC764BA11E1A6AA5CF3FC7F0B50",
+                            "B0D04B2122B211E280D5911FB6765E7D",
+                            "A909DE0CA6D511E2A32B0090FA086DF8"
+                          ],
+                          "backedBy": "real",
+                          "cmmDisplayName": "IO Module 01",
+                          "cmmHealthState": "Normal",
+                          "dataHandle": 1522261881528,
+                          "errorFields": [],
+                          "excludedHealthState": "Normal",
+                          "firmware": [{
+                            "name": "Boot ROM",
+                            "date": "2017-06-02T04:00:00Z",
+                            "type": "Boot ROM",
+                            "build": "",
+                            "version": "7.8.17.4",
+                            "status": "Active"
+                          }, {
+                            "name": "Main Application 1",
+                            "date": "2017-06-02T04:00:00Z",
+                            "type": "Main Application 1",
+                            "build": "",
+                            "version": "7.8.17.4",
+                            "status": "Active"
+                          }, {
+                            "name": "Main Application 2",
+                            "date": "2017-04-11T04:00:00Z",
+                            "type": "Main Application 2",
+                            "build": "",
+                            "version": "7.8.16.13",
+                            "status": "Not-Active"
+                          }],
+                          "ipInterfaces": [{
+                            "name": "ioe0",
+                            "label": "",
+                            "IPv4enabled": true,
+                            "IPv4DHCPmode": "DHCP_THEN_STATIC",
+                            "IPv6enabled": true,
+                            "IPv6DHCPenabled": true,
+                            "IPv4assignments": [{
+                              "id": 64,
+                              "subnet": "0.0.0.0",
+                              "gateway": "0.0.0.0",
+                              "address": "10.243.14.165",
+                              "type": "INUSE"
+                            }],
+                            "IPv6assignments": [{
+                              "id": 33,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Stateless",
+                              "address": "fd55:faaf:e1ab:2021:aa97:dcff:fe7a:62ef",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }, {
+                              "id": 2,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Static",
+                              "address": "0:0:0:0:0:0:0:0",
+                              "prefix": 64,
+                              "type": "CONFIGURED"
+                            }, {
+                              "id": 1,
+                              "scope": "LinkLocal",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Other",
+                              "address": "fe80:0:0:0:aa97:dcff:fe7a:62ef",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }],
+                            "IPv6statelessEnabled": true,
+                            "IPv6staticEnabled": false
+                          }],
+                          "leds": [{
+                            "name": "FRU Fault",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Enclosure Identify",
+                            "state": "Off",
+                            "color": "Blue",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Power",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "FrontPanel"
+                          }],
+                          "ntpPushEnabled": true,
+                          "ntpPushFrequency": 17,
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "switches/1B33D6D2036E86614567A897DC7A6200",
+                          "userDescription": "",
+                          "userDefinedName": "",
+                          "securityDescriptor": {
+                            "managedAuthSupported": true,
+                            "publicAccess": false,
+                            "uri": "switches/1b33d6d2036e86614567a897dc7a6200",
+                            "roleGroups": [],
+                            "managedAuthEnabled": true
+                          },
+                          "ports": []
+                        }, {
+                          "name": "IO Module 03",
+                          "uuid": "513B54041DD2B201579F0027F8F9D679",
+                          "accessState": "Online",
+                          "overallHealthState": "Normal",
+                          "type": "Switch",
+                          "hostname": "",
+                          "description": "FC5022 16Gb SAN Scalable Switch",
+                          "dnsHostnames": [
+                            "10.243.14.149",
+                            "fd55:faaf:e1ab:2021:227:f8ff:fef9:d67a"
+                          ],
+                          "FRU": "88Y6377",
+                          "fruSerialNumber": "Y054UZ4B100F",
+                          "ipv4Addresses": [
+                            "10.243.14.149"
+                          ],
+                          "ipv6Addresses": [
+                            "fe80:0:0:0:227:f8ff:fef9:d67a",
+                            "fd55:faaf:e1ab:2021:227:f8ff:fef9:d67a"
+                          ],
+                          "macAddresses": [
+                            "00:27:F8:F9:D6:7A"
+                          ],
+                          "machineType": "",
+                          "manufacturer": "IBM",
+                          "manufacturerId": "20301",
+                          "model": "",
+                          "partNumber": "88Y6376",
+                          "posID": "17",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 100,
+                            "minimumAllocatedPower": 100
+                          },
+                          "powerState": "On",
+                          "productId": "329",
+                          "productName": "IBM Flex System FC5022 12-port 16Gb ESB SAN Scalable Switch",
+                          "protectedMode": "Not supported",
+                          "serialNumber": "",
+                          "slots": [
+                            3
+                          ],
+                          "stackMode": "N/A",
+                          "vpdID": "309",
+                          "attachedNodes": [
+                            "E6C27EC764BA11E1A6AA5CF3FC7F0B50"
+                          ],
+                          "backedBy": "real",
+                          "cmmDisplayName": "IO Module 03",
+                          "cmmHealthState": "Normal",
+                          "dataHandle": 1522261881786,
+                          "errorFields": [],
+                          "excludedHealthState": "Normal",
+                          "firmware": [{
+                            "name": "Main Application",
+                            "date": "2017-06-05T04:00:00Z",
+                            "type": "Main Application",
+                            "build": "",
+                            "version": "8.1.1",
+                            "status": "Active"
+                          }],
+                          "ipInterfaces": [{
+                            "name": "ioe0",
+                            "label": "",
+                            "IPv4enabled": true,
+                            "IPv4DHCPmode": "DHCP_THEN_STATIC",
+                            "IPv6enabled": true,
+                            "IPv6DHCPenabled": true,
+                            "IPv4assignments": [{
+                              "id": 64,
+                              "subnet": "0.0.0.0",
+                              "gateway": "0.0.0.0",
+                              "address": "10.243.14.149",
+                              "type": "INUSE"
+                            }],
+                            "IPv6assignments": [{
+                              "id": 1,
+                              "scope": "LinkLocal",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Other",
+                              "address": "fe80:0:0:0:227:f8ff:fef9:d67a",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }, {
+                              "id": 33,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Stateless",
+                              "address": "fd55:faaf:e1ab:2021:227:f8ff:fef9:d67a",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }, {
+                              "id": 2,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Static",
+                              "address": "0:0:0:0:0:0:0:0",
+                              "prefix": 64,
+                              "type": "CONFIGURED"
+                            }],
+                            "IPv6statelessEnabled": true,
+                            "IPv6staticEnabled": false
+                          }],
+                          "leds": [{
+                            "name": "FRU Fault",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Enclosure Identify",
+                            "state": "Off",
+                            "color": "Blue",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Power",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "FrontPanel"
+                          }],
+                          "ntpPushEnabled": true,
+                          "ntpPushFrequency": 17,
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "switches/513B54041DD2B201579F0027F8F9D679",
+                          "userDescription": "",
+                          "userDefinedName": "",
+                          "securityDescriptor": {
+                            "managedAuthSupported": true,
+                            "publicAccess": false,
+                            "uri": "switches/513b54041dd2b201579f0027f8f9d679",
+                            "roleGroups": [],
+                            "managedAuthEnabled": true
+                          },
+                          "ports": []
+                        }, {
+                          "name": "IO Module 02",
+                          "uuid": "1B33D6D346C534814567A897DC7A4900",
+                          "accessState": "Online",
+                          "overallHealthState": "Normal",
+                          "type": "Switch",
+                          "hostname": "",
+                          "description": "EN4093R 10Gb Ethernet Switch",
+                          "dnsHostnames": [
+                            "10.243.14.150",
+                            "fd55:faaf:e1ab:2021:aa97:dcff:fe7a:49ef"
+                          ],
+                          "FRU": "95Y3312",
+                          "fruSerialNumber": "Y010CM3BK033",
+                          "ipv4Addresses": [
+                            "10.243.14.150"
+                          ],
+                          "ipv6Addresses": [
+                            "fd55:faaf:e1ab:2021:aa97:dcff:fe7a:49ef",
+                            "fe80:0:0:0:aa97:dcff:fe7a:49ef"
+                          ],
+                          "macAddresses": [
+                            "A8:97:DC:7A:49:EF"
+                          ],
+                          "machineType": "",
+                          "manufacturer": "IBM",
+                          "manufacturerId": "20301",
+                          "model": "",
+                          "partNumber": "95Y3311",
+                          "posID": "33",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 100,
+                            "minimumAllocatedPower": 100
+                          },
+                          "powerState": "On",
+                          "productId": "471",
+                          "productName": "IBM Flex System Fabric EN4093R 10Gb Scalable Switch",
+                          "protectedMode": "False",
+                          "serialNumber": "",
+                          "slots": [
+                            2
+                          ],
+                          "stackMode": "Standby",
+                          "vpdID": "304",
+                          "attachedNodes": [
+                            "645553F8894011E3A5F36CAE8B704B20",
+                            "E6C27EC764BA11E1A6AA5CF3FC7F0B50",
+                            "B0D04B2122B211E280D5911FB6765E7D"
+                          ],
+                          "backedBy": "real",
+                          "cmmDisplayName": "IO Module 02",
+                          "cmmHealthState": "Normal",
+                          "dataHandle": 1522261881911,
+                          "errorFields": [],
+                          "excludedHealthState": "Normal",
+                          "firmware": [{
+                            "name": "Boot ROM",
+                            "date": "2018-01-17T05:00:00Z",
+                            "type": "Boot ROM",
+                            "build": "",
+                            "version": "7.8.19.0",
+                            "status": "Active"
+                          }, {
+                            "name": "Main Application 1",
+                            "date": "2018-01-17T05:00:00Z",
+                            "type": "Main Application 1",
+                            "build": "",
+                            "version": "7.8.19.0",
+                            "status": "Active"
+                          }, {
+                            "name": "Main Application 2",
+                            "date": "2017-06-02T04:00:00Z",
+                            "type": "Main Application 2",
+                            "build": "",
+                            "version": "7.8.17.4",
+                            "status": "Not-Active"
+                          }],
+                          "ipInterfaces": [{
+                            "name": "ioe0",
+                            "label": "",
+                            "IPv4enabled": true,
+                            "IPv4DHCPmode": "DHCP_THEN_STATIC",
+                            "IPv6enabled": true,
+                            "IPv6DHCPenabled": true,
+                            "IPv4assignments": [{
+                              "id": 64,
+                              "subnet": "0.0.0.0",
+                              "gateway": "0.0.0.0",
+                              "address": "10.243.14.150",
+                              "type": "INUSE"
+                            }],
+                            "IPv6assignments": [{
+                              "id": 2,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Static",
+                              "address": "0:0:0:0:0:0:0:0",
+                              "prefix": 64,
+                              "type": "CONFIGURED"
+                            }, {
+                              "id": 33,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Stateless",
+                              "address": "fd55:faaf:e1ab:2021:aa97:dcff:fe7a:49ef",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }, {
+                              "id": 1,
+                              "scope": "LinkLocal",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Other",
+                              "address": "fe80:0:0:0:aa97:dcff:fe7a:49ef",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }],
+                            "IPv6statelessEnabled": true,
+                            "IPv6staticEnabled": false
+                          }],
+                          "leds": [{
+                            "name": "FRU Fault",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Enclosure Identify",
+                            "state": "Off",
+                            "color": "Blue",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Power",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "FrontPanel"
+                          }],
+                          "ntpPushEnabled": true,
+                          "ntpPushFrequency": 17,
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "switches/1B33D6D346C534814567A897DC7A4900",
+                          "userDescription": "",
+                          "userDefinedName": "",
+                          "securityDescriptor": {
+                            "managedAuthSupported": true,
+                            "publicAccess": false,
+                            "uri": "switches/1b33d6d346c534814567a897dc7a4900",
+                            "roleGroups": [],
+                            "managedAuthEnabled": true
+                          },
+                          "ports": []
+                        }, {
+                          "name": "IO Module 04",
+                          "uuid": "513B4D901DD2B2015ABF0027F8F9BD01",
+                          "accessState": "Online",
+                          "overallHealthState": "Normal",
+                          "type": "Switch",
+                          "hostname": "",
+                          "description": "FC5022 16Gb SAN Scalable Switch",
+                          "dnsHostnames": [
+                            "10.243.14.144",
+                            "fd55:faaf:e1ab:2021:227:f8ff:fef9:bd02"
+                          ],
+                          "FRU": "88Y6377",
+                          "fruSerialNumber": "Y054UZ4B1001",
+                          "ipv4Addresses": [
+                            "10.243.14.144"
+                          ],
+                          "ipv6Addresses": [
+                            "fd55:faaf:e1ab:2021:227:f8ff:fef9:bd02",
+                            "fe80:0:0:0:227:f8ff:fef9:bd02"
+                          ],
+                          "macAddresses": [
+                            "00:27:F8:F9:BD:02"
+                          ],
+                          "machineType": "",
+                          "manufacturer": "IBM",
+                          "manufacturerId": "20301",
+                          "model": "",
+                          "partNumber": "88Y6376",
+                          "posID": "17",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 100,
+                            "minimumAllocatedPower": 100
+                          },
+                          "powerState": "On",
+                          "productId": "329",
+                          "productName": "IBM Flex System FC5022 12-port 16Gb ESB SAN Scalable Switch",
+                          "protectedMode": "Not supported",
+                          "serialNumber": "",
+                          "slots": [
+                            4
+                          ],
+                          "stackMode": "N/A",
+                          "vpdID": "309",
+                          "attachedNodes": [],
+                          "backedBy": "real",
+                          "cmmDisplayName": "IO Module 04",
+                          "cmmHealthState": "Normal",
+                          "dataHandle": 1522261881944,
+                          "errorFields": [],
+                          "excludedHealthState": "Normal",
+                          "firmware": [{
+                            "name": "Main Application",
+                            "date": "2016-04-21T04:00:00Z",
+                            "type": "Main Application",
+                            "build": "",
+                            "version": "8.0.1",
+                            "status": "Active"
+                          }],
+                          "ipInterfaces": [{
+                            "name": "ioe0",
+                            "label": "",
+                            "IPv4enabled": true,
+                            "IPv4DHCPmode": "DHCP_THEN_STATIC",
+                            "IPv6enabled": true,
+                            "IPv6DHCPenabled": true,
+                            "IPv4assignments": [{
+                              "id": 64,
+                              "subnet": "0.0.0.0",
+                              "gateway": "0.0.0.0",
+                              "address": "10.243.14.144",
+                              "type": "INUSE"
+                            }],
+                            "IPv6assignments": [{
+                              "id": 1,
+                              "scope": "LinkLocal",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Other",
+                              "address": "fe80:0:0:0:227:f8ff:fef9:bd02",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }, {
+                              "id": 33,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Stateless",
+                              "address": "fd55:faaf:e1ab:2021:227:f8ff:fef9:bd02",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }, {
+                              "id": 2,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Static",
+                              "address": "0:0:0:0:0:0:0:0",
+                              "prefix": 64,
+                              "type": "CONFIGURED"
+                            }],
+                            "IPv6statelessEnabled": true,
+                            "IPv6staticEnabled": false
+                          }],
+                          "leds": [{
+                            "name": "FRU Fault",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Enclosure Identify",
+                            "state": "Off",
+                            "color": "Blue",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Power",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "FrontPanel"
+                          }],
+                          "ntpPushEnabled": true,
+                          "ntpPushFrequency": 17,
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "uri": "switches/513B4D901DD2B2015ABF0027F8F9BD01",
+                          "userDescription": "",
+                          "userDefinedName": "",
+                          "securityDescriptor": {
+                            "managedAuthSupported": true,
+                            "publicAccess": false,
+                            "uri": "switches/513b4d901dd2b2015abf0027f8f9bd01",
+                            "roleGroups": [],
+                            "managedAuthEnabled": true
+                          },
+                          "ports": []
+                        }],
+                        "fanMuxSlots": 2,
+                        "backedBy": "real",
+                        "cmmDisplayName": "SN#Y034BG16E02C",
+                        "userDefinedName": "SN#Y034BG16E02C",
+                        "ledCardSlots": 1,
+                        "excludedHealthState": "Warning",
+                        "cmms": [{
+                          "accessState": "Online",
+                          "model": "",
+                          "manufacturerId": "20301",
+                          "serialNumber": "",
+                          "type": "CMM",
+                          "dataHandle": 1522261862413,
+                          "ipv4Addresses": [
+                            "10.243.14.175"
+                          ],
+                          "backedBy": "real",
+                          "cmmDisplayName": "SN#Y034BG16E02C",
+                          "hostConfig": [],
+                          "leds": [{
+                            "name": "FAULT",
+                            "state": "Off",
+                            "color": "Amber",
+                            "location": "FrontPanel"
+                          }],
+                          "description": "CMM",
+                          "name": "MM5CF3FC25D8EF",
+                          "mgmtProcIPaddress": "10.243.14.175",
+                          "errorFields": [],
+                          "role": "primary",
+                          "cmmHealthState": "Normal",
+                          "userDescription": "",
+                          "partNumber": "68Y7029",
+                          "ipInterfaces": [{
+                            "name": "eth0",
+                            "label": "External",
+                            "IPv4enabled": true,
+                            "IPv4DHCPmode": "DHCP_ONLY",
+                            "IPv6enabled": true,
+                            "IPv6DHCPenabled": true,
+                            "IPv4assignments": [{
+                              "id": 64,
+                              "subnet": "255.255.224.0",
+                              "gateway": "10.243.0.1",
+                              "address": "10.243.14.175",
+                              "type": "INUSE"
+                            }],
+                            "IPv6assignments": [{
+                              "id": 2,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Static",
+                              "address": "0:0:0:0:0:0:0:0",
+                              "prefix": 0,
+                              "type": "CONFIGURED"
+                            }, {
+                              "id": 16,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Stateless",
+                              "address": "fd55:faaf:e1ab:2021:5ef3:fcff:fe25:d8ef",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }, {
+                              "id": 1,
+                              "scope": "LinkLocal",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Other",
+                              "address": "fe80:0:0:0:5ef3:fcff:fe25:d8ef",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }],
+                            "IPv6statelessEnabled": true,
+                            "IPv6staticEnabled": false
+                          }],
+                          "excludedHealthState": "Normal",
+                          "firmware": [{
+                            "name": "CMM firmware",
+                            "date": "2018-01-04T05:00:00Z",
+                            "type": "CMM firmware",
+                            "build": "1AON29G",
+                            "version": "1.8.0",
+                            "role": "",
+                            "status": ""
+                          }],
+                          "machineType": "",
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "hostname": "MM5CF3FC25D8EF",
+                          "domainName": "",
+                          "macAddresses": [
+                            "5C:F3:FC:25:D8:EF"
+                          ],
+                          "uri": "cmm/209DBB399D9F11E09BDEA9FD37942664",
+                          "productId": "65",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 20,
+                            "minimumAllocatedPower": 20
+                          },
+                          "ipv6Addresses": [
+                            "fe80:0:0:0:5ef3:fcff:fe25:d8ef",
+                            "fd55:faaf:e1ab:2021:5ef3:fcff:fe25:d8ef"
+                          ],
+                          "overallHealthState": "Normal",
+                          "slots": [
+                            1
+                          ],
+                          "manufacturer": "IBM",
+                          "uuid": "209DBB399D9F11E09BDEA9FD37942664",
+                          "dnsHostnames": [
+                            "10.243.14.175",
+                            "fd55:faaf:e1ab:2021:5ef3:fcff:fe25:d8ef"
+                          ],
+                          "fruSerialNumber": "Y034BG16E02C",
+                          "userDefinedName": "",
+                          "FRU": "68Y7032"
+                        }],
+                        "mmSlots": 2,
+                        "managerName": "UNKNOWN",
+                        "managerUuid": "UNKNOWN",
+                        "nist": {
+                          "possibleValues": [
+                            "Nist_800_131A_Strict",
+                            "unsupported",
+                            "Nist_800_131A_Custom",
+                            "Compatibility"
+                          ],
+                          "currentValue": "Compatibility"
+                        },
+                        "securityDescriptor": {
+                          "managedAuthSupported": true,
+                          "publicAccess": false,
+                          "uri": "chassis/9841028b07714fd09d9297c6d1a4943e",
+                          "roleGroups": [],
+                          "managedAuthEnabled": true,
+                          "storedCredentials": {
+                            "description": "Credentials for null",
+                            "id": "552",
+                            "userName": "userid"
+                          }
+                        },
+                        "parent": {
+                          "uuid": "",
+                          "uri": "cabinet/"
+                        },
+                        "nodes": [{
+                          "name": "ite-co-017",
+                          "uuid": "E6C27EC764BA11E1A6AA5CF3FC7F0B50",
+                          "status": {
+                            "message": "managed",
+                            "name": "MANAGED"
+                          },
+                          "hostname": "IMM2-5cf3fc7e05a1",
+                          "overallHealthState": "Normal",
+                          "productName": "IBM Flex System C4440 M4 Compute Node",
+                          "type": "ITE",
+                          "manufacturer": "IBM",
+                          "machineType": "7917",
+                          "model": "AC1",
+                          "mgmtProcIPaddress": "10.243.14.24",
+                          "arch": "x86",
+                          "serialNumber": "23ZGE28",
+                          "partNumber": "95Y4436",
+                          "FRU": "88Y6237",
+                          "fruSerialNumber": "Y130BG1C800R",
+                          "domainName": "",
+                          "FQDN": "10.243.14.24",
+                          "powerStatus": 5,
+                          "userDescription": "",
+                          "macAddress": "5C:F3:FC:7E:05:A1,5C:F3:FC:7E:05:A2",
+                          "hostMacAddresses": "5C:F3:FC:7F:0B:50,5C:F3:FC:7F:0B:54",
+                          "tlsVersion": {
+                            "possibleValues": [
+                              "unsupported",
+                              "TLS_12",
+                              "TLS_11",
+                              "TLS_10"
+                            ],
+                            "currentValue": "Unknown"
+                          },
+                          "nist": {
+                            "possibleValues": [
+                              "Nist_800_131A_Strict",
+                              "unsupported",
+                              "Compatibility"
+                            ],
+                            "currentValue": "Unknown"
+                          },
+                          "bootMode": {
+                            "possibleValues": [
+                              "UEFI Only",
+                              "UEFI and Legacy",
+                              "Legacy Only"
+                            ],
+                            "currentValue": "UEFI and Legacy"
+                          },
+                          "location": {
+                            "lowestRackUnit": 0,
+                            "location": "location",
+                            "rack": "",
+                            "room": ""
+                          },
+                          "lanOverUsb": "enabled",
+                          "description": "X440",
+                          "mgmtProcType": "IMM2",
+                          "isRemotePresenceEnabled": true,
+                          "leds": [{
+                            "name": "DIMM 48",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 13",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 2",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "Fault",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "DIMM 33",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 28",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "Mezz Exp 2",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "DIMM 23",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "SSD6",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "DIMM 38",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 18",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 7",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 34",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "CMOS Batt Error",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "IMM Fault",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "SAS BP 2 Error",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "Check Log",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "Identification",
+                            "state": "Off",
+                            "color": "Blue",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "DIMM 44",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "S BRD",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "LightPathCard"
+                          }, {
+                            "name": "DIMM 39",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 22",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "MEM",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "LightPathCard"
+                          }, {
+                            "name": "NMI",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "LightPathCard"
+                          }, {
+                            "name": "DIMM 12",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "LP",
+                            "state": "On",
+                            "color": "Green",
+                            "location": "LightPathCard"
+                          }, {
+                            "name": "Power",
+                            "state": "Blinking",
+                            "color": "Green",
+                            "location": "FrontPanel"
+                          }, {
+                            "name": "DIMM 29",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "Mezz Exp 1",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "SSD7",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "DIMM 5",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "CPU 3",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 42",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 19",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 32",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "M5115 Flt",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "MIS",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "LightPathCard"
+                          }, {
+                            "name": "DIMM 45",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 25",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 8",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 1",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 35",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "SSD4",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "Mezz Exp 4",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "DIMM 31",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "BMC Heartbeat",
+                            "state": "Blinking",
+                            "color": "Green",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 21",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 15",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 46",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 9",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 4",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 41",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "CPU 2",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 26",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DC Fault",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 36",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 16",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 11",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 30",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "Mezz Exp 3",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "ADJ",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "LightPathCard"
+                          }, {
+                            "name": "SSD5",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "DIMM 14",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 3",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "CPU 1",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 40",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "SAS BP 1 Error",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 24",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "TEMP",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "LightPathCard"
+                          }, {
+                            "name": "DIMM 37",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 47",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 43",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 17",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "CPU 4",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "M5115 SCp",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "FRU"
+                          }, {
+                            "name": "DIMM 6",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 27",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 20",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }, {
+                            "name": "DIMM 10",
+                            "state": "Off",
+                            "color": "Yellow",
+                            "location": "Planar"
+                          }],
+                          "expansionCards": [],
+                          "firmware": [{
+                            "name": "IMM2 Firmware",
+                            "date": "2018-01-17T00:00:00Z",
+                            "type": "IMM2",
+                            "build": "1AOO81E",
+                            "version": "6.60",
+                            "role": "Primary",
+                            "status": "Active"
+                          }, {
+                            "name": "DSA Diagnostic Software",
+                            "date": "2017-06-23T00:00:00Z",
+                            "type": "DSA",
+                            "build": "DSYTE1W",
+                            "version": "9.65",
+                            "role": "Primary",
+                            "status": "Active"
+                          }, {
+                            "name": "UEFI Backup Firmware/BIOS",
+                            "date": "2015-11-18T00:00:00Z",
+                            "type": "UEFI-Backup",
+                            "build": "CNE149BUS",
+                            "version": "1.70",
+                            "role": "Backup",
+                            "status": "Inactive"
+                          }, {
+                            "name": "UEFI Firmware/BIOS",
+                            "date": "2018-01-26T00:00:00Z",
+                            "type": "UEFI",
+                            "build": "CNE159FUS",
+                            "version": "2.00",
+                            "role": "Primary",
+                            "status": "Active"
+                          }, {
+                            "name": "IMM2 Backup Firmware",
+                            "date": "2018-01-17T00:00:00Z",
+                            "type": "IMM2-Backup",
+                            "build": "1AOO81E",
+                            "version": "6.60",
+                            "role": "Backup",
+                            "status": "Inactive"
+                          }],
+                          "powerSupplies": [],
+                          "ipv4Addresses": [
+                            "10.243.14.24",
+                            "169.254.95.118"
+                          ],
+                          "ipv6Addresses": [
+                            "fd55:faaf:e1ab:2021:5ef3:fcff:fe7e:5a1",
+                            "fe80:0:0:0:5ef3:fcff:fe7e:5a1"
+                          ],
+                          "raidSettings": [],
+                          "drives": [],
+                          "memoryModules": [{
+                            "model": "DDR3",
+                            "speed": 1333,
+                            "manufacturer": "Samsung",
+                            "capacity": 16,
+                            "serialNumber": "232A5692",
+                            "displayName": "DIMM 1",
+                            "slot": 1,
+                            "type": "DDR3",
+                            "partNumber": "M386B2K70DM0-YH90",
+                            "speedMBs": 0
+                          }, {
+                            "model": "DDR3",
+                            "speed": 1333,
+                            "manufacturer": "Samsung",
+                            "capacity": 16,
+                            "serialNumber": "232A5766",
+                            "displayName": "DIMM 4",
+                            "slot": 4,
+                            "type": "DDR3",
+                            "partNumber": "M386B2K70DM0-YH90",
+                            "speedMBs": 0
+                          }, {
+                            "model": "DDR3",
+                            "speed": 1333,
+                            "manufacturer": "Samsung",
+                            "capacity": 16,
+                            "serialNumber": "232A56A5",
+                            "displayName": "DIMM 13",
+                            "slot": 13,
+                            "type": "DDR3",
+                            "partNumber": "M386B2K70DM0-YH90",
+                            "speedMBs": 0
+                          }, {
+                            "model": "DDR3",
+                            "speed": 1333,
+                            "manufacturer": "Samsung",
+                            "capacity": 16,
+                            "serialNumber": "232A57B7",
+                            "displayName": "DIMM 16",
+                            "slot": 16,
+                            "type": "DDR3",
+                            "partNumber": "M386B2K70DM0-YH90",
+                            "speedMBs": 0
+                          }, {
+                            "model": "DDR3",
+                            "speed": 1333,
+                            "manufacturer": "Samsung",
+                            "capacity": 16,
+                            "serialNumber": "232A5798",
+                            "displayName": "DIMM 33",
+                            "slot": 33,
+                            "type": "DDR3",
+                            "partNumber": "M386B2K70DM0-YH90",
+                            "speedMBs": 0
+                          }, {
+                            "model": "DDR3",
+                            "speed": 1333,
+                            "manufacturer": "Samsung",
+                            "capacity": 16,
+                            "serialNumber": "232A56F5",
+                            "displayName": "DIMM 36",
+                            "slot": 36,
+                            "type": "DDR3",
+                            "partNumber": "M386B2K70DM0-YH90",
+                            "speedMBs": 0
+                          }, {
+                            "model": "DDR3",
+                            "speed": 1333,
+                            "manufacturer": "Samsung",
+                            "capacity": 16,
+                            "serialNumber": "232A5734",
+                            "displayName": "DIMM 45",
+                            "slot": 45,
+                            "type": "DDR3",
+                            "partNumber": "M386B2K70DM0-YH90",
+                            "speedMBs": 0
+                          }, {
+                            "model": "DDR3",
+                            "speed": 1333,
+                            "manufacturer": "Samsung",
+                            "capacity": 16,
+                            "serialNumber": "232A5795",
+                            "displayName": "DIMM 48",
+                            "slot": 48,
+                            "type": "DDR3",
+                            "partNumber": "M386B2K70DM0-YH90",
+                            "speedMBs": 0
+                          }],
+                          "processors": [{
+                            "speed": 2.4,
+                            "manufacturer": "Intel(R) Corporation",
+                            "family": "INTEL_R_XEON_TM",
+                            "displayName": "Genuine Intel(R) CPU  @ 2.40GHz",
+                            "slot": 1,
+                            "productVersion": "Genuine Intel(R) CPU  @ 2.40GHz",
+                            "cores": 8,
+                            "socket": ""
+                          }, {
+                            "speed": 2.4,
+                            "manufacturer": "Intel(R) Corporation",
+                            "family": "INTEL_R_XEON_TM",
+                            "displayName": "Genuine Intel(R) CPU  @ 2.40GHz",
+                            "slot": 2,
+                            "productVersion": "Genuine Intel(R) CPU  @ 2.40GHz",
+                            "cores": 8,
+                            "socket": ""
+                          }, {
+                            "speed": 2.4,
+                            "manufacturer": "Intel(R) Corporation",
+                            "family": "INTEL_R_XEON_TM",
+                            "displayName": "Genuine Intel(R) CPU  @ 2.40GHz",
+                            "slot": 3,
+                            "productVersion": "Genuine Intel(R) CPU  @ 2.40GHz",
+                            "cores": 8,
+                            "socket": ""
+                          }, {
+                            "speed": 2.4,
+                            "manufacturer": "Intel(R) Corporation",
+                            "family": "INTEL_R_XEON_TM",
+                            "displayName": "Genuine Intel(R) CPU  @ 2.40GHz",
+                            "slot": 4,
+                            "productVersion": "Genuine Intel(R) CPU  @ 2.40GHz",
+                            "cores": 8,
+                            "socket": ""
+                          }],
+                          "pciDevices": [{
+                            "firmware": [{
+                              "revision": "0",
+                              "classifications": [
+                                13
+                              ],
+                              "status": "Active",
+                              "name": "BladeEngine 10G Flash Image",
+                              "role": "Primary",
+                              "type": "Software Bundle",
+                              "build": "0",
+                              "date": "",
+                              "version": "10.3.149.0",
+                              "softwareID": "10DFE70F"
+                            }],
+                            "pciRevision": "2",
+                            "pciBusNumber": "12",
+                            "pciDeviceNumber": "0",
+                            "pciFunctionNumber": "1",
+                            "name": "N/A",
+                            "portInfo": {
+                              "physicalPorts": [{
+                                "portType": "ETHERNET",
+                                "portNumber": 2,
+                                "logicalPorts": [{
+                                  "portType": "ETHERNET",
+                                  "portNumber": 1,
+                                  "logicalPortIndex": 1,
+                                  "addresses": "5CF3FC7F0B54",
+                                  "vnicMode": false
+                                }],
+                                "peerBay": 2,
+                                "physicalPortIndex": 2
+                              }]
+                            },
+                            "pciSubID": "e70f",
+                            "fodUniqueID": "WZG1HRBT39HS9GRW87DJY29SBJHR37GV",
+                            "isAgentless": true,
+                            "pciSubVendorID": "10df",
+                            "isAddOnCard": false,
+                            "posID": "710",
+                            "vpdID": "19a2",
+                            "class": "Network controller"
+                          }, {
+                            "firmware": [],
+                            "pciRevision": "0",
+                            "pciBusNumber": "4",
+                            "pciDeviceNumber": "0",
+                            "pciFunctionNumber": "0",
+                            "name": "",
+                            "portInfo": {},
+                            "pciSubID": "405",
+                            "fodUniqueID": "",
+                            "isAgentless": false,
+                            "pciSubVendorID": "1014",
+                            "isAddOnCard": false,
+                            "posID": "534",
+                            "vpdID": "102b",
+                            "class": "Display controller"
+                          }, {
+                            "firmware": [{
+                              "revision": "0",
+                              "classifications": [
+                                10
+                              ],
+                              "status": "Active",
+                              "name": "ISP 25xx RISC Firmware",
+                              "role": "Primary",
+                              "type": "Firmware",
+                              "build": "0",
+                              "date": "",
+                              "version": "7.04.00",
+                              "softwareID": "10770175"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32774
+                              ],
+                              "status": "Active",
+                              "name": "ISP 25xx UEFI",
+                              "role": "Primary",
+                              "type": "UEFI",
+                              "build": "0",
+                              "date": "",
+                              "version": "6.12",
+                              "softwareID": "10770175"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32770
+                              ],
+                              "status": "Active",
+                              "name": "ISP 25xx BIOS",
+                              "role": "Primary",
+                              "type": "BIOS",
+                              "build": "0",
+                              "date": "",
+                              "version": "2.14",
+                              "softwareID": "10770175"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32771
+                              ],
+                              "status": "Active",
+                              "name": "ISP 25xx FCODE",
+                              "role": "Primary",
+                              "type": "FCODE",
+                              "build": "0",
+                              "date": "",
+                              "version": "3.22",
+                              "softwareID": "10770175"
+                            }],
+                            "slotSupportsHotPlug": "false",
+                            "pciRevision": "2",
+                            "pciBusNumber": "22",
+                            "pciDeviceNumber": "0",
+                            "slotNumber": "2",
+                            "pciFunctionNumber": "0",
+                            "manufacturer": "IBM",
+                            "name": "IBM Flex System FC3172 2-port 8Gb FC Adapter",
+                            "portInfo": {
+                              "physicalPorts": [{
+                                "portType": "FC",
+                                "portNumber": 9,
+                                "logicalPorts": [{
+                                  "portType": "FC",
+                                  "portNumber": 1,
+                                  "logicalPortIndex": 1,
+                                  "addresses": "21000024FF2F6658",
+                                  "vnicMode": false
+                                }],
+                                "peerBay": 3,
+                                "physicalPortIndex": 1
+                              }]
+                            },
+                            "uuid": "7568E421985711E0AF61E4F5CC842700",
+                            "productName": "IBM Flex System FC3172 2-port 8Gb FC Adapter",
+                            "partNumber": "90Y3581",
+                            "fruSerialNumber": "YK502216GGW1",
+                            "slotName": "SlotDesig5_Mezzanine 2 Card",
+                            "pciSubID": "175",
+                            "fodUniqueID": "N/A",
+                            "isAgentless": true,
+                            "pciSubVendorID": "1077",
+                            "isAddOnCard": true,
+                            "FRU": "69Y1941",
+                            "posID": "2532",
+                            "vpdID": "1077",
+                            "class": "Serial bus controller"
+                          }, {
+                            "firmware": [{
+                              "revision": "0",
+                              "classifications": [
+                                10
+                              ],
+                              "status": "Active",
+                              "name": "LSI IT/IR Controller Firmware",
+                              "role": "Primary",
+                              "type": "Firmware",
+                              "build": "0",
+                              "date": "",
+                              "version": "20.0.5.0",
+                              "softwareID": "10140421"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32774
+                              ],
+                              "status": "Active",
+                              "name": "LSI IT/IR Boot Services Driver",
+                              "role": "Primary",
+                              "type": "UEFI",
+                              "build": "0",
+                              "date": "",
+                              "version": "7.27.4.0",
+                              "softwareID": "10140421"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32770
+                              ],
+                              "status": "Active",
+                              "name": "LSI IT/IR Legacy OptionROM",
+                              "role": "Primary",
+                              "type": "BIOS",
+                              "build": "0",
+                              "date": "",
+                              "version": "7.39.0.0",
+                              "softwareID": "10140421"
+                            }],
+                            "pciRevision": "3",
+                            "pciBusNumber": "6",
+                            "pciDeviceNumber": "0",
+                            "pciFunctionNumber": "0",
+                            "name": "LSI2004",
+                            "portInfo": {},
+                            "pciSubID": "421",
+                            "fodUniqueID": "N/A",
+                            "isAgentless": true,
+                            "pciSubVendorID": "1014",
+                            "isAddOnCard": false,
+                            "posID": "70",
+                            "vpdID": "1000",
+                            "class": "Mass storage controller"
+                          }, {
+                            "firmware": [{
+                              "revision": "0",
+                              "classifications": [
+                                13
+                              ],
+                              "status": "Active",
+                              "name": "BladeEngine 10G Flash Image",
+                              "role": "Primary",
+                              "type": "Software Bundle",
+                              "build": "0",
+                              "date": "",
+                              "version": "10.3.149.0",
+                              "softwareID": "10DFE70F"
+                            }],
+                            "pciRevision": "2",
+                            "pciBusNumber": "12",
+                            "pciDeviceNumber": "0",
+                            "pciFunctionNumber": "0",
+                            "name": "N/A",
+                            "portInfo": {
+                              "physicalPorts": [{
+                                "portType": "ETHERNET",
+                                "portNumber": 1,
+                                "logicalPorts": [{
+                                  "portType": "ETHERNET",
+                                  "portNumber": 1,
+                                  "logicalPortIndex": 1,
+                                  "addresses": "5CF3FC7F0B50",
+                                  "vnicMode": false
+                                }],
+                                "peerBay": 1,
+                                "physicalPortIndex": 1
+                              }]
+                            },
+                            "pciSubID": "e70f",
+                            "fodUniqueID": "WZG1HRBT39HS9GRW87DJY29SBJHR37GV",
+                            "isAgentless": true,
+                            "pciSubVendorID": "10df",
+                            "isAddOnCard": false,
+                            "posID": "710",
+                            "vpdID": "19a2",
+                            "class": "Network controller"
+                          }, {
+                            "firmware": [{
+                              "revision": "0",
+                              "classifications": [
+                                10
+                              ],
+                              "status": "Active",
+                              "name": "ISP 25xx RISC Firmware",
+                              "role": "Primary",
+                              "type": "Firmware",
+                              "build": "0",
+                              "date": "",
+                              "version": "7.04.00",
+                              "softwareID": "10770175"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32774
+                              ],
+                              "status": "Active",
+                              "name": "ISP 25xx UEFI",
+                              "role": "Primary",
+                              "type": "UEFI",
+                              "build": "0",
+                              "date": "",
+                              "version": "6.12",
+                              "softwareID": "10770175"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32770
+                              ],
+                              "status": "Active",
+                              "name": "ISP 25xx BIOS",
+                              "role": "Primary",
+                              "type": "BIOS",
+                              "build": "0",
+                              "date": "",
+                              "version": "2.14",
+                              "softwareID": "10770175"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32771
+                              ],
+                              "status": "Active",
+                              "name": "ISP 25xx FCODE",
+                              "role": "Primary",
+                              "type": "FCODE",
+                              "build": "0",
+                              "date": "",
+                              "version": "3.22",
+                              "softwareID": "10770175"
+                            }],
+                            "slotSupportsHotPlug": "false",
+                            "pciRevision": "2",
+                            "pciBusNumber": "22",
+                            "pciDeviceNumber": "0",
+                            "slotNumber": "2",
+                            "pciFunctionNumber": "1",
+                            "manufacturer": "IBM",
+                            "name": "IBM Flex System FC3172 2-port 8Gb FC Adapter",
+                            "portInfo": {
+                              "physicalPorts": [{
+                                "portType": "FC",
+                                "portNumber": 10,
+                                "logicalPorts": [{
+                                  "portType": "FC",
+                                  "portNumber": 1,
+                                  "logicalPortIndex": 1,
+                                  "addresses": "21000024FF2F6659",
+                                  "vnicMode": false
+                                }],
+                                "peerBay": 0,
+                                "physicalPortIndex": 2
+                              }]
+                            },
+                            "uuid": "7568E421985711E0AF61E4F5CC842700",
+                            "productName": "IBM Flex System FC3172 2-port 8Gb FC Adapter",
+                            "partNumber": "90Y3581",
+                            "fruSerialNumber": "YK502216GGW1",
+                            "slotName": "SlotDesig5_Mezzanine 2 Card",
+                            "pciSubID": "175",
+                            "fodUniqueID": "N/A",
+                            "isAgentless": true,
+                            "pciSubVendorID": "1077",
+                            "isAddOnCard": true,
+                            "FRU": "69Y1941",
+                            "posID": "2532",
+                            "vpdID": "1077",
+                            "class": "Serial bus controller"
+                          }],
+                          "accessState": "Online",
+                          "manufacturerId": "20301",
+                          "addinCardSlots": 0,
+                          "driveBays": 8,
+                          "errorFields": [],
+                          "bladeState": 1,
+                          "activationKeys": [],
+                          "uri": "nodes/E6C27EC764BA11E1A6AA5CF3FC7F0B50",
+                          "vnicMode": "disabled",
+                          "powerAllocation": {
+                            "maximumAllocatedPower": 378,
+                            "minimumAllocatedPower": 286
+                          },
+                          "expansionProductType": "",
+                          "bootOrder": {
+                            "uri": "nodes/E6C27EC764BA11E1A6AA5CF3FC7F0B50/bootOrder",
+                            "bootOrderList": [{
+                              "currentBootOrderDevices": [],
+                              "bootType": "SingleUse",
+                              "possibleBootOrderDevices": []
+                            }]
+                          },
+                          "expansionProducts": [],
+                          "slots": [
+                            5,
+                            6
+                          ],
+                          "vpdID": "256",
+                          "encapsulation": {
+                            "encapsulationMode": "notSupported"
+                          },
+                          "secureBootMode": {
+                            "possibleValues": [],
+                            "currentValue": ""
+                          },
+                          "expansionCardSlots": 4,
+                          "contact": "contact",
+                          "dataHandle": 1522261995917,
+                          "cmmDisplayName": "Node 05",
+                          "backedBy": "real",
+                          "complexID": -1,
+                          "memorySlots": 48,
+                          "cmmHealthState": "Normal",
+                          "subSlots": [],
+                          "excludedHealthState": "Normal",
+                          "processorSlots": 4,
+                          "pciCapabilities": [
+                            "Raid Link",
+                            "OOB PCIe"
+                          ],
+                          "productId": "352",
+                          "hasOS": false,
+                          "ports": [{
+                            "ioModuleBay": 1,
+                            "portNumber": 1
+                          }, {
+                            "ioModuleBay": 2,
+                            "portNumber": 2
+                          }, {
+                            "ioModuleBay": 3,
+                            "portNumber": 9
+                          }, {
+                            "ioModuleBay": 0,
+                            "portNumber": 10
+                          }],
+                          "embeddedHypervisorPresence": false,
+                          "posID": "23",
+                          "subType": "Congo",
+                          "partitionID": -1,
+                          "flashStorage": [],
+                          "userDefinedName": "ite-co-017",
+                          "securityDescriptor": {
+                            "managedAuthSupported": true,
+                            "publicAccess": false,
+                            "uri": "nodes/e6c27ec764ba11e1a6aa5cf3fc7f0b50",
+                            "roleGroups": [],
+                            "managedAuthEnabled": true
+                          },
+                          "logicalID": -1,
+                          "primary": false,
+                          "parent": {
+                            "uuid": "9841028B07714FD09D9297C6D1A4943E",
+                            "uri": "chassis/9841028B07714FD09D9297C6D1A4943E"
+                          },
+                          "bladeState_health": "GOOD",
+                          "bladeState_string": "ite-co-017",
+                          "dnsHostnames": [
+                            "10.243.14.24",
+                            "fd55:faaf:e1ab:2021:5ef3:fcff:fe7e:5a1"
+                          ],
+                          "addinCards": [],
+                          "faceplateIDs": [{
+                            "name": "I/O module 2",
+                            "vpdID": 0,
+                            "posID": 0,
+                            "productId": 0,
+                            "entityId": 0,
+                            "deviceId": 0
+                          }, {
+                            "name": "front panel board 1",
+                            "vpdID": 0,
+                            "posID": 0,
+                            "productId": 0,
+                            "entityId": 0,
+                            "deviceId": 0
+                          }, {
+                            "name": "system board 1",
+                            "vpdID": 0,
+                            "posID": 0,
+                            "productId": 0,
+                            "entityId": 0,
+                            "deviceId": 0
+                          }],
+                          "lanOverUsbPortForwardingModes": [{
+                            "state": "disabled",
+                            "type": "DSA",
+                            "externalIPAddress": ""
+                          }],
+                          "m2Presence": false,
+                          "onboardPciDevices": [{
+                            "firmware": [{
+                              "revision": "0",
+                              "classifications": [
+                                13
+                              ],
+                              "status": "Active",
+                              "name": "BladeEngine 10G Flash Image",
+                              "role": "Primary",
+                              "type": "Software Bundle",
+                              "build": "0",
+                              "date": "",
+                              "version": "10.3.149.0",
+                              "softwareID": "10DFE70F"
+                            }],
+                            "pciRevision": "2",
+                            "pciBusNumber": "12",
+                            "pciDeviceNumber": "0",
+                            "pciFunctionNumber": "1",
+                            "name": "N/A",
+                            "portInfo": {
+                              "physicalPorts": [{
+                                "portType": "ETHERNET",
+                                "portNumber": 2,
+                                "logicalPorts": [{
+                                  "portType": "ETHERNET",
+                                  "portNumber": 1,
+                                  "logicalPortIndex": 1,
+                                  "addresses": "5CF3FC7F0B54",
+                                  "vnicMode": false
+                                }],
+                                "peerBay": 2,
+                                "physicalPortIndex": 2
+                              }]
+                            },
+                            "pciSubID": "e70f",
+                            "fodUniqueID": "WZG1HRBT39HS9GRW87DJY29SBJHR37GV",
+                            "isAgentless": true,
+                            "pciSubVendorID": "10df",
+                            "isAddOnCard": false,
+                            "posID": "710",
+                            "vpdID": "19a2",
+                            "class": "Network controller"
+                          }, {
+                            "firmware": [],
+                            "pciRevision": "0",
+                            "pciBusNumber": "4",
+                            "pciDeviceNumber": "0",
+                            "pciFunctionNumber": "0",
+                            "name": "",
+                            "portInfo": {},
+                            "pciSubID": "405",
+                            "fodUniqueID": "",
+                            "isAgentless": false,
+                            "pciSubVendorID": "1014",
+                            "isAddOnCard": false,
+                            "posID": "534",
+                            "vpdID": "102b",
+                            "class": "Display controller"
+                          }, {
+                            "firmware": [{
+                              "revision": "0",
+                              "classifications": [
+                                10
+                              ],
+                              "status": "Active",
+                              "name": "LSI IT/IR Controller Firmware",
+                              "role": "Primary",
+                              "type": "Firmware",
+                              "build": "0",
+                              "date": "",
+                              "version": "20.0.5.0",
+                              "softwareID": "10140421"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32774
+                              ],
+                              "status": "Active",
+                              "name": "LSI IT/IR Boot Services Driver",
+                              "role": "Primary",
+                              "type": "UEFI",
+                              "build": "0",
+                              "date": "",
+                              "version": "7.27.4.0",
+                              "softwareID": "10140421"
+                            }, {
+                              "revision": "0",
+                              "classifications": [
+                                32770
+                              ],
+                              "status": "Active",
+                              "name": "LSI IT/IR Legacy OptionROM",
+                              "role": "Primary",
+                              "type": "BIOS",
+                              "build": "0",
+                              "date": "",
+                              "version": "7.39.0.0",
+                              "softwareID": "10140421"
+                            }],
+                            "pciRevision": "3",
+                            "pciBusNumber": "6",
+                            "pciDeviceNumber": "0",
+                            "pciFunctionNumber": "0",
+                            "name": "LSI2004",
+                            "portInfo": {},
+                            "pciSubID": "421",
+                            "fodUniqueID": "N/A",
+                            "isAgentless": true,
+                            "pciSubVendorID": "1014",
+                            "isAddOnCard": false,
+                            "posID": "70",
+                            "vpdID": "1000",
+                            "class": "Mass storage controller"
+                          }, {
+                            "firmware": [{
+                              "revision": "0",
+                              "classifications": [
+                                13
+                              ],
+                              "status": "Active",
+                              "name": "BladeEngine 10G Flash Image",
+                              "role": "Primary",
+                              "type": "Software Bundle",
+                              "build": "0",
+                              "date": "",
+                              "version": "10.3.149.0",
+                              "softwareID": "10DFE70F"
+                            }],
+                            "pciRevision": "2",
+                            "pciBusNumber": "12",
+                            "pciDeviceNumber": "0",
+                            "pciFunctionNumber": "0",
+                            "name": "N/A",
+                            "portInfo": {
+                              "physicalPorts": [{
+                                "portType": "ETHERNET",
+                                "portNumber": 1,
+                                "logicalPorts": [{
+                                  "portType": "ETHERNET",
+                                  "portNumber": 1,
+                                  "logicalPortIndex": 1,
+                                  "addresses": "5CF3FC7F0B50",
+                                  "vnicMode": false
+                                }],
+                                "peerBay": 1,
+                                "physicalPortIndex": 1
+                              }]
+                            },
+                            "pciSubID": "e70f",
+                            "fodUniqueID": "WZG1HRBT39HS9GRW87DJY29SBJHR37GV",
+                            "isAgentless": true,
+                            "pciSubVendorID": "10df",
+                            "isAddOnCard": false,
+                            "posID": "710",
+                            "vpdID": "19a2",
+                            "class": "Network controller"
+                          }],
+                          "ipInterfaces": [{
+                            "name": "eth0",
+                            "label": "unknown",
+                            "IPv4enabled": true,
+                            "IPv4DHCPmode": "STATIC_ONLY",
+                            "IPv6enabled": true,
+                            "IPv6DHCPenabled": true,
+                            "IPv4assignments": [{
+                              "id": 0,
+                              "subnet": "255.255.224.0",
+                              "gateway": "0.0.0.0",
+                              "address": "10.243.14.24",
+                              "type": "INUSE"
+                            }],
+                            "IPv6assignments": [{
+                              "id": 0,
+                              "scope": "Global",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Stateless",
+                              "address": "fd55:faaf:e1ab:2021:5ef3:fcff:fe7e:5a1",
+                              "prefix": 64,
+                              "type": "INUSE"
+                            }, {
+                              "id": 0,
+                              "scope": "Unknown",
+                              "gateway": "0:0:0:0:0:0:0:0",
+                              "source": "Unknown",
+                              "address": "fe80:0:0:0:5ef3:fcff:fe7e:5a1",
+                              "prefix": 64,
+                              "type": "UNKNOWN"
+                            }],
+                            "IPv6statelessEnabled": true,
+                            "IPv6staticEnabled": false
+                          }],
+                          "isConnectionTrusted": "true",
+                          "isScalable": false,
+                          "isITME": false
+                        }],
+                        "activationKeys": [],
+                        "SecurityPolicy": {
+                          "cmmPolicyState": "ACTIVE",
+                          "cmmPolicyLevel": "SECURE"
+                        }
+                      }
+                    }],
+                    "location": "",
+                    "UUID": "096F8C92-08D4-4A24-ABD8-FE56D482F8C4",
+                    "nodeList": [{
+                      "itemParentUUID": null,
+                      "itemName": "Management Controller UUID-7936DD182C5311E3A8D6000AF7256738",
+                      "complexNodeCount": 1,
+                      "itemLowerUnit": 0,
+                      "itemType": "SERVER",
+                      "itemUUID": "7936DD182C5311E3A8D6000AF7256738",
+                      "itemSubType": "",
+                      "itemHeight": 4,
+                      "itemInventory": {
+                        "accessState": "Online",
+                        "arch": "x86",
+                        "manufacturerId": " IBM(CLCN)",
+                        "location": {
+                          "lowestRackUnit": 0,
+                          "location": "",
+                          "rack": "",
+                          "room": ""
+                        },
+                        "addinCardSlots": 0,
+                        "serialNumber": "23Y6458",
+                        "driveBays": 17,
+                        "macAddress": "6C:AE:8B:4B:4F:15,6C:AE:8B:4B:4F:16",
+                        "type": "Rack-Tower Server",
+                        "lanOverUsb": "enabled",
+                        "onboardPciDevices": [{
+                          "pciSubID": "0",
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              0
+                            ],
+                            "status": "Active",
+                            "name": "PCIFirmware",
+                            "role": "Primary",
+                            "softwareID": "0:0",
+                            "type": "",
+                            "build": "0",
+                            "date": "",
+                            "version": ""
+                          }],
+                          "fodUniqueID": "",
+                          "pciRevision": "0",
+                          "isAgentless": false,
+                          "pciBusNumber": "27",
+                          "pciSubVendorID": "0",
+                          "isAddOnCard": false,
+                          "pciDeviceNumber": "0",
+                          "posID": "534",
+                          "pciFunctionNumber": "0",
+                          "name": "",
+                          "portInfo": {},
+                          "vpdID": "102b"
+                        }],
+                        "height": 4,
+                        "leds": [{
+                          "color": "Yellow",
+                          "location": "FrontRearPanel",
+                          "name": "Fault",
+                          "state": "Off"
+                        }, {
+                          "color": "Blue",
+                          "location": "FrontRearPanel",
+                          "name": "Identify",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FrontPanel",
+                          "name": "Check Log",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "CNFG",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "CPU",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "PS",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "DASD",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "FAN",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "MEM",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "NMI",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "OVER SPEC",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "TEMP",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "PCI",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "LightPathCard",
+                          "name": "LINK",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 1",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 2",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 3",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 5",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 6",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 7",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 8",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 9",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "FAN 10PEC",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 1",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 2",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 3",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 5",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 6",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 7",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 8",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 9",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 10Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 11Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 12Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 13Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 14Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 15Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 16Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 1",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 2",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 3",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 5",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 6",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 7",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 8",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 9",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "ML2",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 11DIMM 16Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 12DIMM 16Ctlr",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "Planar",
+                          "name": "SysBrd",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "Planar",
+                          "name": "CMOS Batt Error",
+                          "state": "Off"
+                        }, {
+                          "color": "Green",
+                          "location": "FrontRearPanel",
+                          "name": "Power",
+                          "state": "Blinking"
+                        }, {
+                          "color": "Green",
+                          "location": "Planar",
+                          "name": "BMC Heartbeat",
+                          "state": "Blinking"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 17",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 18",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 19",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 20",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 21",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 22",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 23",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 1 DIMM 24",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 1",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 2",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 3",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 5",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 6",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 7",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 8",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 9",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 10",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 11",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 12",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 13",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 14",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 15",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 16",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 17",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 18",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 19",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 20",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 21",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 22",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 23",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 2 DIMM 24",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 1",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 2",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 3",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 5",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 6",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 7",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 8",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 9",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 10",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 11",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 12",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 13",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 14",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 15",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 16",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 17",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 18",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 19",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 20",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 21",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 22",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 23",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 3 DIMM 24",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 1",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 2",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 3",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 5",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 6",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 7",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 8",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 9",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 10",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 11",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 12",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 13",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 14",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 15",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 16",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 17",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 18",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 19",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 20",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 21",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 22",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 23",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "CPU 4 DIMM 24",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "Book 1 Board4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "Book 2 Board4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "Book 3 Board4",
+                          "state": "Off"
+                        }, {
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "Book 4 Board4",
+                          "state": "Off"
+                        }, {
+                          "color": "Amber",
+                          "location": "FRU",
+                          "name": "Book 1 Attention",
+                          "state": "Off"
+                        }, {
+                          "color": "Amber",
+                          "location": "FRU",
+                          "name": "Book 2 Attention",
+                          "state": "Off"
+                        }, {
+                          "color": "Amber",
+                          "location": "FRU",
+                          "name": "Book 3 Attention",
+                          "state": "Off"
+                        }, {
+                          "color": "Amber",
+                          "location": "FRU",
+                          "name": "Book 4 Attention",
+                          "state": "Off"
+                        }],
+                        "description": "Chassis",
+                        "mgmtProcIPaddress": "10.243.6.17",
+                        "expansionCards": [],
+                        "errorFields": [{
+                          "FirmwareData": "NO_CONNECTOR"
+                        }, {
+                          "ChassisMounted": "NO_CONNECTOR"
+                        }],
+                        "FQDN": "cmm-dt1.labs.lenovo.com",
+                        "ipInterfaces": [{
+                          "IPv4enabled": true,
+                          "IPv4DHCPmode": "STATIC_ONLY",
+                          "IPv6enabled": true,
+                          "IPv6DHCPenabled": true,
+                          "IPv4assignments": [{
+                            "id": 0,
+                            "subnet": "255.255.240.0",
+                            "gateway": "0.0.0.0",
+                            "address": "10.243.6.17",
+                            "type": "INUSE"
+                          }],
+                          "IPv6assignments": [{
+                            "id": 0,
+                            "scope": "Global",
+                            "gateway": "0:0:0:0:0:0:0:0",
+                            "source": "Stateless",
+                            "address": "fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15",
+                            "prefix": 64,
+                            "type": "INUSE"
+                          }, {
+                            "id": 0,
+                            "scope": "LinkLocal",
+                            "gateway": "0:0:0:0:0:0:0:0",
+                            "source": "Other",
+                            "address": "fe80:0:0:0:6eae:8bff:fe4b:4f15",
+                            "prefix": 64,
+                            "type": "INUSE"
+                          }],
+                          "name": "eth0",
+                          "IPv6statelessEnabled": true,
+                          "label": "unknown",
+                          "IPv6staticEnabled": false
+                        }],
+                        "firmware": [{
+                          "status": "Active",
+                          "name": "UEFI Firmware/BIOS",
+                          "role": "Primary",
+                          "date": "2017-02-21T00:00:00Z",
+                          "type": "UEFI",
+                          "build": "A9E139GUS",
+                          "version": "4.10"
+                        }, {
+                          "status": "Inactive",
+                          "name": "UEFI Backup Firmware/BIOS",
+                          "role": "Backup",
+                          "date": "2017-02-21T00:00:00Z",
+                          "type": "UEFI-Backup",
+                          "build": "A9E139GUS",
+                          "version": "4.10"
+                        }, {
+                          "status": "Active",
+                          "name": "DSA Diagnostic Software",
+                          "role": "Primary",
+                          "date": "2016-06-07T00:00:00Z",
+                          "type": "DSA",
+                          "build": "DSALA7J",
+                          "version": "10.2"
+                        }, {
+                          "status": "Active",
+                          "name": "IMM2 Firmware",
+                          "role": "Primary",
+                          "date": "2016-12-05T00:00:00Z",
+                          "type": "IMM2",
+                          "build": "TCOO59G",
+                          "version": "9.00"
+                        }, {
+                          "status": "Inactive",
+                          "name": "IMM2 Backup Firmware",
+                          "role": "Backup",
+                          "date": "2016-12-05T00:00:00Z",
+                          "type": "IMM2-Backup",
+                          "build": "TCOO59G",
+                          "version": "9.00"
+                        }],
+                        "bladeState": 0,
+                        "activationKeys": [],
+                        "status": {
+                          "message": "managed",
+                          "name": "MANAGED"
+                        },
+                        "powerCappingPolicy": {
+                          "cappingACorDCMode": "DC",
+                          "minimumHardCapLevel": 439100,
+                          "cappingPolicy": "OFF",
+                          "maxPowerCap": 533000,
+                          "minimumPowerCappingHotPlugLevel": 759000,
+                          "powerCappingAllocUnit": "watts*10^-3",
+                          "maximumPowerCappingHotPlugLevel": 854000,
+                          "currentPowerCap": 0,
+                          "minPowerCap": 130000
+                        },
+                        "hostname": "IMM2-6cae8b4b4f15",
+                        "powerSupplies": [{
+                          "model": "",
+                          "manufacturerId": "",
+                          "serialNumber": "Unknown",
+                          "inputVoltageIsAC": true,
+                          "inputVoltageMin": -1,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Power Supply 1",
+                          "leds": [],
+                          "description": "",
+                          "name": "Power Supply 1",
+                          "userDescription": "",
+                          "manufactureDate": "",
+                          "partNumber": "Unknown",
+                          "firmware": [],
+                          "healthState": "GOOD",
+                          "machineType": "",
+                          "hardwareRevision": "",
+                          "FRU": "",
+                          "uri": "powerSupply/",
+                          "productId": "",
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 900
+                          },
+                          "powerState": "Unknown",
+                          "posID": "",
+                          "slots": [
+                            2
+                          ],
+                          "manufacturer": "Unknown",
+                          "vpdID": "",
+                          "uuid": "",
+                          "productName": "",
+                          "fruSerialNumber": "",
+                          "inputVoltageMax": -1
+                        }, {
+                          "model": "",
+                          "manufacturerId": "",
+                          "serialNumber": "K115136V11E",
+                          "inputVoltageIsAC": true,
+                          "inputVoltageMin": -1,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": "Power Supply 2",
+                          "leds": [],
+                          "description": "",
+                          "name": "Power Supply 2",
+                          "userDescription": "",
+                          "manufactureDate": "",
+                          "partNumber": "94Y8066",
+                          "firmware": [],
+                          "healthState": "GOOD",
+                          "machineType": "",
+                          "hardwareRevision": "",
+                          "FRU": "",
+                          "uri": "powerSupply/",
+                          "productId": "",
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 900
+                          },
+                          "powerState": "Unknown",
+                          "posID": "",
+                          "slots": [
+                            3
+                          ],
+                          "manufacturer": "DELT",
+                          "vpdID": "",
+                          "uuid": "",
+                          "productName": "",
+                          "fruSerialNumber": "",
+                          "inputVoltageMax": -1
+                        }],
+                        "parentComplexID": "7936DD182C5311E3A8D6000AF7256738",
+                        "FRU": "None",
+                        "uri": "node/7936DD182C5311E3A8D6000AF7256738",
+                        "vnicMode": "disabled",
+                        "powerAllocation": {
+                          "maximumAllocatedPower": 1710,
+                          "minimumAllocatedPower": 26
+                        },
+                        "expansionProductType": "",
+                        "powerStatus": 5,
+                        "bootOrder": {
+                          "uri": "node/7936DD182C5311E3A8D6000AF7256738/bootOrder",
+                          "bootOrderList": [{
+                            "currentBootOrderDevices": [
+                              "None"
+                            ],
+                            "bootType": "SingleUse",
+                            "possibleBootOrderDevices": [
+                              "None",
+                              "PXE Network",
+                              "Hard Disk 0",
+                              "Diagnostics",
+                              "CD/DVD Rom",
+                              "Boot To F1",
+                              "Hypervisor",
+                              "Floppy Disk"
+                            ]
+                          }, {
+                            "currentBootOrderDevices": [
+                              "CentOS Linux",
+                              "Hard Disk 0",
+                              "Windows Boot Manager",
+                              "PXE Network",
+                              "CD/DVD Rom"
+                            ],
+                            "bootType": "Permanent",
+                            "possibleBootOrderDevices": [
+                              "CentOS Linux",
+                              "Hard Disk 0",
+                              "Windows Boot Manager",
+                              "PXE Network",
+                              "CD/DVD Rom",
+                              "Floppy Disk",
+                              "Hard Disk 1",
+                              "Hard Disk 2",
+                              "Hard Disk 3",
+                              "Hard Disk 4",
+                              "USB Storage",
+                              "Diagnostics",
+                              "iSCSI",
+                              "iSCSI Critical",
+                              "Embedded Hypervisor",
+                              "Legacy Only",
+                              "USB0",
+                              "USB1",
+                              "USB2",
+                              "USB3",
+                              "USB4",
+                              "USB5",
+                              "USB6",
+                              "USB7",
+                              "DSA",
+                              "Slot16",
+                              "Slot17",
+                              "Slot18",
+                              "Slot19",
+                              "Slot12",
+                              "Slot11",
+                              "Slot10",
+                              "Slot1",
+                              "Slot2",
+                              "Slot3",
+                              "Slot4",
+                              "Slot5",
+                              "Slot6",
+                              "Slot7",
+                              "Slot8",
+                              "Slot9",
+                              "IMM1",
+                              "IMM2"
+                            ]
+                          }, {
+                            "currentBootOrderDevices": [
+                              "PXE Network",
+                              "CD/DVD Rom",
+                              "Hard Disk 0"
+                            ],
+                            "bootType": "WakeOnLAN",
+                            "possibleBootOrderDevices": [
+                              "PXE Network",
+                              "CD/DVD Rom",
+                              "Hard Disk 0",
+                              "CentOS Linux",
+                              "Windows Boot Manager",
+                              "Floppy Disk",
+                              "Hard Disk 1",
+                              "Hard Disk 2",
+                              "Hard Disk 3",
+                              "Hard Disk 4",
+                              "USB Storage",
+                              "Diagnostics",
+                              "iSCSI",
+                              "iSCSI Critical",
+                              "Embedded Hypervisor",
+                              "Legacy Only",
+                              "USB0",
+                              "USB1",
+                              "USB2",
+                              "USB3",
+                              "USB4",
+                              "USB5",
+                              "USB6",
+                              "USB7",
+                              "DSA",
+                              "Slot16",
+                              "Slot17",
+                              "Slot18",
+                              "Slot19",
+                              "Slot12",
+                              "Slot11",
+                              "Slot10",
+                              "Slot1",
+                              "Slot2",
+                              "Slot3",
+                              "Slot4",
+                              "Slot5",
+                              "Slot6",
+                              "Slot7",
+                              "Slot8",
+                              "Slot9",
+                              "IMM1",
+                              "IMM2"
+                            ]
+                          }]
+                        },
+                        "expansionProducts": [],
+                        "ipv6Addresses": [
+                          "fd55:faaf:e1ab:2021:6eae:8bff:fe4b:4f15",
+                          "fe80:0:0:0:6eae:8bff:fe4b:4f15"
+                        ],
+                        "slots": [
+                          1
+                        ],
+                        "manufacturer": " IBM(CLCN)",
+                        "addinCards": [{
+                          "pciSubID": "454",
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              13
+                            ],
+                            "status": "Active",
+                            "name": "MegaRAID Controller Firmware",
+                            "role": "Primary",
+                            "softwareID": "10140454",
+                            "type": "Software Bundle",
+                            "build": "0",
+                            "date": "2016-07-20T00:00:00Z",
+                            "version": "24.12.0-0033"
+                          }],
+                          "slotSupportsHotPlug": "false",
+                          "fodUniqueID": "N/A",
+                          "pciRevision": "2",
+                          "isAgentless": true,
+                          "pciBusNumber": "7",
+                          "pciSubVendorID": "1014",
+                          "isAddOnCard": true,
+                          "FRU": "N/A",
+                          "pciDeviceNumber": "0",
+                          "slotNumber": "12",
+                          "posID": "5d",
+                          "pciFunctionNumber": "0",
+                          "manufacturer": "IBM",
+                          "name": "ServeRAID M5210",
+                          "portInfo": {},
+                          "vpdID": "1000",
+                          "productName": "ServeRAID M5210",
+                          "partNumber": "N/A",
+                          "fruSerialNumber": "SV334P0606",
+                          "slotName": "SlotDesig7_Slot 12 (Pri Storage)"
+                        }, {
+                          "pciSubID": "450",
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              33024
+                            ],
+                            "status": "Active",
+                            "name": "17.4.4.2a",
+                            "role": "Primary",
+                            "softwareID": "10140450",
+                            "type": "VPD-V0",
+                            "build": "0",
+                            "date": "",
+                            "version": "17.4.4.2a"
+                          }],
+                          "slotSupportsHotPlug": "false",
+                          "fodUniqueID": "11S90Y9372Y0502037P0ES",
+                          "pciRevision": "0",
+                          "isAgentless": true,
+                          "pciBusNumber": "145",
+                          "pciSubVendorID": "1014",
+                          "isAddOnCard": true,
+                          "FRU": "90Y9373",
+                          "pciDeviceNumber": "0",
+                          "slotNumber": "7",
+                          "posID": "165f",
+                          "pciFunctionNumber": "0",
+                          "manufacturer": "IBM",
+                          "name": "Broadcom 2-port 1GbE NIC Card for IBM",
+                          "portInfo": {
+                            "physicalPorts": [{
+                              "portType": "ETHERNET",
+                              "portNumber": 49,
+                              "logicalPorts": [{
+                                "portType": "ETHERNET",
+                                "portNumber": 1,
+                                "logicalPortIndex": 1,
+                                "addresses": "000AF7256738",
+                                "vnicMode": false
+                              }],
+                              "peerBay": 0,
+                              "physicalPortIndex": 1
+                            }]
+                          },
+                          "vpdID": "14e4",
+                          "productName": "Broadcom 2-port 1GbE NIC Card for IBM",
+                          "partNumber": "90Y9372",
+                          "fruSerialNumber": "Y0502037P0ES",
+                          "slotName": "SlotDesig6_Slot 7"
+                        }, {
+                          "pciSubID": "450",
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              33024
+                            ],
+                            "status": "Active",
+                            "name": "17.4.4.2a",
+                            "role": "Primary",
+                            "softwareID": "10140450",
+                            "type": "VPD-V0",
+                            "build": "0",
+                            "date": "",
+                            "version": "17.4.4.2a"
+                          }],
+                          "slotSupportsHotPlug": "false",
+                          "fodUniqueID": "11S90Y9372Y0502037P0ES",
+                          "pciRevision": "0",
+                          "isAgentless": true,
+                          "pciBusNumber": "145",
+                          "pciSubVendorID": "1014",
+                          "isAddOnCard": true,
+                          "FRU": "90Y9373",
+                          "pciDeviceNumber": "0",
+                          "slotNumber": "7",
+                          "posID": "165f",
+                          "pciFunctionNumber": "1",
+                          "manufacturer": "IBM",
+                          "name": "Broadcom 2-port 1GbE NIC Card for IBM",
+                          "portInfo": {
+                            "physicalPorts": [{
+                              "portType": "ETHERNET",
+                              "portNumber": 50,
+                              "logicalPorts": [{
+                                "portType": "ETHERNET",
+                                "portNumber": 1,
+                                "logicalPortIndex": 1,
+                                "addresses": "000AF7256739",
+                                "vnicMode": false
+                              }],
+                              "peerBay": 0,
+                              "physicalPortIndex": 2
+                            }]
+                          },
+                          "vpdID": "14e4",
+                          "productName": "Broadcom 2-port 1GbE NIC Card for IBM",
+                          "partNumber": "90Y9372",
+                          "fruSerialNumber": "Y0502037P0ES",
+                          "slotName": "SlotDesig6_Slot 7"
+                        }],
+                        "parentPartitionUUID": "",
+                        "raidSettings": [{
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              10
+                            ],
+                            "status": "Active",
+                            "name": "MegaRAID Controller Firmware",
+                            "role": "Primary",
+                            "type": "Firmware",
+                            "build": "0",
+                            "date": "2017-06-15T00:00:00Z",
+                            "version": "24.21.0-0016",
+                            "softwareID": "101404AC"
+                          }],
+                          "description": "ServeRAID M1210e",
+                          "name": "ServeRAID M1210e",
+                          "uuid": "000000000000000050050760670002AC",
+                          "diskDrives": [{
+                            "model": "ST300MM0006",
+                            "healthState": "Normal",
+                            "numberOfBlocks": 585937500,
+                            "interfaceType": "SAS",
+                            "serialNumber": "S0K2QNGE",
+                            "blockSize": 512,
+                            "mediaType": "Rotational",
+                            "diskState": "Online",
+                            "bay": 0,
+                            "description": "ST300MM0006",
+                            "manufacturer": "IBM-ESXS",
+                            "name": "Disk 0_e",
+                            "uuid": "",
+                            "partNumber": "00AJ100",
+                            "largestAvailableSize": 512,
+                            "capacity": 300000000000,
+                            "m2Location": "",
+                            "softwareData": [{
+                              "revision": "0",
+                              "classifications": [
+                                10
+                              ],
+                              "status": "Active",
+                              "name": "Drive",
+                              "role": "Primary",
+                              "type": "Firmware",
+                              "build": "0",
+                              "date": "",
+                              "version": "B56T",
+                              "softwareID": "ST300MM0006"
+                            }],
+                            "FRU": "00AJ097"
+                          }],
+                          "storagePools": [{
+                            "name": "Pool_0",
+                            "arrayUid": "0",
+                            "description": "000000000000000050050760670002AC_Storage Pool_M1210e_000000000000000050050760670002AC_30:Pool:0",
+                            "arrayStatus": "Offline",
+                            "totalManagedSpace": 298999349248,
+                            "remainingSpace": 0,
+                            "raidLevel": 0,
+                            "storageVolumes": [{
+                              "name": "GenericR0_0",
+                              "bootable": true,
+                              "description": "Volume 0 000000000000000050050760670002AC_0",
+                              "blockSize": 512,
+                              "numberOfBlocks": 583983104,
+                              "primaryPartition": 0,
+                              "stripeSize": 65536,
+                              "volumeStatus": "Dynamic Reconfig",
+                              "volumeID": "104",
+                              "volumeUID": "0",
+                              "driveIndex": 0,
+                              "removable": false,
+                              "health": "Unknown",
+                              "LUN": -1
+                            }],
+                            "diskDrives": [{
+                              "model": "ST300MM0006",
+                              "healthState": "Normal",
+                              "numberOfBlocks": 585937500,
+                              "interfaceType": "SAS",
+                              "serialNumber": "S0K2QNGE",
+                              "blockSize": 512,
+                              "mediaType": "Rotational",
+                              "diskState": "Online",
+                              "bay": 0,
+                              "description": "ST300MM0006",
+                              "manufacturer": "IBM-ESXS",
+                              "name": "Disk 0_e",
+                              "uuid": "",
+                              "partNumber": "00AJ100",
+                              "largestAvailableSize": 512,
+                              "capacity": 300000000000,
+                              "m2Location": "",
+                              "softwareData": [{
+                                "revision": "0",
+                                "classifications": [
+                                  10
+                                ],
+                                "status": "Active",
+                                "name": "Drive",
+                                "role": "Primary",
+                                "type": "Firmware",
+                                "build": "0",
+                                "date": "",
+                                "version": "B56T",
+                                "softwareID": "ST300MM0006"
+                              }],
+                              "FRU": "00AJ097"
+                            }]
+                          }],
+                          "batteryData": []
+                        }],
+                        "vpdID": "",
+                        "uuid": "7936DD182C5311E3A8D6000AF7256738",
+                        "isConnectionTrusted": "true",
+                        "memoryModules": [{
+                          "model": "DDR3",
+                          "speed": 1600,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 4,
+                          "serialNumber": "3AAF65F9",
+                          "displayName": "CPU 1 DIMM 9",
+                          "slot": 9,
+                          "type": "DDR3",
+                          "partNumber": "Unknown"
+                        }, {
+                          "model": "DDR3",
+                          "speed": 1600,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 4,
+                          "serialNumber": "3AAF65FA",
+                          "displayName": "CPU 1 DIMM 15",
+                          "slot": 15,
+                          "type": "DDR3",
+                          "partNumber": "Unknown"
+                        }, {
+                          "model": "DDR3",
+                          "speed": 1600,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 4,
+                          "serialNumber": "3AAF65FE",
+                          "displayName": "CPU 2 DIMM 9",
+                          "slot": 9,
+                          "type": "DDR3",
+                          "partNumber": "Unknown"
+                        }, {
+                          "model": "DDR3",
+                          "speed": 1600,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 4,
+                          "serialNumber": "3AAF6603",
+                          "displayName": "CPU 2 DIMM 15",
+                          "slot": 15,
+                          "type": "DDR3",
+                          "partNumber": "Unknown"
+                        }],
+                        "partitionEnabled": false,
+                        "fruSerialNumber": "None",
+                        "secureBootMode": {
+                          "possibleValues": [
+                            "Disabled",
+                            "Enabled"
+                          ],
+                          "currentValue": "Disabled"
+                        },
+                        "encapsulation": {
+                          "encapsulationMode": "normal"
+                        },
+                        "tlsVersion": {
+                          "possibleValues": [
+                            "TLS_10",
+                            "TLS_11",
+                            "TLS_12",
+                            "unsupported"
+                          ],
+                          "currentValue": "TLS_10"
+                        },
+                        "model": "AC1",
+                        "isScalable": true,
+                        "expansionCardSlots": 0,
+                        "fans": [],
+                        "isITME": false,
+                        "hostMacAddresses": "00:0A:F7:25:67:38,00:0A:F7:25:67:39",
+                        "contact": "",
+                        "dataHandle": 1496851623453,
+                        "ipv4Addresses": [
+                          "10.243.6.17",
+                          "169.254.95.118"
+                        ],
+                        "cmmDisplayName": "Management Controller UUID-7936DD182C5311E3A8D6000AF7256738",
+                        "backedBy": "real",
+                        "complexID": 1,
+                        "name": "17dspncsvdm",
+                        "memorySlots": 0,
+                        "drives": [],
+                        "cmmHealthState": "Normal",
+                        "userDescription": "",
+                        "subSlots": [],
+                        "partNumber": "00D0188     ",
+                        "excludedHealthState": "Normal",
+                        "machineType": "6241",
+                        "isRemotePresenceEnabled": true,
+                        "pciDevices": [{
+                          "pciSubID": "454",
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              13
+                            ],
+                            "status": "Active",
+                            "name": "MegaRAID Controller Firmware",
+                            "role": "Primary",
+                            "softwareID": "10140454",
+                            "type": "Software Bundle",
+                            "build": "0",
+                            "date": "2016-07-20T00:00:00Z",
+                            "version": "24.12.0-0033"
+                          }],
+                          "slotSupportsHotPlug": "false",
+                          "fodUniqueID": "N/A",
+                          "pciRevision": "2",
+                          "isAgentless": true,
+                          "pciBusNumber": "7",
+                          "pciSubVendorID": "1014",
+                          "isAddOnCard": true,
+                          "FRU": "N/A",
+                          "pciDeviceNumber": "0",
+                          "slotNumber": "12",
+                          "posID": "5d",
+                          "pciFunctionNumber": "0",
+                          "manufacturer": "IBM",
+                          "name": "ServeRAID M5210",
+                          "portInfo": {},
+                          "vpdID": "1000",
+                          "productName": "ServeRAID M5210",
+                          "partNumber": "N/A",
+                          "fruSerialNumber": "SV334P0606",
+                          "slotName": "SlotDesig7_Slot 12 (Pri Storage)"
+                        }, {
+                          "pciSubID": "0",
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              0
+                            ],
+                            "status": "Active",
+                            "name": "PCIFirmware",
+                            "role": "Primary",
+                            "softwareID": "0:0",
+                            "type": "",
+                            "build": "0",
+                            "date": "",
+                            "version": ""
+                          }],
+                          "fodUniqueID": "",
+                          "pciRevision": "0",
+                          "isAgentless": false,
+                          "pciBusNumber": "27",
+                          "pciSubVendorID": "0",
+                          "isAddOnCard": false,
+                          "pciDeviceNumber": "0",
+                          "posID": "534",
+                          "pciFunctionNumber": "0",
+                          "name": "",
+                          "portInfo": {},
+                          "vpdID": "102b"
+                        }, {
+                          "pciSubID": "450",
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              33024
+                            ],
+                            "status": "Active",
+                            "name": "17.4.4.2a",
+                            "role": "Primary",
+                            "softwareID": "10140450",
+                            "type": "VPD-V0",
+                            "build": "0",
+                            "date": "",
+                            "version": "17.4.4.2a"
+                          }],
+                          "slotSupportsHotPlug": "false",
+                          "fodUniqueID": "11S90Y9372Y0502037P0ES",
+                          "pciRevision": "0",
+                          "isAgentless": true,
+                          "pciBusNumber": "145",
+                          "pciSubVendorID": "1014",
+                          "isAddOnCard": true,
+                          "FRU": "90Y9373",
+                          "pciDeviceNumber": "0",
+                          "slotNumber": "7",
+                          "posID": "165f",
+                          "pciFunctionNumber": "0",
+                          "manufacturer": "IBM",
+                          "name": "Broadcom 2-port 1GbE NIC Card for IBM",
+                          "portInfo": {
+                            "physicalPorts": [{
+                              "portType": "ETHERNET",
+                              "portNumber": 49,
+                              "logicalPorts": [{
+                                "portType": "ETHERNET",
+                                "portNumber": 1,
+                                "logicalPortIndex": 1,
+                                "addresses": "000AF7256738",
+                                "vnicMode": false
+                              }],
+                              "peerBay": 0,
+                              "physicalPortIndex": 1
+                            }]
+                          },
+                          "vpdID": "14e4",
+                          "productName": "Broadcom 2-port 1GbE NIC Card for IBM",
+                          "partNumber": "90Y9372",
+                          "fruSerialNumber": "Y0502037P0ES",
+                          "slotName": "SlotDesig6_Slot 7"
+                        }, {
+                          "pciSubID": "450",
+                          "firmware": [{
+                            "revision": "0",
+                            "classifications": [
+                              33024
+                            ],
+                            "status": "Active",
+                            "name": "17.4.4.2a",
+                            "role": "Primary",
+                            "softwareID": "10140450",
+                            "type": "VPD-V0",
+                            "build": "0",
+                            "date": "",
+                            "version": "17.4.4.2a"
+                          }],
+                          "slotSupportsHotPlug": "false",
+                          "fodUniqueID": "11S90Y9372Y0502037P0ES",
+                          "pciRevision": "0",
+                          "isAgentless": true,
+                          "pciBusNumber": "145",
+                          "pciSubVendorID": "1014",
+                          "isAddOnCard": true,
+                          "FRU": "90Y9373",
+                          "pciDeviceNumber": "0",
+                          "slotNumber": "7",
+                          "posID": "165f",
+                          "pciFunctionNumber": "1",
+                          "manufacturer": "IBM",
+                          "name": "Broadcom 2-port 1GbE NIC Card for IBM",
+                          "portInfo": {
+                            "physicalPorts": [{
+                              "portType": "ETHERNET",
+                              "portNumber": 50,
+                              "logicalPorts": [{
+                                "portType": "ETHERNET",
+                                "portNumber": 1,
+                                "logicalPortIndex": 1,
+                                "addresses": "000AF7256739",
+                                "vnicMode": false
+                              }],
+                              "peerBay": 0,
+                              "physicalPortIndex": 2
+                            }]
+                          },
+                          "vpdID": "14e4",
+                          "productName": "Broadcom 2-port 1GbE NIC Card for IBM",
+                          "partNumber": "90Y9372",
+                          "fruSerialNumber": "Y0502037P0ES",
+                          "slotName": "SlotDesig6_Slot 7"
+                        }],
+                        "domainName": "",
+                        "processors": [{
+                          "speed": 2.2,
+                          "manufacturer": "Intel(R) Corporation",
+                          "family": "PENTIUM_R_4",
+                          "displayName": "Intel(R) Xeon(R) CPU E7-8880L v2 @ 2.20GHz",
+                          "slot": 1,
+                          "productVersion": "Intel(R) Xeon(R) CPU E7-8880L v2 @ 2.20GHz",
+                          "cores": 15
+                        }, {
+                          "speed": 2.2,
+                          "manufacturer": "Intel(R) Corporation",
+                          "family": "PENTIUM_R_4",
+                          "displayName": "Intel(R) Xeon(R) CPU E7-8880L v2 @ 2.20GHz",
+                          "slot": 2,
+                          "productVersion": "Intel(R) Xeon(R) CPU E7-8880L v2 @ 2.20GHz",
+                          "cores": 15
+                        }],
+                        "processorSlots": 0,
+                        "pciCapabilities": [
+                          "Raid Link",
+                          "OOB PCIe",
+                          "Raid Link Config",
+                          "Raid Link Alert",
+                          "OOB PCIe Config"
+                        ],
+                        "productId": "4D4F00",
+                        "hasOS": false,
+                        "lanOverUsbPortForwardingModes": [{
+                          "state": "disabled",
+                          "type": "DSA",
+                          "externalIPAddress": ""
+                        }, {
+                          "state": "disabled",
+                          "type": "OSDeploy",
+                          "externalIPAddress": ""
+                        }],
+                        "bootMode": {
+                          "possibleValues": [
+                            "UEFI Mode",
+                            "Legacy Mode"
+                          ],
+                          "currentValue": "UEFI Mode"
+                        },
+                        "ports": [{
+                          "ioModuleBay": 0,
+                          "portNumber": 49
+                        }, {
+                          "ioModuleBay": 0,
+                          "portNumber": 50
+                        }],
+                        "embeddedHypervisorPresence": false,
+                        "posID": "",
+                        "nist": {
+                          "possibleValues": [
+                            "Compatibility",
+                            "Nist_800_131A_Strict",
+                            "unsupported"
+                          ],
+                          "currentValue": "Compatibility"
+                        },
+                        "overallHealthState": "Normal",
+                        "subType": "",
+                        "partitionID": -1,
+                        "physicalID": 0,
+                        "flashStorage": [],
+                        "productName": "Lenovo System x3850 X6"
+                      },
+                      "complexNodeUUIDs": [
+                        "7936DD182C5311E3A8D6000AF7256738"
+                      ],
+                      "complexID": "7936DD182C5311E3A8D6000AF7256738",
+                      "itemLocationRack": "",
+                      "physicalID": 0,
+                      "nodeCount": 1,
+                      "itemLocation": "",
+                      "itemLocationRoom": ""
+                    }],
+                    "placeholderList": [],
+                    "switchList": [],
+                    "room": ""
+                  }, {
+                    "storageList": [],
+                    "cabinetName": "STANDALONE_OBJECT_NAME",
+                    "height": 42,
+                    "complexList": [],
+                    "chassisList": [],
+                    "location": "",
+                    "UUID": "STANDALONE_OBJECT_UUID",
+                    "nodeList": [{
+                      "itemParentUUID": null,
+                      "itemName": "SERVER-A59D5B36821111E1A9F5E41F13ED4F6A",
+                      "itemLowerUnit": 0,
+                      "itemType": "SERVER",
+                      "itemLocationRack": "",
+                      "itemSubType": "LegacyServer",
+                      "itemUUID": "A59D5B36821111E1A9F5E41F13ED4F6A",
+                      "itemInventory": {
+                        "accessState": "Pending",
+                        "arch": "x86_64",
+                        "manufacturerId": "",
+                        "location": {
+                          "lowestRackUnit": 0,
+                          "location": "",
+                          "rack": "",
+                          "room": ""
+                        },
+                        "addinCardSlots": 0,
+                        "serialNumber": "06ARFA2",
+                        "driveBays": 0,
+                        "macAddress": "e4:1f:13:ed:4f:6f",
+                        "type": "Rack-Tower Server",
+                        "lanOverUsb": "disabled",
+                        "height": 1,
+                        "leds": [{
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Front Panel",
+                          "name": "Check Log",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Front Panel",
+                          "name": "Fault",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Attention",
+                          "color": "Blue",
+                          "location": "Front Panel",
+                          "name": "Identify",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Health",
+                          "color": "Green",
+                          "location": "Front Panel",
+                          "name": "Power",
+                          "state": "On"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "BOARD",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "Battery",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "CONFIG",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "CPU",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "CPU 1",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "CPU 2",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 1",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 10",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 11",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 12",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 13",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 14",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 15",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 16",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 17",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 18",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 19",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 2",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 20",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 21",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 22",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 23",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 24",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 3",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 4",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 5",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 6",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 7",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 8",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "DIMM 9",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "FAN",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "FAN 1",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "FAN 2",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "FAN 3",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "FAN 4",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "FAN 5",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "FAN 6",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "HDD",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Health",
+                          "color": "Green",
+                          "location": "System Board",
+                          "name": "IMM2 Heartbeat",
+                          "state": "Blink"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "Internal RAID",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Health",
+                          "color": "Green",
+                          "location": "Lightpath Card",
+                          "name": "LINK",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "MEM",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "Mezz Card Error",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "NMI",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "OVER SPEC",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "PCI",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 1",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "FRU",
+                          "name": "PCI 2",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "PS",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Status",
+                          "color": "Green",
+                          "location": "FRU",
+                          "name": "Power",
+                          "state": "On"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "System Board",
+                          "name": "SysBrd Fault",
+                          "state": "Off"
+                        }, {
+                          "conditions": "Warning",
+                          "color": "Yellow",
+                          "location": "Lightpath Card",
+                          "name": "TEMP",
+                          "state": "Off"
+                        }],
+                        "description": "chassis System x3550 M4",
+                        "mgmtProcIPaddress": "10.243.9.111",
+                        "expansionCards": [],
+                        "errorFields": [],
+                        "FQDN": "ratchetimm1.labs.lenovo.com",
+                        "ipInterfaces": [],
+                        "firmware": [{
+                          "status": "ACTIVE",
+                          "name": "IMM",
+                          "role": "",
+                          "date": "",
+                          "type": "IMM",
+                          "build": "",
+                          "version": "1AOO72H-5.60"
+                        }, {
+                          "status": "ACTIVE",
+                          "name": "Preboot DSA",
+                          "role": "",
+                          "date": "",
+                          "type": "Preboot DSA",
+                          "build": "",
+                          "version": "DSYTD8G-9.54"
+                        }, {
+                          "status": "ACTIVE",
+                          "name": "UEFI",
+                          "role": "",
+                          "date": "",
+                          "type": "UEFI",
+                          "build": "",
+                          "version": "D7E152CUS-2.11"
+                        }],
+                        "bladeState": 0,
+                        "activationKeys": [],
+                        "status": {
+                          "message": "managed",
+                          "name": "MANAGED"
+                        },
+                        "powerCappingPolicy": {
+                          "cappingACorDCMode": "UNKNOWN",
+                          "minimumHardCapLevel": -1,
+                          "cappingPolicy": "UNKNOWN",
+                          "maxPowerCap": -1,
+                          "minimumPowerCappingHotPlugLevel": -1,
+                          "powerCappingAllocUnit": "watts",
+                          "maximumPowerCappingHotPlugLevel": -1,
+                          "currentPowerCap": 0,
+                          "minPowerCap": -1
+                        },
+                        "hostname": "IMM-e41f13ed4f6f",
+                        "powerSupplies": [{
+                          "model": "43X3313",
+                          "manufacturerId": "EMER",
+                          "serialNumber": " K1181227068",
+                          "inputVoltageIsAC": false,
+                          "inputVoltageMin": 0,
+                          "type": "PowerSupply",
+                          "dataHandle": 0,
+                          "cmmDisplayName": null,
+                          "leds": [{
+                            "color": "Green",
+                            "location": "FRU",
+                            "name": "IN",
+                            "state": "On"
+                          }, {
+                            "color": "Green",
+                            "location": "FRU",
+                            "name": "OUT",
+                            "state": "On"
+                          }, {
+                            "color": "Amber",
+                            "location": "FRU",
+                            "name": "FAULT",
+                            "state": "Off"
+                          }],
+                          "description": "Power Supply 1",
+                          "name": " K1181227068",
+                          "userDescription": null,
+                          "manufactureDate": "2011-12-02",
+                          "partNumber": null,
+                          "firmware": [],
+                          "healthState": "GOOD",
+                          "machineType": null,
+                          "hardwareRevision": null,
+                          "FRU": null,
+                          "uri": "powerSupply/null",
+                          "productId": null,
+                          "powerAllocation": {
+                            "totalInputPower": 0,
+                            "totalOutputPower": 0
+                          },
+                          "powerState": null,
+                          "posID": null,
+                          "slots": [
+                            0
+                          ],
+                          "manufacturer": null,
+                          "vpdID": null,
+                          "uuid": null,
+                          "productName": null,
+                          "fruSerialNumber": null,
+                          "inputVoltageMax": 0
+                        }],
+                        "FRU": "",
+                        "thinkServerFru": [],
+                        "uri": "node/A59D5B36821111E1A9F5E41F13ED4F6A",
+                        "vnicMode": "disabled",
+                        "powerAllocation": {
+                          "maximumAllocatedPower": 0,
+                          "minimumAllocatedPower": 0
+                        },
+                        "expansionProductType": "",
+                        "powerStatus": 8,
+                        "bootOrder": {
+                          "uri": "node/A59D5B36821111E1A9F5E41F13ED4F6A/bootOrder",
+                          "bootOrderList": [{
+                            "currentBootOrderDevices": [
+                              "default"
+                            ],
+                            "bootType": "SingleUse",
+                            "possibleBootOrderDevices": [
+                              "setup",
+                              "network",
+                              "hd",
+                              "cd",
+                              "default"
+                            ]
+                          }]
+                        },
+                        "expansionProducts": [],
+                        "ipv6Addresses": [
+                          "fe80::e61f:13ff:feed:4f6f"
+                        ],
+                        "slots": [
+                          1
+                        ],
+                        "manufacturer": " IBM",
+                        "raidSettings": [],
+                        "vpdID": "",
+                        "uuid": "A59D5B36821111E1A9F5E41F13ED4F6A",
+                        "isConnectionTrusted": "true",
+                        "memoryModules": [{
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "39170a03",
+                          "displayName": "DIMM 1",
+                          "slot": 1,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "1a8c3c13",
+                          "displayName": "DIMM 2",
+                          "slot": 2,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "d673191b",
+                          "displayName": "DIMM 4",
+                          "slot": 4,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "1a8c3c0a",
+                          "displayName": "DIMM 5",
+                          "slot": 5,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "354074cd",
+                          "displayName": "DIMM 8",
+                          "slot": 8,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "d673192d",
+                          "displayName": "DIMM 9",
+                          "slot": 9,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "d673192e",
+                          "displayName": "DIMM 11",
+                          "slot": 11,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "354074c3",
+                          "displayName": "DIMM 12",
+                          "slot": 12,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "354074c7",
+                          "displayName": "DIMM 13",
+                          "slot": 13,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "1a8c3c82",
+                          "displayName": "DIMM 14",
+                          "slot": 14,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "d67318fb",
+                          "displayName": "DIMM 16",
+                          "slot": 16,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "1a8c3c75",
+                          "displayName": "DIMM 17",
+                          "slot": 17,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "d67318f3",
+                          "displayName": "DIMM 20",
+                          "slot": 20,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "d67318ff",
+                          "displayName": "DIMM 21",
+                          "slot": 21,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "d67318ef",
+                          "displayName": "DIMM 23",
+                          "slot": 23,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }, {
+                          "model": "",
+                          "voltage": null,
+                          "speed": 12800,
+                          "manufacturer": "Micron Technology",
+                          "capacity": 8,
+                          "serialNumber": "35407515",
+                          "displayName": "DIMM 24",
+                          "slot": 24,
+                          "type": "DDR3 SDRAM",
+                          "partNumber": "36JSF1G72PZ-1G6M1 "
+                        }],
+                        "fruSerialNumber": "Y015UN23X06L",
+                        "secureBootMode": {
+                          "possibleValues": [],
+                          "currentValue": ""
+                        },
+                        "tlsVersion": {
+                          "possibleValues": [
+                            "TLS_10",
+                            "TLS_11",
+                            "TLS_12",
+                            "unsupported"
+                          ],
+                          "currentValue": "unsupported"
+                        },
+                        "model": "AC1",
+                        "isScalable": false,
+                        "expansionCardSlots": 0,
+                        "fans": [],
+                        "isITME": false,
+                        "hostMacAddresses": "",
+                        "contact": "",
+                        "dataHandle": 0,
+                        "ipv4Addresses": [
+                          "10.243.9.111"
+                        ],
+                        "cmmDisplayName": "",
+                        "backedBy": "real",
+                        "complexID": -1,
+                        "name": "IMM-e41f13ed4f6f",
+                        "memorySlots": 0,
+                        "drives": [],
+                        "cmmHealthState": "Normal",
+                        "userDescription": "",
+                        "subSlots": [],
+                        "partNumber": null,
+                        "excludedHealthState": "Normal",
+                        "machineType": "7914",
+                        "isRemotePresenceEnabled": false,
+                        "pciDevices": [],
+                        "domainName": "",
+                        "processors": [{
+                          "speed": 2.7,
+                          "manufacturer": "Intel(R) Corporation",
+                          "family": "Intel(R) Xeon(R) processor",
+                          "displayName": "",
+                          "slot": 1,
+                          "productVersion": "Intel(R) Xeon(R) CPU E5-2680 0 @ 2.70GHz",
+                          "cores": 8
+                        }, {
+                          "speed": 2.7,
+                          "manufacturer": "Intel(R) Corporation",
+                          "family": "Intel(R) Xeon(R) processor",
+                          "displayName": "",
+                          "slot": 2,
+                          "productVersion": "Intel(R) Xeon(R) CPU E5-2680 0 @ 2.70GHz",
+                          "cores": 8
+                        }],
+                        "processorSlots": 0,
+                        "pciCapabilities": [],
+                        "productId": "",
+                        "hasOS": false,
+                        "bootMode": {
+                          "possibleValues": [
+                            "uefi",
+                            "bios"
+                          ],
+                          "currentValue": "unspecified"
+                        },
+                        "ports": [],
+                        "embeddedHypervisorPresence": false,
+                        "posID": "",
+                        "nist": {
+                          "possibleValues": [
+                            "Compatibility",
+                            "Nist_800_131A_Strict",
+                            "Nist_800_131A_Custom",
+                            "unsupported"
+                          ],
+                          "currentValue": "unsupported"
+                        },
+                        "overallHealthState": "Normal",
+                        "subType": "LegacyServer",
+                        "partitionID": -1,
+                        "flashStorage": [],
+                        "productName": "System x3550 M4"
+                      },
+                      "itemLocation": "",
+                      "itemHeight": 1,
+                      "itemLocationRoom": ""
+                    }],
+                    "placeholderList": [],
+                    "switchList": [],
+                    "room": ""
+                  }]
+                }'
     http_version:
   recorded_at: Mon, 24 Apr 2017 18:45:40 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
- Parse Physical Chassis informations and maps the relationship to Physical Servers that live inside a chassi.
- Added chassis to the /cabinet mock.

Depends on:
- ~[ManageIQ/manageiq-schema#183](https://github.com/ManageIQ/manageiq-schema/pull/183) [Merged]~