### PR TITLE
Indentation fix on config/settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -85,6 +85,6 @@
     :event_catcher:
       :event_catcher_lenovo:
         :poll: 15.seconds
-:queue_worker_base:
-  :ems_refresh_worker:
-    :ems_refresh_worker_lenovo_physical_infra: {}
+    :queue_worker_base:
+      :ems_refresh_worker:
+        :ems_refresh_worker_lenovo_physical_infra: {}


### PR DESCRIPTION
This PR is a Fix of https://github.com/ManageIQ/manageiq-providers-lenovo/pull/164 the indentation was  making the travis to fail here https://github.com/ManageIQ/manageiq/pull/17349.
I overlooked through this, my mistake
