### PR TITLE
Refactoring the Network Devices Parser to save ports information on physical_network_ports table

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_network_ports_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_network_ports_parser.rb
@@ -1,0 +1,75 @@
+module ManageIQ::Providers::Lenovo
+  class PhysicalInfraManager::Parser::PhysicalNetworkPortsParser < PhysicalInfraManager::Parser::ComponentParser
+    class << self
+      #
+      # Mounts the ports from Network Device
+      #
+      def parse_network_device_ports(ports)
+        parsed_ports = []
+
+        ports.each do |port|
+          parsed_port = parse_physical_server_ports(port)
+          parsed_ports.concat(parsed_port) if parsed_port.present?
+        end
+
+        parsed_ports.uniq { |port| port[:port_name] }
+      end
+
+      #
+      # Mounts the Physical Switches ports
+      #
+      # @param [XClarityClient::Switch] physical_switch - The switch to have
+      #   it ports parsed
+      #
+      def parse_physical_switch_ports(physical_switch)
+        physical_switch.ports&.map { |port| parse_switch_port(port) }
+      end
+
+      private
+
+      def parse_physical_server_ports(port)
+        port_info = port["portInfo"]
+        physical_ports = port_info["physicalPorts"]
+        physical_ports&.map do |physical_port|
+          parsed_physical_port = parse_physical_port(physical_port)
+          logical_ports = physical_port["logicalPorts"]
+          parsed_logical_port = parse_logical_port(logical_ports[0])
+          parsed_logical_port[:uid_ems] = mount_uuid(port, physical_port['physicalPortIndex'])
+          parsed_logical_port.merge!(parsed_physical_port)
+          parsed_logical_port
+        end
+      end
+
+      def parse_switch_port(port)
+        result = parse(port, parent::ParserDictionaryConstants::PHYSICAL_SWITCH_PORT)
+        result.merge(
+          :port_name    => port["portName"].presence || port["port"],
+          :port_type    => "physical_port",
+          :vlan_enabled => port["PVID"].present?
+        )
+      end
+
+      def parse_physical_port(port)
+        {
+          :port_type  => port["portType"],
+          :port_name  => "Physical Port #{port['physicalPortIndex']}",
+          :port_index => port['physicalPortIndex'],
+        }
+      end
+
+      def parse_logical_port(port)
+        {
+          :mac_address => format_mac_address(port["addresses"])
+        }
+      end
+
+      def format_mac_address(mac_address)
+        mac_address.scan(/\w{2}/).join(":")
+      end
+
+      def mount_uuid(device, port_number = nil)
+        (device["uuid"] || "#{device['pciBusNumber']}#{device['pciDeviceNumber']}") + port_number.to_s
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
@@ -18,6 +18,8 @@ module ManageIQ::Providers::Lenovo
         result[:health_state] = parent::ParserDictionaryConstants::HEALTH_STATE_MAP[physical_switch.overallHealthState.nil? ? physical_switch.overallHealthState : physical_switch.overallHealthState.downcase]
         result[:hardware]     = get_hardwares(physical_switch)
 
+        result[:physical_network_ports] = parent::PhysicalNetworkPortsParser.parse_physical_switch_ports(physical_switch)
+
         return physical_switch.uuid, result
       end
 
@@ -26,13 +28,8 @@ module ManageIQ::Providers::Lenovo
       def get_hardwares(physical_switch)
         {
           :firmwares     => get_firmwares(physical_switch),
-          :guest_devices => get_ports(physical_switch),
           :networks      => get_networks(physical_switch)
         }
-      end
-
-      def get_ports(physical_switch)
-        physical_switch.ports&.map { |port| parse_port(port) }
       end
 
       def get_networks(physical_switch)
@@ -60,16 +57,6 @@ module ManageIQ::Providers::Lenovo
 
         result[:ipaddress]   = assignment['address'] unless is_ipv6
         result[:ipv6address] = assignment['address'] if is_ipv6
-
-        result
-      end
-
-      def parse_port(port)
-        result = parse(port, parent::ParserDictionaryConstants::PHYSICAL_SWITCH_PORT)
-
-        result[:device_name]  = port["portName"].presence || port["port"]
-        result[:device_type]  = "physical_port"
-        result[:vlan_enabled] = port["PVID"].present?
 
         result
       end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -60,10 +60,10 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
 
     it 'will retrieve a port from physical switches' do
       switch = @result[:physical_switches].first
-      port   = switch[:hardware][:guest_devices].first
+      port   = switch[:physical_network_ports].first
 
       expect(port[:peer_mac_address]).to eq("7c:d3:0a:e6:47:51")
-      expect(port[:device_type]).to eq("physical_port")
+      expect(port[:port_type]).to eq("physical_port")
       expect(port[:vlan_enabled]).to eq(true)
       expect(port[:vlan_key]).to eq("\"Lenovo-Network-VLAN546\"")
     end
@@ -180,12 +180,17 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(guest_device[:manufacturer]).to eq("IBM")
       expect(guest_device[:field_replaceable_unit]).to eq("90Y9373")
       expect(guest_device[:location]).to eq("Bay 7")
+    end
 
-      child_device = guest_device[:child_devices][0]
+    it 'will retrieve physical network ports' do
+      ports = @hardware[:guest_devices].first[:physical_network_ports]
+      port1 = ports.first
+      port2 = ports.second
 
-      expect(child_device[:address]).to eq("00:0A:F7:25:67:38")
-      expect(child_device[:device_type]).to eq("physical_port")
-      expect(child_device[:device_name]).to eq("Physical Port 1")
+      expect(port1[:uid_ems]).to_not be_nil
+      expect(port1[:mac_address]).to eq("00:0A:F7:25:67:38")
+      expect(port2[:uid_ems]).to_not be_nil
+      expect(port2[:mac_address]).to eq("00:0A:F7:25:67:39")
     end
 
     it 'will retrieve storage device' do

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -79,6 +79,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
       assert_specific_rack
       assert_specific_server
       assert_guest_table_contents
+      assert_physical_network_ports_table_content
     end
   end
 
@@ -103,20 +104,26 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
   def assert_table_counts
     expect(PhysicalRack.count).to eq(3)
     expect(PhysicalServer.count).to eq(2)
-    expect(GuestDevice.count).to eq(38)
+    expect(GuestDevice.count).to eq(4)
+    expect(PhysicalNetworkPort.count).to eq(34)
   end
 
   def assert_guest_table_contents
     server = PhysicalServer.find_by(:ems_ref => "7936DD182C5311E3A8D6000AF7256738")
     nic = server.hardware.nics.first
-    ports = nic.child_devices
-    port1 = ports.find_by(:device_name => "Physical Port 1")
-    port2 = ports.find_by(:device_name => "Physical Port 2")
-
     expect(nic.device_name).to eq("Broadcom 2-port 1GbE NIC Card for IBM")
-    expect(port1.device_name).to eq("Physical Port 1")
-    expect(port1.address).to eq("00:0A:F7:25:67:38")
-    expect(port2.device_name).to eq("Physical Port 2")
-    expect(port2.address).to eq("00:0A:F7:25:67:39")
+  end
+
+  def assert_physical_network_ports_table_content
+    server = PhysicalServer.find_by(:ems_ref => "7936DD182C5311E3A8D6000AF7256738")
+    ports = server.hardware.nics.first.physical_network_ports
+
+    port1 = ports.find_by(:port_name => "Physical Port 1")
+    port2 = ports.find_by(:port_name => "Physical Port 2")
+
+    expect(port1.port_name).to eq("Physical Port 1")
+    expect(port1.mac_address).to eq("00:0A:F7:25:67:38")
+    expect(port2.port_name).to eq("Physical Port 2")
+    expect(port2.mac_address).to eq("00:0A:F7:25:67:39")
   end
 end


### PR DESCRIPTION
__This PR is able to:__
- Move the __Network Devices__ ports information from `guest_devices` table to `physical_network_ports`;
- Move the __Physical Switches__ ports information from `guest_devices` table to `physical_network_ports` 

__Depends on:__
~https://github.com/ManageIQ/manageiq-schema/pull/185~ - Merged
https://github.com/ManageIQ/manageiq/pull/17268