### PR TITLE
Adding Storage Devices parser

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/physical_server_parser.rb
@@ -1,5 +1,6 @@
 require_relative 'component_parser'
 require_relative 'network_device_parser'
+require_relative 'storage_device_parser'
 
 module ManageIQ::Providers::Lenovo
   module Parsers
@@ -79,6 +80,7 @@ module ManageIQ::Providers::Lenovo
 
         def get_guest_devices(node)
           guest_devices = NetworkDeviceParser.parse_network_devices(node)
+          guest_devices.concat(StorageDeviceParser.parse_storage_device(node))
           guest_devices << parse_management_device(node)
         end
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/storage_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parsers/components/storage_device_parser.rb
@@ -1,0 +1,89 @@
+require_relative 'component_parser'
+
+module ManageIQ::Providers::Lenovo
+  module Parsers
+    class StorageDeviceParser < ComponentParser
+      class << self
+        #
+        # @param [XClarityClient::Node] component - component that has storage devices
+        #
+        def parse_storage_device(component)
+          devices = distinct_storage_devices(select_storage_devices(component))
+
+          devices.map do |device|
+            parse_device(device)
+          end
+        end
+
+        private
+
+        #
+        # Mount the storage device from a hash object
+        #
+        # @param [Hash] device - a hash containing the storage device informations
+        #
+        def parse_device(device)
+          {
+            :uid_ems                => mount_uuid(device),
+            :device_name            => device["productName"] ? device["productName"] : device["name"],
+            :device_type            => "storage",
+            :firmwares              => parse_device_firmware(device),
+            :manufacturer           => device["manufacturer"],
+            :field_replaceable_unit => device["FRU"],
+            :location               => device['slotNumber'] ? "Bay #{device['slotNumber']}" : nil,
+            :controller_type        => device["class"],
+          }
+        end
+
+        #
+        # Selects all storage devices.
+        #   The storage devices could be in `pci_devices` or `addin_cards` prop
+        #
+        def select_storage_devices(component)
+          pci_devices = component.try(:pciDevices).try(:select) { |device| storage_device?(device) }
+          addin_cards = component.try(:addinCards).try(:select) { |device| storage_device?(device) }
+
+          devices = []
+          devices.concat(pci_devices) if pci_devices.present?
+          devices.concat(addin_cards) if addin_cards.present?
+          devices
+        end
+
+        def distinct_storage_devices(devices)
+          devices.uniq { |device| mount_uuid(device) }
+        end
+
+        def storage_device?(device)
+          device_name = (device["productName"] ? device["productName"] : device["name"]).try(:downcase)
+          device["class"] == "Mass storage controller" || device_name =~ /serveraid/ || device_name =~ /sd media raid/
+        end
+
+        def parse_device_firmware(device)
+          device_fw = []
+
+          firmware = device["firmware"]
+          unless firmware.nil?
+            device_fw = firmware.map do |fw|
+              parse_firmware(fw)
+            end
+          end
+
+          device_fw
+        end
+
+        def parse_firmware(firmware)
+          {
+            :name         => "#{firmware["role"]} #{firmware["name"]}-#{firmware["status"]}",
+            :build        => firmware["build"],
+            :version      => firmware["version"],
+            :release_date => firmware["date"],
+          }
+        end
+
+        def mount_uuid(device)
+          device["uuid"] || "#{device['pciBusNumber']}#{device['pciDeviceNumber']}"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -39,6 +39,9 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
   context 'parse physical servers' do
     before do
       @result = ems_inv_to_hashes
+      physical_server = @result[:physical_servers].second
+      computer_system = physical_server[:computer_system]
+      @hardware = computer_system[:hardware]
     end
 
     it 'will retrieve physical servers' do
@@ -46,10 +49,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
     end
 
     it 'will retrieve addin cards on the physical servers' do
-      physical_server = @result[:physical_servers][1]
-      computer_system = physical_server[:computer_system]
-      hardware = computer_system[:hardware]
-      guest_device = hardware[:guest_devices][0]
+      guest_device = @hardware[:guest_devices][0]
 
       expect(guest_device[:device_name]).to eq("Broadcom 2-port 1GbE NIC Card for IBM")
       expect(guest_device[:device_type]).to eq("ethernet")
@@ -64,6 +64,15 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(child_device[:address]).to eq("00:0A:F7:25:67:38")
       expect(child_device[:device_type]).to eq("physical_port")
       expect(child_device[:device_name]).to eq("Physical Port 1")
+    end
+
+    it 'will retrieve storage device' do
+      storage_device = @hardware[:guest_devices].second
+
+      expect(storage_device[:device_name]).to eq("ServeRAID M5210")
+      expect(storage_device[:device_type]).to eq("storage")
+      expect(storage_device[:manufacturer]).to eq("IBM")
+      expect(storage_device[:location]).to eq("Bay 12")
     end
 
     %i(

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -100,7 +100,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
   def assert_table_counts
     expect(PhysicalRack.count).to eq(3)
     expect(PhysicalServer.count).to eq(2)
-    expect(GuestDevice.count).to eq(5)
+    expect(GuestDevice.count).to eq(6)
   end
 
   def assert_guest_table_contents


### PR DESCRIPTION
__This PR is able to:__
- Add Storage Devices to `guest_devices` physical server prop;
- Create `StorageDeviceParser` to parse the storage devices informations;
- Add some specs for new devices.