### PR TITLE
Remove ipaddress and hostname updates from physical_infra_manager (#1)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -19,11 +19,4 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   def self.description
     @description ||= "Lenovo XClarity"
   end
-
-  def hostname_ipaddress?(hostname)
-    IPAddr.new(hostname)
-    return true
-  rescue
-    return false
-  end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -28,7 +28,6 @@ module ManageIQ::Providers::Lenovo
       $log.info("#{log_header}...")
 
       get_all_physical_infra
-      discover_ip_physical_infra
       get_physical_switches
       get_config_patterns
 
@@ -144,30 +143,6 @@ module ManageIQ::Providers::Lenovo
     def get_config_patterns
       config_patterns = @connection.discover_config_pattern
       process_collection(config_patterns, :customization_scripts) { |config_pattern| @parser.parse_config_pattern(config_pattern) }
-    end
-
-    def discover_ip_physical_infra
-      hostname = URI.parse(@ems.hostname).host || URI.parse(@ems.hostname).path
-      if @ems.ipaddress.blank?
-        resolve_ip_address(hostname, @ems)
-      end
-      if @ems.hostname_ipaddress?(hostname)
-        resolve_hostname(hostname, @ems)
-      end
-    end
-
-    def resolve_hostname(ipaddress, ems)
-      ems.hostname = Resolv.getname(ipaddress)
-      $log.info("EMS ID: #{ems.id}" + " Resolved hostname successfully.")
-    rescue => err
-      $log.warn("EMS ID: #{ems.id}" + " It's not possible resolve hostname of the physical infra, #{err}.")
-    end
-
-    def resolve_ip_address(hostname, ems)
-      ems.ipaddress = Resolv.getaddress(hostname)
-      $log.info("EMS ID: #{ems.id}" + " Resolved ip address successfully.")
-    rescue => err
-      $log.warn("EMS ID: #{ems.id}" + " It's not possible resolve ip address of the physical infra, #{err}.")
     end
   end
 end


### PR DESCRIPTION
**What this PR does:**
- Removes the updates of hostname and IP Address features.

**Reason:**

- I believe the `RefreshParser` responsibility is to handle the inventory fetching and parsing. Also, the updates are unnecessary and may create errors in some use cases.