### PR TITLE
Adapting change password to the new core implementation

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -9,6 +9,8 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   require_nested :EventParser
   require_nested :RefreshWorker
 
+  supports :change_password
+
   def self.ems_type
     @ems_type ||= "lenovo_ph_infra".freeze
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/authenticatable_provider.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/authenticatable_provider.rb
@@ -2,7 +2,7 @@
 # An Authenticatable Provider must be able to do some operations with its credentials
 #
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::AuthenticatableProvider
-  # (see ManageIQ::Providers::PhysicalInfraManager#raw_change_password)
+  # (see AuthenticationMixin#raw_change_password)
   def raw_change_password(current_password, new_password)
     _log.info("Password change requested for physical provider '#{name}' and userId #{authentication_userid}")
 


### PR DESCRIPTION
__This PR is able to:__
- Add the support for `change_password` for Lenovo Provider;
- Change the documentation to follow the new implementation of change password routine added on this PR: https://github.com/ManageIQ/manageiq/pull/17323