### PR TITLE
Fixing error while trying to refresh a provider with invalid credentials

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser.rb
@@ -20,9 +20,8 @@ module ManageIQ::Providers::Lenovo
     # returns the parser of api version request
     # see the +VERSION_PARSERS+ to know what versions are supporteds
     def self.get_instance(version)
-      version_parser = version.match(/^(?:(\d+)\.?(\d+))/).to_s # getting just major and minor version
-      parser = VERSION_PARSERS[version_parser] # getting the class that supports the version
-      parser ||= VERSION_PARSERS['default']
+      version_parser = version.match(/^(?:(\d+)\.?(\d+))/).to_s if version.present? # getting just major and minor version
+      parser = VERSION_PARSERS[version_parser] || VERSION_PARSERS['default'] # getting the class that supports the version
       parser.new
     end
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -41,7 +41,8 @@ module ManageIQ::Providers::Lenovo
 
     # returns the specific parser based on the version of the appliance
     def init_parser(connection)
-      version = connection.discover_aicc.first.appliance['version'] # getting the appliance version
+      aicc = connection.discover_aicc
+      version = aicc.first.appliance['version'] if aicc.present? # getting the appliance version
       self.class.parent::Parser.get_instance(version)
     end
 


### PR DESCRIPTION
__Current behavior__:
If the system cannot access the provider due to invalid credentials or server offline an error is throw:
```
ems_refresher_mixin.rb:50:in `refresh': undefined method `appliance' for nil:NilClass (EmsRefresh::Refreshers::EmsRefresherMixin::PartialRefreshError)
```

__Bugzilla:__
https://bugzilla.redhat.com/show_bug.cgi?id=1579934