### PR TITLE
Removing RefreshHelperMethods unused code (#3)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -7,19 +7,15 @@ module ManageIQ::Providers::Lenovo
       parent::Parser::ParserDictionaryConstants::MIQ_TYPES["template"]
     end
 
-    def initialize(ems, options = nil)
+    def initialize(ems, _options = nil)
       ems_auth = ems.authentications.first
 
-      @ems               = ems
-      @connection        = ems.connect(:user => ems_auth.userid,
-                                       :pass => ems_auth.password,
-                                       :host => ems.endpoints.first.hostname,
-                                       :port => ems.endpoints.first.port)
-      @options           = options || {}
-      @data              = {}
-      @data_index        = {}
-      @host_hash_by_name = {}
-      @parser            = init_parser(@connection)
+      @ems        = ems
+      @connection = ems.connect(:user => ems_auth.userid,
+                                :pass => ems_auth.password,
+                                :host => ems.endpoints.first.hostname,
+                                :port => ems.endpoints.first.port)
+      @parser     = init_parser(@connection)
     end
 
     def ems_inv_to_hashes

--- a/app/models/manageiq/providers/lenovo/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/lenovo/refresh_helper_methods.rb
@@ -1,27 +1,6 @@
 module ManageIQ::Providers::Lenovo::RefreshHelperMethods
   extend ActiveSupport::Concern
 
-  def process_collection(collection, key)
-    @data[key]       ||= []
-    @data_index[key] ||= {}
-
-    collection.each do |item|
-      uid, new_result = yield(item)
-      next if uid.nil?
-
-      @data[key] << new_result
-      @data_index.store_path(key, uid, new_result)
-    end
-  end
-
-  def parse_uid_from_url(url)
-    # A lot of attributes in gce are full URLs with the
-    # uid being the last component.  This helper method
-    # returns the last component of the url
-    uid = url.split('/')[-1]
-    uid
-  end
-
   module ClassMethods
     def ems_inv_to_hashes(ems, options = nil)
       new(ems, options).ems_inv_to_hashes


### PR DESCRIPTION
**What this PR does:**
- Removes the unused code inside `RefreshHelperMethods` module.
- Removes unnecessary instance variables inside `RefreshParser#initialize`.

**Depends on:**
- ~#178~ [Merged]