### PR TITLE
[GAPRINDASHVILI] [BZ 1563796] Fixing the network devices and ports parser

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -135,6 +135,7 @@ module ManageIQ::Providers::Lenovo
           if get_device_type(node_device) == "ethernet"
             add_device = true
             parsed_node_device = yield(node_device)
+            parsed_node_device[:uid_ems] = mount_network_device_uuid(node_device)
 
             parsed_devices.each do |device|
               if parsed_node_device[:device_name] == device[:device_name]
@@ -191,6 +192,7 @@ module ManageIQ::Providers::Lenovo
             parsed_physical_port = parse_physical_port(physical_port)
             logical_ports = physical_port["logicalPorts"]
             parsed_logical_port = parse_logical_port(logical_ports[0])
+            parsed_logical_port[:uid_ems] = mount_network_device_uuid(device, true, physical_port['physicalPortIndex'])
             device_ports.push(parsed_logical_port.merge(parsed_physical_port))
           end
         end
@@ -392,6 +394,12 @@ module ManageIQ::Providers::Lenovo
       $log.info("EMS ID: #{ems.id}" + " Resolved ip address successfully.")
     rescue => err
       $log.warn("EMS ID: #{ems.id}" + " It's not possible resolve ip address of the physical infra, #{err}.")
+    end
+
+    def mount_network_device_uuid(device, child_device = false, port_number = nil)
+      uuid = device["uuid"] || "#{device['pciBusNumber']}#{device['pciDeviceNumber']}"
+      return uuid + port_number.to_s if child_device
+      uuid
     end
   end
 end


### PR DESCRIPTION
Bug Fix
======
When execute the refresh for the first time all Network Devices and Ports are saved successfully, but, from the second time onwards, some Network Devices are deleted and sometimes the ports are duplicated.

__Actual result:__

`guest_devices` table after first refresh:

![image](https://user-images.githubusercontent.com/8550928/38314275-2dc4a09a-37fc-11e8-8675-01d567a66e4a.png)

`guest_devices` table after second refresh:

![image](https://user-images.githubusercontent.com/8550928/38314320-4954121e-37fc-11e8-95fe-460508824d04.png)

This problem occurs because the devices are distinguish by their type and uuid, and once that before this PR the uid_ems field was not filled, the network devices and its ports were distinguish incorrectly causing a wrong update.

__Bugzilla:__
https://bugzilla.redhat.com/show_bug.cgi?id=1563796