### PR TITLE
Parsing partNumber for Physical Servers

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/parser_dictionary_constants.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/parser_dictionary_constants.rb
@@ -67,6 +67,7 @@ module ManageIQ::Providers::Lenovo
         :machine_type           => 'machineType',
         :model                  => 'model',
         :serial_number          => 'serialNumber',
+        :part_number            => 'partNumber',
         :field_replaceable_unit => 'FRU',
         :contact                => 'contact',
         :description            => 'description',


### PR DESCRIPTION
This PR adds the part_number value for Physical Servers.

**Depends on:**

- [https://github.com/ManageIQ/manageiq-schema/pull/182](https://github.com/ManageIQ/manageiq-schema/pull/182) [Merged]