### PR TITLE
Extract management device parser (#10)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
@@ -55,8 +55,6 @@ module ManageIQ::Providers::Lenovo
       # @param source     - Object that will be parse to a hash
       # @param dictionary - Hash containing the instructions to translate the object into a Hash
       #
-      # @see ParserDictionaryConstants
-      #
       def parse(source, dictionary)
         result = {}
         dictionary&.each do |key, value|

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/management_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/management_device_parser.rb
@@ -1,0 +1,29 @@
+module ManageIQ::Providers::Lenovo
+  class PhysicalInfraManager::Parser::ManagementDeviceParser < PhysicalInfraManager::Parser::ComponentParser
+    class << self
+      # Mapping between fields inside a [Hash] of a Management Device to a [Hash] with symbols
+      MANAGEMENT_DEVICE = {
+        :address => 'macAddress',
+        :network => {
+          :ipaddress => 'mgmtProcIPaddress'
+        }
+      }.freeze
+
+      #
+      # Parse a node object to get Its management device
+      #
+      # @param [Hash] node - Node that contains a Management Device attached to It
+      #
+      # @return [Hash] containing the management device information
+      #
+      def parse_management_device(node)
+        result = parse(node, MANAGEMENT_DEVICE)
+
+        result[:device_type] = 'management'
+        result[:network][:ipv6address] = node.ipv6Addresses&.join(', ')
+
+        result
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
@@ -30,13 +30,6 @@ module ManageIQ::Providers::Lenovo
         }
       }.freeze
 
-      MANAGEMENT_DEVICE = {
-        :address => 'macAddress',
-        :network => {
-          :ipaddress => 'mgmtProcIPaddress'
-        }
-      }.freeze
-
       #
       # parse a node object to a hash with physical servers data
       #
@@ -112,16 +105,7 @@ module ManageIQ::Providers::Lenovo
       def get_guest_devices(node)
         guest_devices = parent::NetworkDeviceParser.parse_network_devices(node)
         guest_devices.concat(parent::StorageDeviceParser.parse_storage_device(node))
-        guest_devices << parse_management_device(node)
-      end
-
-      def parse_management_device(node)
-        result = parse(node, MANAGEMENT_DEVICE)
-
-        result[:device_type] = "management"
-        result[:network][:ipv6address] = node.ipv6Addresses.nil? ? node.ipv6Addresses : node.ipv6Addresses.join(", ")
-
-        result
+        guest_devices << parent::ManagementDeviceParser.parse_management_device(node)
       end
     end
   end


### PR DESCRIPTION
**What this PR does:**
- Extracts a `ManagementDeviceParser` from an internal part of the `PhysicalServerParser`;

**Reason:**
- Each parser should have only one responsibility.
