### PR TITLE
Fix bug when portInfo was null

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_network_ports_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_network_ports_parser.rb
@@ -29,7 +29,7 @@ module ManageIQ::Providers::Lenovo
 
       def parse_physical_server_ports(port)
         port_info = port["portInfo"]
-        physical_ports = port_info["physicalPorts"]
+        physical_ports = port_info&.dig('physicalPorts')
         physical_ports&.map do |physical_port|
           parsed_physical_port = parse_physical_port(physical_port)
           logical_ports = physical_port["logicalPorts"]


### PR DESCRIPTION
The refresh was crashing when a port didn't contain a "portInfo" field