### PR TITLE
Removing type assigment from PhysicalSwitchParser

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
@@ -14,7 +14,6 @@ module ManageIQ::Providers::Lenovo
         unless result[:power_state].nil?
           result[:power_state] = result[:power_state].downcase if %w(on off).include?(result[:power_state].downcase)
         end
-        result[:type]         = parent::ParserDictionaryConstants::MIQ_TYPES["physical_switch"]
         result[:health_state] = parent::ParserDictionaryConstants::HEALTH_STATE_MAP[physical_switch.overallHealthState.nil? ? physical_switch.overallHealthState : physical_switch.overallHealthState.downcase]
         result[:hardware]     = get_hardwares(physical_switch)
 


### PR DESCRIPTION
This PR is able to:
- Remove unnecessary type assigment from PhysicalSwitchParser, since the migration already covers that

Depends on:
- [ManageIQ/manageiq-schema#202](https://github.com/ManageIQ/manageiq-schema/pull/202)
- [ManageIQ/manageiq#17431](https://github.com/ManageIQ/manageiq/pull/17431)