### PR TITLE
Organizing existing parsers (#11)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
@@ -32,10 +32,6 @@ module ManageIQ::Providers::Lenovo
         }
       }.freeze
 
-      PHYSICAL_CHASSIS_NETWORK = {
-        :ipaddress => 'mgmtProcIPaddress'
-      }.freeze
-
       #
       # Parse a chassis hash to a hash with physical racks data
       #
@@ -62,12 +58,12 @@ module ManageIQ::Providers::Lenovo
       private
 
       def get_hardwares(chassis)
-        parsed_chassi_network = parse(chassis, PHYSICAL_CHASSIS_NETWORK)
-
         {
           :guest_devices => [{
-            :device_type => "management",
-            :network     => parsed_chassi_network
+            :device_type => 'management',
+            :network     => {
+              :ipaddress => chassis.mgmtProcIPaddress
+            }
           }]
         }
       end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -30,10 +30,6 @@ module ManageIQ::Providers::Lenovo
         },
       }.freeze
 
-      PHYSICAL_STORAGE_NETWORK = {
-        :ipaddress => 'mgmtProcIPaddress',
-      }.freeze
-
       #
       # Parse a storage into a hash
       #
@@ -59,12 +55,12 @@ module ManageIQ::Providers::Lenovo
       private
 
       def get_hardwares(storage)
-        parsed_storage_network = parse(storage, PHYSICAL_STORAGE_NETWORK)
-
         {
           :guest_devices => [{
             :device_type => "management",
-            :network     => parsed_storage_network
+            :network     => {
+              :ipaddress => storage.mgmtProcIPaddress
+            }
           }]
         }
       end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
@@ -17,11 +17,6 @@ module ManageIQ::Providers::Lenovo
         }
       }.freeze
 
-      PHYSICAL_SWITCH_NETWORK = {
-        :subnet_mask     => 'subnet',
-        :default_gateway => 'gateway'
-      }.freeze
-
       #
       # Parses a switch into a Hash
       #
@@ -74,12 +69,12 @@ module ManageIQ::Providers::Lenovo
       end
 
       def parse_network(assignment, is_ipv6 = false)
-        result = parse(assignment, PHYSICAL_SWITCH_NETWORK)
-
-        result[:ipaddress]   = assignment['address'] unless is_ipv6
-        result[:ipv6address] = assignment['address'] if is_ipv6
-
-        result
+        {
+          :subnet_mask     => assignment['subnet'],
+          :default_gateway => assignment['gateway'],
+          :ipaddress       => (assignment['address'] unless is_ipv6),
+          :ipv6address     => (assignment['address'] if is_ipv6)
+        }
       end
 
       def get_firmwares(physical_switch)


### PR DESCRIPTION
**What this PR does:**
- Removes the Dictionary Constants of parsers inside `PhysicalChassisParser` and `PhysicalServerParser`;
- Adds the parsing steps to the code of the classes.

**Reason:**
- Switches and Chassis parsers had some half-parsers that were not complete parsers to be extracted. I put their logic directly on parent parsers.
