### PR TITLE
Passing only connection info to RefreshParser (#4)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -19,4 +19,12 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   def self.description
     @description ||= "Lenovo XClarity"
   end
+
+  # Returns a new connection to the LXCA
+  def connection
+    connect(:user => authentications.first.userid,
+            :pass => authentications.first.password,
+            :host => endpoints.first.hostname,
+            :port => endpoints.first.port)
+  end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser.rb
@@ -7,27 +7,15 @@ module ManageIQ::Providers::Lenovo
       parent::Parser::ParserDictionaryConstants::MIQ_TYPES["template"]
     end
 
-    def initialize(ems, _options = nil)
-      ems_auth = ems.authentications.first
-
-      @ems        = ems
-      @connection = ems.connect(:user => ems_auth.userid,
-                                :pass => ems_auth.password,
-                                :host => ems.endpoints.first.hostname,
-                                :port => ems.endpoints.first.port)
-      @parser     = init_parser(@connection)
+    def initialize(connection, _options = nil)
+      @connection = connection
+      @parser     = init_parser
     end
 
     def ems_inv_to_hashes
-      log_header = "MIQ(#{self.class.name}.#{__method__}) Collecting data for EMS : [#{@ems.name}] id: [#{@ems.id} ref: #{@ems.uid_ems}]"
-
-      $log.info("#{log_header}...")
-
       inventory                         = get_all_physical_infra
       inventory[:physical_switches]     = get_physical_switches
       inventory[:customization_scripts] = get_config_patterns
-
-      $log.info("#{log_header}...Complete")
 
       inventory
     end
@@ -35,8 +23,8 @@ module ManageIQ::Providers::Lenovo
     private
 
     # returns the specific parser based on the version of the appliance
-    def init_parser(connection)
-      aicc = connection.discover_aicc
+    def init_parser
+      aicc = @connection.discover_aicc
       version = aicc.first.appliance['version'] if aicc.present? # getting the appliance version
       self.class.parent::Parser.get_instance(version)
     end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
@@ -1,10 +1,15 @@
 module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     def parse_legacy_inventory(ems)
-      log_header = "MIQ_LENOVO(#{self.class.name}.#{__method__} Calling for [#{ems.name}])"
-      $log.info("#{log_header}")
+      $log.info("MIQ_LENOVO(#{self.class.name}.#{__method__} Calling for [#{ems.name}])")
 
-      ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
+      # Perform a full fetch of the EMS inventory
+      log_header = "Collecting data for EMS : [#{ems.name}] id: [#{ems.id} ref: #{ems.uid_ems}]"
+      $log.info("#{log_header}...")
+      inventory = PhysicalInfraManager::RefreshParser.ems_inv_to_hashes(ems.connection, refresher_options)
+      $log.info("#{log_header}...Complete")
+
+      inventory
     end
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -22,17 +22,17 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
                        :authtype => "default")
   end
 
-  let(:ems) do
+  let(:connection) do
     ems = FactoryGirl.create(:physical_infra,
                              :name      => "LXCA",
                              :hostname  => "10.243.9.123",
                              :port      => "443",
                              :ipaddress => "https://10.243.9.123/443")
     ems.authentications = [auth]
-    ems
+    ems.connection
   end
 
-  let(:ems_inv_to_hashes) { described_class.new(ems).ems_inv_to_hashes }
+  let(:ems_inv_to_hashes) { described_class.new(connection).ems_inv_to_hashes }
 
   it 'will return its miq_template_type' do
     expect(described_class.miq_template_type).to eq("ManageIQ::Providers::Lenovo::PhysicalInfraManager::Template")


### PR DESCRIPTION
**What this PR does:**
- Add a `connection` method to the `PhysicalInfraManager` so that It can return how to connect to the external provider;
- Changes the initialization of `RefreshParser` to accept only the connection to an external provider and not all the info that a ems has to offer.
- Updates the tests to pass the connection instead of the entire `ems` object.

**Reason:**
- The `RefreshParser` should only require initialization parameters that are important to its execution. Thus, It only needs a connection object.

**Depends on:**
- ~#179~ [MERGED]