### PR TITLE
Using firmware parser at storage parser

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/storage_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/storage_device_parser.rb
@@ -61,20 +61,11 @@ module ManageIQ::Providers::Lenovo
         firmware = device["firmware"]
         unless firmware.nil?
           device_fw = firmware.map do |fw|
-            parse_firmware(fw)
+            parent::FirmwareParser.parse_firmware(fw)
           end
         end
 
         device_fw
-      end
-
-      def parse_firmware(firmware)
-        {
-          :name         => "#{firmware["role"]} #{firmware["name"]}-#{firmware["status"]}",
-          :build        => firmware["build"],
-          :version      => firmware["version"],
-          :release_date => firmware["date"],
-        }
       end
 
       def mount_uuid(device)


### PR DESCRIPTION
Uses the new FirmwareParser introduced at https://github.com/ManageIQ/manageiq-providers-lenovo/pull/132 to parse filters in the storage parser.