### PR TITLE
Update xclarity_client gem

### DIFF
--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,lib}/**/*"]
 
-  s.add_dependency "xclarity_client", "~> 0.5.3"
+  s.add_dependency "xclarity_client", "~> 0.6.0"
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "webmock", "~> 2.1.0"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
'~> 0.5.x' would not pick the latest version '0.6.0', as it equals to
['>= 0.5.x', '< 0.6.0'].
Reference:
http://guides.rubygems.org/patterns/#pessimistic-version-constraint.