### PR TITLE
Move faker gem to development

### DIFF
--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "webmock", "~> 2.1.0"
   s.add_development_dependency "simplecov"
-  s.add_dependency "faker", "=1.8.3"
+  s.add_development_dependency "faker", "= 1.8.3"
 end


### PR DESCRIPTION
Faker gem is only used for specs. This PR moves it to development.
It is pinned as `1.8.3` due to https://github.com/ManageIQ/manageiq-providers-lenovo/pull/118.