### PR TITLE
Use local variable to return inventory (#2)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/config_pattern_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/config_pattern_parser.rb
@@ -10,7 +10,7 @@ module ManageIQ::Providers::Lenovo
       # @return [Hash] containing the config pattern informations
       #
       def parse_config_pattern(config_pattern)
-        return config_pattern.id, parse(config_pattern, parent::ParserDictionaryConstants::CONFIG_PATTERNS)
+        parse(config_pattern, parent::ParserDictionaryConstants::CONFIG_PATTERNS)
       end
     end
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
@@ -20,7 +20,7 @@ module ManageIQ::Providers::Lenovo
         result[:location_led_state]         = find_loc_led_state(chassis.leds)
         result[:computer_system][:hardware] = get_hardwares(chassis)
 
-        return chassis.uuid, result
+        result
       end
 
       private

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_rack_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_rack_parser.rb
@@ -9,9 +9,7 @@ module ManageIQ::Providers::Lenovo
       # @return [Integer, Hash] PhysicalRack UUID and a parsed hash from PhysicalRack and every components inside it
       #
       def parse_physical_rack(cab)
-        result = parse(cab, parent::ParserDictionaryConstants::PHYSICAL_RACK)
-
-        return cab.UUID, result
+        parse(cab, parent::ParserDictionaryConstants::PHYSICAL_RACK)
       end
     end
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
@@ -27,7 +27,7 @@ module ManageIQ::Providers::Lenovo
         result[:location_led_state]         = find_loc_led_state(node.leds)
         result[:computer_system][:hardware] = get_hardwares(node)
 
-        return node.uuid, result
+        result
       end
 
       private

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -18,7 +18,7 @@ module ManageIQ::Providers::Lenovo
         result[:health_state]               = parent::ParserDictionaryConstants::HEALTH_STATE_MAP[storage.cmmHealthState.nil? ? storage.cmmHealthState : storage.cmmHealthState.downcase]
         result[:computer_system][:hardware] = get_hardwares(storage)
 
-        return storage.uuid, result
+        result
       end
 
       private

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
@@ -20,7 +20,7 @@ module ManageIQ::Providers::Lenovo
 
         result[:physical_network_ports] = parent::PhysicalNetworkPortsParser.parse_physical_switch_ports(physical_switch)
 
-        return physical_switch.uuid, result
+        result
       end
 
       private

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -27,13 +27,13 @@ module ManageIQ::Providers::Lenovo
 
       $log.info("#{log_header}...")
 
-      get_all_physical_infra
-      get_physical_switches
-      get_config_patterns
+      inventory                         = get_all_physical_infra
+      inventory[:physical_switches]     = get_physical_switches
+      inventory[:customization_scripts] = get_config_patterns
 
       $log.info("#{log_header}...Complete")
 
-      @data
+      inventory
     end
 
     private
@@ -45,14 +45,14 @@ module ManageIQ::Providers::Lenovo
       self.class.parent::Parser.get_instance(version)
     end
 
-    # Retrieve all physical infrastructure that can be obtained from the
-    # LXCA (racks, chassis, servers, switches) as XClarity objects and
-    # add it to the +@data+ as a hash.
+    # Retrieve all physical infrastructure that can be obtained from the LXCA (racks, chassis, servers, switches)
+    # as XClarity objects.
     def get_all_physical_infra
-      @data[:physical_racks]    = []
-      @data[:physical_chassis]  = []
-      @data[:physical_storages] = []
-      @data[:physical_servers]  = []
+      inventory = {}
+      inventory[:physical_racks]    = []
+      inventory[:physical_chassis]  = []
+      inventory[:physical_servers]  = []
+      inventory[:physical_storages] = []
 
       racks = get_plain_physical_racks
       racks.each do |rack|
@@ -60,38 +60,40 @@ module ManageIQ::Providers::Lenovo
         # One of the API's racks is a mock to indicate physical chassis and servers that are not inside any rack.
         # This rack has the UUID equals to 'STANDALONE_OBJECT_UUID'
         if rack.UUID != 'STANDALONE_OBJECT_UUID'
-          _, parsed_rack = @parser.parse_physical_rack(rack)
-          @data[:physical_racks] << parsed_rack
+          parsed_rack = @parser.parse_physical_rack(rack)
+          inventory[:physical_racks] << parsed_rack
         end
 
         # Retrieve and parse the servers that are inside the rack, but not inside any chassis.
         rack_servers = get_plain_physical_servers_inside_rack(rack)
         rack_servers.each do |server|
-          _, parsed_server = @parser.parse_physical_server(server, find_compliance(server), parsed_rack)
-          @data[:physical_servers] << parsed_server
+          parsed_server = @parser.parse_physical_server(server, find_compliance(server), parsed_rack)
+          inventory[:physical_servers] << parsed_server
         end
 
         # Retrieve and parse the chassis that are inside the rack.
         rack_chassis = get_plain_physical_chassis_inside_rack(rack)
         rack_chassis.each do |chassis|
-          _, parsed_chassis = @parser.parse_physical_chassis(chassis, parsed_rack)
-          @data[:physical_chassis] << parsed_chassis
+          parsed_chassis = @parser.parse_physical_chassis(chassis, parsed_rack)
+          inventory[:physical_chassis] << parsed_chassis
 
           # Retrieve and parse the servers that are inside the chassi.
           chassis_servers = get_plain_physical_servers_inside_chassis(chassis)
           chassis_servers.each do |server|
-            _, parsed_server = @parser.parse_physical_server(server, find_compliance(server), parsed_rack, parsed_chassis)
-            @data[:physical_servers] << parsed_server
+            parsed_server = @parser.parse_physical_server(server, find_compliance(server), parsed_rack, parsed_chassis)
+            inventory[:physical_servers] << parsed_server
           end
         end
 
         # Retrieve and parse storages that are inside the rack.
         rack_storages = get_plain_physical_storages_inside_rack(rack)
         rack_storages.each do |storage|
-          _, parsed_storage = @parser.parse_physical_storage(storage, parsed_rack)
-          @data[:physical_storages] << parsed_storage
+          parsed_storage = @parser.parse_physical_storage(storage, parsed_rack)
+          inventory[:physical_storages] << parsed_storage
         end
       end
+
+      inventory
     end
 
     # Returns all physical rack from the api.
@@ -120,11 +122,8 @@ module ManageIQ::Providers::Lenovo
     end
 
     def get_physical_switches
-      @all_physical_switches ||= @connection.discover_switches
-
-      process_collection(@all_physical_switches, :physical_switches) do |physical_switch|
-        @parser.parse_physical_switch(physical_switch)
-      end
+      switches = @connection.discover_switches
+      switches.map { |switch| @parser.parse_physical_switch(switch) }
     end
 
     def find_compliance(node)
@@ -142,7 +141,7 @@ module ManageIQ::Providers::Lenovo
 
     def get_config_patterns
       config_patterns = @connection.discover_config_pattern
-      process_collection(config_patterns, :customization_scripts) { |config_pattern| @parser.parse_config_pattern(config_pattern) }
+      config_patterns.map { |config_pattern| @parser.parse_config_pattern(config_pattern) }
     end
   end
 end


### PR DESCRIPTION
**What this PR does:**
- Makes a **refactoring** on the `RefreshParser` logic and removes the use of the instance variable `@data` to return EMS inventory.

**Reason:**
- The `process_collection` method simply populates the `data` instance variable. We can return these results without the need to use variable in class scope.

**Depends on:**
- ~#173~ [merged]