### PR TITLE
Moved common dictionary constants to component parser (#7)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
@@ -4,43 +4,88 @@ module ManageIQ::Providers::Lenovo
   # to a MiQ format
   #
   class PhysicalInfraManager::Parser::ComponentParser
-    #
-    # Returns a hash containing the structure described on dictionary
-    # and with the values in the source.
-    #
-    # @param source     - Object that will be parse to a hash
-    # @param dictionary - Hash containing the instructions to translate the object into a Hash
-    #
-    # @see ParserDictionaryConstants
-    #
-    def self.parse(source, dictionary)
-      result = {}
-      dictionary&.each do |key, value|
-        if value.kind_of?(String)
-          next if value.empty?
-          source_keys = value.split('.') # getting source keys navigation
-          source_value = source
-          source_keys.each do |source_key|
-            begin
-              attr_method = source_value.method(source_key) # getting method to get the attribute value
-              source_value = attr_method.call
-            rescue NameError
-              # when the key doesn't correspond to a method
-              source_value = source_value[source_key]
-            end
-          end
-          result[key] = source_value.kind_of?(String) ? source_value.strip.presence : source_value
-        elsif value.kind_of?(Hash)
-          result[key] = parse(source, dictionary[key])
-        end
-      end
-      result
-    end
+    class << self
+      GUEST_DEVICE = {
+        :manufacturer           => 'manufacturer',
+        :field_replaceable_unit => 'FRU',
+        :controller_type        => 'class'
+      }.freeze
 
-    def self.get_location_led_info(leds)
-      return if leds.blank?
-      identification_led = leds.to_a.find { |led| parent::ParserDictionaryConstants::PROPERTIES_MAP[:led_identify_name].include?(led["name"]) }
-      return identification_led.try(:[], "name"), identification_led.try(:[], "state")
+      HEALTH_STATE_MAP = {
+        'normal'          => 'Valid',
+        'non-critical'    => 'Valid',
+        'warning'         => 'Warning',
+        'critical'        => 'Critical',
+        'unknown'         => 'None',
+        'minor-failure'   => 'Critical',
+        'major-failure'   => 'Critical',
+        'non-recoverable' => 'Critical',
+        'fatal'           => 'Critical',
+        nil               => 'Unknown'
+      }.freeze
+
+      MIQ_TYPES = {
+        'physical_server'  => 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer',
+        'physical_switch'  => 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch',
+        'physical_storage' => 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalStorage',
+        'physical_chassis' => 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis'
+      }.freeze
+
+      POWER_STATE_MAP = {
+        8  => 'On',
+        5  => 'Off',
+        18 => 'Standby',
+        0  => 'Unknown'
+      }.freeze
+
+      PROPERTIES_MAP = {
+        :led_identify_name => %w(Identification Identify Location),
+      }.freeze
+
+      private_constant :GUEST_DEVICE
+      private_constant :HEALTH_STATE_MAP
+      private_constant :MIQ_TYPES
+      private_constant :POWER_STATE_MAP
+      private_constant :PROPERTIES_MAP
+
+      #
+      # Returns a hash containing the structure described on dictionary
+      # and with the values in the source.
+      #
+      # @param source     - Object that will be parse to a hash
+      # @param dictionary - Hash containing the instructions to translate the object into a Hash
+      #
+      # @see ParserDictionaryConstants
+      #
+      def parse(source, dictionary)
+        result = {}
+        dictionary&.each do |key, value|
+          if value.kind_of?(String)
+            next if value.empty?
+            source_keys = value.split('.') # getting source keys navigation
+            source_value = source
+            source_keys.each do |source_key|
+              begin
+                attr_method = source_value.method(source_key) # getting method to get the attribute value
+                source_value = attr_method.call
+              rescue NameError
+                # when the key doesn't correspond to a method
+                source_value = source_value[source_key]
+              end
+            end
+            result[key] = source_value.kind_of?(String) ? source_value.strip.presence : source_value
+          elsif value.kind_of?(Hash)
+            result[key] = parse(source, dictionary[key])
+          end
+        end
+        result
+      end
+
+      def get_location_led_info(leds)
+        return if leds.blank?
+        identification_led = leds.to_a.find { |led| PROPERTIES_MAP[:led_identify_name].include?(led["name"]) }
+        return identification_led.try(:[], "name"), identification_led.try(:[], "state")
+      end
     end
   end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/network_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/network_device_parser.rb
@@ -51,7 +51,7 @@ module ManageIQ::Providers::Lenovo
       end
 
       def parse_device(device)
-        result = parse(device, parent::ParserDictionaryConstants::GUEST_DEVICE)
+        result = parse(device, GUEST_DEVICE)
 
         result[:uid_ems]     = mount_uuid(device)
         result[:device_name] = device["productName"] ? device["productName"] : device["name"]

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/parser_dictionary_constants.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/parser_dictionary_constants.rb
@@ -2,38 +2,6 @@ module ManageIQ::Providers::Lenovo
   # dictionary homologated for versions:
   # 1.3
   class PhysicalInfraManager::Parser::ParserDictionaryConstants
-    POWER_STATE_MAP = {
-      8  => "On",
-      5  => "Off",
-      18 => "Standby",
-      0  => "Unknown",
-    }.freeze
-
-    HEALTH_STATE_MAP = {
-      "normal"          => "Valid",
-      "non-critical"    => "Valid",
-      "warning"         => "Warning",
-      "critical"        => "Critical",
-      "unknown"         => "None",
-      "minor-failure"   => "Critical",
-      "major-failure"   => "Critical",
-      "non-recoverable" => "Critical",
-      "fatal"           => "Critical",
-      nil               => "Unknown",
-    }.freeze
-
-    MIQ_TYPES = {
-      "physical_server"  => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer",
-      "physical_switch"  => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch",
-      "physical_storage" => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalStorage",
-      "physical_chassis" => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis",
-      "template"         => "ManageIQ::Providers::Lenovo::PhysicalInfraManager::Template",
-    }.freeze
-
-    PROPERTIES_MAP = {
-      :led_identify_name => %w(Identification Identify Location),
-    }.freeze
-
     # TRANSLATE HASHES BEGIN
     # The translate hashes are used to parse an object to a hash
     # where the translate hash keys are set as object hash keys
@@ -170,12 +138,6 @@ module ManageIQ::Providers::Lenovo
       :network => {
         :ipaddress => 'mgmtProcIPaddress',
       },
-    }.freeze
-
-    GUEST_DEVICE = {
-      :manufacturer           => 'manufacturer',
-      :field_replaceable_unit => 'FRU',
-      :controller_type        => 'class',
     }.freeze
 
     FIRMWARE = {

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
@@ -17,8 +17,8 @@ module ManageIQ::Providers::Lenovo
 
         result[:physical_rack]                       = rack if rack
         result[:vendor]                              = "lenovo"
-        result[:type]                                = parent::ParserDictionaryConstants::MIQ_TYPES["physical_chassis"]
-        result[:health_state]                        = parent::ParserDictionaryConstants::HEALTH_STATE_MAP[chassis.cmmHealthState.nil? ? chassis.cmmHealthState : chassis.cmmHealthState.downcase]
+        result[:type]                                = MIQ_TYPES["physical_chassis"]
+        result[:health_state]                        = HEALTH_STATE_MAP[chassis.cmmHealthState.nil? ? chassis.cmmHealthState : chassis.cmmHealthState.downcase]
         result[:asset_detail][:location_led_ems_ref] = loc_led_name
         result[:location_led_state]                  = loc_led_state
         result[:computer_system][:hardware]          = get_hardwares(chassis)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
@@ -22,9 +22,9 @@ module ManageIQ::Providers::Lenovo
         result[:ems_compliance_name]                 = compliance[:policy_name]
         result[:ems_compliance_status]               = compliance[:status]
         result[:vendor]                              = "lenovo"
-        result[:type]                                = parent::ParserDictionaryConstants::MIQ_TYPES["physical_server"]
-        result[:power_state]                         = parent::ParserDictionaryConstants::POWER_STATE_MAP[node.powerStatus]
-        result[:health_state]                        = parent::ParserDictionaryConstants::HEALTH_STATE_MAP[node.cmmHealthState.nil? ? node.cmmHealthState : node.cmmHealthState.downcase]
+        result[:type]                                = MIQ_TYPES["physical_server"]
+        result[:power_state]                         = POWER_STATE_MAP[node.powerStatus]
+        result[:health_state]                        = HEALTH_STATE_MAP[node.cmmHealthState.nil? ? node.cmmHealthState : node.cmmHealthState.downcase]
         result[:host]                                = get_host_relationship(node.serialNumber)
         result[:asset_detail][:location_led_ems_ref] = loc_led_name
         result[:location_led_state]                  = loc_led_state

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -16,8 +16,8 @@ module ManageIQ::Providers::Lenovo
 
         result[:physical_rack]              = rack if rack
         result[:physical_chassis]           = chassis if chassis
-        result[:type]                       = parent::ParserDictionaryConstants::MIQ_TYPES["physical_storage"]
-        result[:health_state]               = parent::ParserDictionaryConstants::HEALTH_STATE_MAP[storage.cmmHealthState.nil? ? storage.cmmHealthState : storage.cmmHealthState.downcase]
+        result[:type]                       = MIQ_TYPES["physical_storage"]
+        result[:health_state]               = HEALTH_STATE_MAP[storage.cmmHealthState.nil? ? storage.cmmHealthState : storage.cmmHealthState.downcase]
         result[:computer_system][:hardware] = get_hardwares(storage)
 
         result

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
@@ -14,8 +14,8 @@ module ManageIQ::Providers::Lenovo
         unless result[:power_state].nil?
           result[:power_state] = result[:power_state].downcase if %w(on off).include?(result[:power_state].downcase)
         end
-        result[:type]         = parent::ParserDictionaryConstants::MIQ_TYPES["physical_switch"]
-        result[:health_state] = parent::ParserDictionaryConstants::HEALTH_STATE_MAP[physical_switch.overallHealthState.nil? ? physical_switch.overallHealthState : physical_switch.overallHealthState.downcase]
+        result[:type]         = MIQ_TYPES["physical_switch"]
+        result[:health_state] = HEALTH_STATE_MAP[physical_switch.overallHealthState.nil? ? physical_switch.overallHealthState : physical_switch.overallHealthState.downcase]
         result[:hardware]     = get_hardwares(physical_switch)
 
         result[:physical_network_ports] = parent::PhysicalNetworkPortsParser.parse_physical_switch_ports(physical_switch)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/storage_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/storage_device_parser.rb
@@ -20,7 +20,7 @@ module ManageIQ::Providers::Lenovo
       # @param [Hash] device - a hash containing the storage device informations
       #
       def parse_device(device)
-        result = parse(device, parent::ParserDictionaryConstants::GUEST_DEVICE)
+        result = parse(device, GUEST_DEVICE)
 
         result[:uid_ems]     = mount_uuid(device)
         result[:device_name] = device["productName"] ? device["productName"] : device["name"]


### PR DESCRIPTION
**What this PR does:**
- The specialized parsers inherit from `ComponentParser`. Thus, all maps that were used in more than one parser can live inside the parent class and be used directly by Its children (without namespacing).

**Reason:**
- This enables a better cohesion on the parser classes. The maps that are common to more than one parser are available in the parent class.
