### PR TITLE
Fix all rubocop issues (#5)

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -3,3 +3,11 @@ GlobalVars:
   # Loggers
   - $lenovo_log
   - $log
+
+# Ignores the file at lib folder that needs to have a naming with dashes.
+AllCops:
+  Exclude:
+  - lib/manageiq-providers-lenovo.rb
+  - Rakefile
+  - manageiq-providers-lenovo.gemspec
+  - bin/**

--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -74,7 +74,7 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
 
     def connection_rescue_block
       yield
-    rescue => err
+    rescue StandardError => err
       miq_exception = translate_exception(err)
       raise unless miq_exception
 
@@ -116,7 +116,7 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
         _log.info("Created EMS: #{new_ems.name} with id: #{new_ems.id}")
       end
 
-      EmsRefresh.queue_refresh(new_ems) unless new_ems.blank?
+      EmsRefresh.queue_refresh(new_ems) if new_ems.present?
     end
 
     def discover_queue(ip_address, port, zone = nil)

--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -74,7 +74,7 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
 
     def connection_rescue_block
       yield
-    rescue StandardError => err
+    rescue => err
       miq_exception = translate_exception(err)
       raise unless miq_exception
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
@@ -43,7 +43,7 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
     change_resource_state(server, :power_restart_node_controller)
   end
 
-  def apply_config_pattern(args, options = {})
+  def apply_config_pattern(_args, options = {})
     $lenovo_log.info("Entering apply_config_pattern with pattern ID: #{options[:id]} and UUID: #{options[:uuid]}")
 
     # Retrieve a connection to the LXCA instance

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
@@ -27,8 +27,8 @@ module ManageIQ::Providers::Lenovo
 
       def get_hardwares(physical_switch)
         {
-          :firmwares     => get_firmwares(physical_switch),
-          :networks      => get_networks(physical_switch)
+          :firmwares => get_firmwares(physical_switch),
+          :networks  => get_networks(physical_switch)
         }
       end
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_worker.rb
@@ -8,5 +8,4 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshWorker < ::MiqEm
   def self.settings_name
     :ems_refresh_worker_lenovo_physical_infra
   end
-
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
@@ -2,7 +2,7 @@ module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     def parse_legacy_inventory(ems)
       log_header = "MIQ_LENOVO(#{self.class.name}.#{__method__} Calling for [#{ems.name}])"
-      $log.info("#{log_header}")
+      $log.info(log_header)
 
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
     end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresher.rb
@@ -1,8 +1,7 @@
 module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Refresher < ManageIQ::Providers::BaseManager::Refresher
     def parse_legacy_inventory(ems)
-      log_header = "MIQ_LENOVO(#{self.class.name}.#{__method__} Calling for [#{ems.name}])"
-      $log.info(log_header)
+      $log.info("MIQ_LENOVO(#{self.class.name}.#{__method__} Calling for [#{ems.name}])")
 
       ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser.ems_inv_to_hashes(ems, refresher_options)
     end

--- a/app/models/manageiq/providers/lenovo/provider.rb
+++ b/app/models/manageiq/providers/lenovo/provider.rb
@@ -1,9 +1,10 @@
 class ManageIQ::Providers::Lenovo::Provider < ::Provider
+  # rubocop:disable Rails/HasManyOrHasOneDependent,Rails/InverseOf
   has_one :ph_infra_manager,
-          :foreign_key  =>  "provider_id",
-          :class_name   =>  "ManageIQ::Providers::Lenovo::PhysicalInfraManager",
-          :autosave     => true
+          :foreign_key => "provider_id",
+          :class_name  => "ManageIQ::Providers::Lenovo::PhysicalInfraManager",
+          :autosave    => true
+  # rubocop:enable Rails/HasManyOrHasOneDependent,Rails/InverseOf
 
-  validates   :name, :presence => true, :uniqueness =>  true  
-
+  validates :name, :presence => true, :uniqueness => true
 end

--- a/app/models/manageiq/providers/lenovo/provider.rb
+++ b/app/models/manageiq/providers/lenovo/provider.rb
@@ -1,10 +1,8 @@
 class ManageIQ::Providers::Lenovo::Provider < ::Provider
-  # rubocop:disable Rails/HasManyOrHasOneDependent,Rails/InverseOf
   has_one :ph_infra_manager,
           :foreign_key => "provider_id",
           :class_name  => "ManageIQ::Providers::Lenovo::PhysicalInfraManager",
           :autosave    => true
-  # rubocop:enable Rails/HasManyOrHasOneDependent,Rails/InverseOf
 
   validates :name, :presence => true, :uniqueness => true
 end

--- a/lib/tasks/lenovo.rake
+++ b/lib/tasks/lenovo.rake
@@ -1,10 +1,10 @@
-#namespace :manageiq do
-#  namespace :providers do
-#    namespace :lenovo do
-#      desc "Explaining what the task does"
-#      task :your_task do
-#        # Task goes here
-#      end
-#    end
-#  end
-#end
+# namespace :manageiq do
+#   namespace :providers do
+#     namespace :lenovo do
+#       desc "Explaining what the task does"
+#       task :your_task do
+#         # Task goes here
+#       end
+#     end
+#   end
+# end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,5 +8,5 @@ VCR.configure do |config|
   config.cassette_library_dir = File.join(ManageIQ::Providers::Lenovo::Engine.root, 'spec/vcr_cassettes')
 end
 
-Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec", "shared", "**", "*.rb")].each { |f| require f }
 Dir[ManageIQ::Providers::Lenovo::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
**What this PR does:**
- Fix all rubocop issues;
- Removes this generated paths from rubocop lint:
  - lib/manageiq-providers-lenovo.rb
  - Rakefile
  - manageiq-providers-lenovo.gemspec
  - bin/**

**Reason:**
- Running `rubocop` on the project root will show new problems with added code.

**Depends on:**
- ~#179~ [MERGED]