### PR TITLE
Adds support for computed properties on parser mapping (#12)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
@@ -24,13 +24,6 @@ module ManageIQ::Providers::Lenovo
         nil               => 'Unknown'
       }.freeze
 
-      MIQ_TYPES = {
-        'physical_server'  => 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer',
-        'physical_switch'  => 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch',
-        'physical_storage' => 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalStorage',
-        'physical_chassis' => 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis'
-      }.freeze
-
       POWER_STATE_MAP = {
         8  => 'On',
         5  => 'Off',
@@ -44,7 +37,6 @@ module ManageIQ::Providers::Lenovo
 
       private_constant :GUEST_DEVICE
       private_constant :HEALTH_STATE_MAP
-      private_constant :MIQ_TYPES
       private_constant :POWER_STATE_MAP
       private_constant :PROPERTIES_MAP
 
@@ -72,6 +64,8 @@ module ManageIQ::Providers::Lenovo
               end
             end
             result[key] = source_value.kind_of?(String) ? source_value.strip.presence : source_value
+          elsif value.kind_of?(Symbol)
+            result[key] = send(value, source)
           elsif value.kind_of?(Hash)
             result[key] = parse(source, dictionary[key])
           end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/firmware_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/firmware_parser.rb
@@ -5,7 +5,8 @@ module ManageIQ::Providers::Lenovo
       FIRMWARE = {
         :build        => 'build',
         :version      => 'version',
-        :release_date => 'date'
+        :release_date => 'date',
+        :name         => :name
       }.freeze
 
       #
@@ -16,11 +17,11 @@ module ManageIQ::Providers::Lenovo
       # @return [Hash] the firmware as required by the application
       #
       def parse_firmware(firmware)
-        result = parse(firmware, FIRMWARE)
+        parse(firmware, FIRMWARE)
+      end
 
-        result[:name] = "#{firmware["role"]} #{firmware["name"]}-#{firmware["status"]}".strip
-
-        result
+      def name(firmware)
+        "#{firmware['role']} #{firmware['name']}-#{firmware['status']}".strip
       end
     end
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/management_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/management_device_parser.rb
@@ -3,9 +3,11 @@ module ManageIQ::Providers::Lenovo
     class << self
       # Mapping between fields inside a [Hash] of a Management Device to a [Hash] with symbols
       MANAGEMENT_DEVICE = {
-        :address => 'macAddress',
-        :network => {
-          :ipaddress => 'mgmtProcIPaddress'
+        :address     => 'macAddress',
+        :device_type => :device_type,
+        :network     => {
+          :ipaddress   => 'mgmtProcIPaddress',
+          :ipv6address => :ipv6address
         }
       }.freeze
 
@@ -17,12 +19,17 @@ module ManageIQ::Providers::Lenovo
       # @return [Hash] containing the management device information
       #
       def parse_management_device(node)
-        result = parse(node, MANAGEMENT_DEVICE)
+        parse(node, MANAGEMENT_DEVICE)
+      end
 
-        result[:device_type] = 'management'
-        result[:network][:ipv6address] = node.ipv6Addresses&.join(', ')
+      private
 
-        result
+      def device_type(_node)
+        'management'
+      end
+
+      def ipv6address(node)
+        node.ipv6Addresses&.join(', ')
       end
     end
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
@@ -7,6 +7,20 @@ module ManageIQ::Providers::Lenovo
         :ems_ref         => 'uuid',
         :uid_ems         => 'uuid',
         :hostname        => 'hostname',
+        :vendor          => :vendor,
+        :type            => :type,
+        :power_state     => :power_state,
+        :health_state    => :health_state,
+        :host            => :host,
+        :computer_system => {
+          :hardware => {
+            :disk_capacity   => :disk_capacity,
+            :memory_mb       => :memory_info,
+            :cpu_total_cores => :total_cores,
+            :firmwares       => :firmwares,
+            :guest_devices   => :guest_devices
+          }
+        },
         :asset_detail    => {
           :product_name           => 'productName',
           :manufacturer           => 'manufacturer',
@@ -21,21 +35,16 @@ module ManageIQ::Providers::Lenovo
           :room                   => 'location.room',
           :rack_name              => 'location.rack',
           :lowest_rack_unit       => 'location.lowestRackUnit'
-        },
-        :computer_system => {
-          :hardware => {
-            :guest_devices => '',
-            :firmwares     => ''
-          }
         }
       }.freeze
 
       #
       # parse a node object to a hash with physical servers data
       #
-      # @param [Hash] node_hash - hash containing physical server raw data
-      # @param [Hash] rack - parsed physical rack data
-      # @param [Hash] chassis - parsed physical chassis data
+      # @param [Hash] node_hash  - hash containing physical server raw data
+      # @param [Hash] compliance - parsed compliance applied to this physical server
+      # @param [Hash] rack       - parsed physical rack data
+      # @param [Hash] chassis    - parsed physical chassis data
       #
       # @return [Hash] containing the physical server information
       #
@@ -44,17 +53,10 @@ module ManageIQ::Providers::Lenovo
         result = parse(node, PHYSICAL_SERVER)
 
         # Keep track of the rack where this server is in, if it is in any rack
-        result[:physical_rack]                       = rack if rack
-        result[:physical_chassis]                    = chassis if chassis
-        result[:ems_compliance_name]                 = compliance[:policy_name]
-        result[:ems_compliance_status]               = compliance[:status]
-        result[:vendor]                              = "lenovo"
-        result[:type]                                = MIQ_TYPES["physical_server"]
-        result[:power_state]                         = POWER_STATE_MAP[node.powerStatus]
-        result[:health_state]                        = HEALTH_STATE_MAP[node.cmmHealthState.nil? ? node.cmmHealthState : node.cmmHealthState.downcase]
-        result[:host]                                = get_host_relationship(node.serialNumber)
-        result[:computer_system][:hardware]          = get_hardwares(node)
-
+        result[:physical_rack]              = rack if rack
+        result[:physical_chassis]           = chassis if chassis
+        result[:ems_compliance_name]        = compliance[:policy_name]
+        result[:ems_compliance_status]      = compliance[:status]
         result[:asset_detail].merge!(get_location_led_info(node.leds) || {})
 
         result
@@ -62,24 +64,31 @@ module ManageIQ::Providers::Lenovo
 
       private
 
+      def vendor(_node)
+        'lenovo'
+      end
+
+      def type(_node)
+        'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer'
+      end
+
+      def power_state(node)
+        POWER_STATE_MAP[node.powerStatus]
+      end
+
+      def health_state(node)
+        HEALTH_STATE_MAP[node.cmmHealthState.nil? ? node.cmmHealthState : node.cmmHealthState.downcase]
+      end
+
       # Assign a physicalserver and host if server already exists and
       # some host match with physical Server's serial number
-      def get_host_relationship(serial_number)
+      def host(node)
+        serial_number = node.serialNumber
         Host.find_by(:service_tag => serial_number) ||
           Host.joins(:hardware).find_by('hardwares.serial_number' => serial_number)
       end
 
-      def get_hardwares(node)
-        {
-          :disk_capacity   => get_disk_capacity(node),
-          :memory_mb       => get_memory_info(node),
-          :cpu_total_cores => get_total_cores(node),
-          :firmwares       => get_firmwares(node),
-          :guest_devices   => get_guest_devices(node)
-        }
-      end
-
-      def get_disk_capacity(node)
+      def disk_capacity(node)
         total_disk_cap = 0
         node.raidSettings&.each do |storage|
           storage['diskDrives']&.each do |disk|
@@ -89,20 +98,20 @@ module ManageIQ::Providers::Lenovo
         total_disk_cap.positive? ? total_disk_cap : nil
       end
 
-      def get_memory_info(node)
+      def memory_info(node)
         total_memory_gigabytes = node.memoryModules&.reduce(0) { |total, mem| total + mem['capacity'] }
         total_memory_gigabytes * 1024 # convert to megabytes
       end
 
-      def get_total_cores(node)
+      def total_cores(node)
         node.processors&.reduce(0) { |total, pr| total + pr['cores'] }
       end
 
-      def get_firmwares(node)
+      def firmwares(node)
         node.firmware&.map { |firmware| parent::FirmwareParser.parse_firmware(firmware) }
       end
 
-      def get_guest_devices(node)
+      def guest_devices(node)
         guest_devices = parent::NetworkDeviceParser.parse_network_devices(node)
         guest_devices.concat(parent::StorageDeviceParser.parse_storage_device(node))
         guest_devices << parent::ManagementDeviceParser.parse_management_device(node)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -11,6 +11,8 @@ module ManageIQ::Providers::Lenovo
         :drive_bays           => 'driveBays',
         :enclosures           => 'enclosureCount',
         :canister_slots       => 'canisterSlots',
+        :type                 => :type,
+        :health_state         => :health_state,
         :asset_detail         => {
           :product_name     => 'productName',
           :machine_type     => 'machineType',
@@ -25,9 +27,9 @@ module ManageIQ::Providers::Lenovo
         },
         :computer_system      => {
           :hardware => {
-            :guest_devices => '',
-          },
-        },
+            :guest_devices => :guest_devices
+          }
+        }
       }.freeze
 
       #
@@ -43,26 +45,28 @@ module ManageIQ::Providers::Lenovo
         storage = XClarityClient::Storage.new(storage_hash)
         result = parse(storage, PHYSICAL_STORAGE)
 
-        result[:physical_rack]              = rack if rack
-        result[:physical_chassis]           = chassis if chassis
-        result[:type]                       = MIQ_TYPES["physical_storage"]
-        result[:health_state]               = HEALTH_STATE_MAP[storage.cmmHealthState.nil? ? storage.cmmHealthState : storage.cmmHealthState.downcase]
-        result[:computer_system][:hardware] = get_hardwares(storage)
-
+        result[:physical_rack] = rack if rack
+        result[:physical_chassis] = chassis if chassis
         result
       end
 
       private
 
-      def get_hardwares(storage)
-        {
-          :guest_devices => [{
-            :device_type => "management",
-            :network     => {
-              :ipaddress => storage.mgmtProcIPaddress
-            }
-          }]
-        }
+      def type(_storage)
+        'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalStorage'
+      end
+
+      def health_state(storage)
+        HEALTH_STATE_MAP[storage.cmmHealthState.nil? ? storage.cmmHealthState : storage.cmmHealthState.downcase]
+      end
+
+      def guest_devices(storage)
+        [{
+          :device_type => 'management',
+          :network     => {
+            :ipaddress => storage.mgmtProcIPaddress
+          }
+        }]
       end
     end
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_switch_parser.rb
@@ -3,11 +3,18 @@ module ManageIQ::Providers::Lenovo
     class << self
       # Mapping between fields inside a [XClarityClient::Switch] to a [Hash] with symbols of PhysicalSwitch fields
       PHYSICAL_SWITCH = {
-        :name         => 'name',
-        :uid_ems      => 'uuid',
-        :switch_uuid  => 'uuid',
-        :power_state  => 'powerState',
-        :asset_detail => {
+        :name                   => 'name',
+        :uid_ems                => 'uuid',
+        :switch_uuid            => 'uuid',
+        :power_state            => :power_state,
+        :type                   => :type,
+        :health_state           => :health_state,
+        :physical_network_ports => :physical_network_ports,
+        :hardware               => {
+          :firmwares => :firmwares,
+          :networks  => :networks
+        },
+        :asset_detail           => {
           :product_name           => 'productName',
           :serial_number          => 'serialNumber',
           :part_number            => 'partNumber',
@@ -25,30 +32,37 @@ module ManageIQ::Providers::Lenovo
       # @return [Hash] the switch data as required by the application
       #
       def parse_physical_switch(physical_switch)
-        result = parse(physical_switch, PHYSICAL_SWITCH)
-
-        unless result[:power_state].nil?
-          result[:power_state] = result[:power_state].downcase if %w(on off).include?(result[:power_state].downcase)
-        end
-        result[:type]         = MIQ_TYPES["physical_switch"]
-        result[:health_state] = HEALTH_STATE_MAP[physical_switch.overallHealthState.nil? ? physical_switch.overallHealthState : physical_switch.overallHealthState.downcase]
-        result[:hardware]     = get_hardwares(physical_switch)
-
-        result[:physical_network_ports] = parent::PhysicalNetworkPortsParser.parse_physical_switch_ports(physical_switch)
-
-        result
+        parse(physical_switch, PHYSICAL_SWITCH)
       end
 
       private
 
-      def get_hardwares(physical_switch)
-        {
-          :firmwares => get_firmwares(physical_switch),
-          :networks  => get_networks(physical_switch)
-        }
+      def power_state(switch)
+        state = switch.powerState
+        if !state.nil? && %w(on off).include?(state.downcase)
+          state.downcase
+        else
+          state
+        end
       end
 
-      def get_networks(physical_switch)
+      def type(_switch)
+        'ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch'
+      end
+
+      def health_state(switch)
+        HEALTH_STATE_MAP[switch.overallHealthState.nil? ? switch.overallHealthState : switch.overallHealthState.downcase]
+      end
+
+      def physical_network_ports(switch)
+        parent::PhysicalNetworkPortsParser.parse_physical_switch_ports(switch)
+      end
+
+      def firmwares(physical_switch)
+        physical_switch.firmware&.map { |firmware| parent::FirmwareParser.parse_firmware(firmware) }
+      end
+
+      def networks(physical_switch)
         get_parsed_switch_ip_interfaces_by_key(
           physical_switch.ipInterfaces,
           'IPv4assignments',
@@ -75,10 +89,6 @@ module ManageIQ::Providers::Lenovo
           :ipaddress       => (assignment['address'] unless is_ipv6),
           :ipv6address     => (assignment['address'] if is_ipv6)
         }
-      end
-
-      def get_firmwares(physical_switch)
-        physical_switch.firmware&.map { |firmware| parent::FirmwareParser.parse_firmware(firmware) }
       end
     end
   end


### PR DESCRIPTION
**What this PR does:**
- Enhances the way the parser iterates over the Dictionary of each parser. Now, the dictionary should have the simple properties as strings (as It was before) and **Symbols** to be computed properties.

**Reason:**
- `ComponentParser` was enhanced and understands a symbol inside a dictionary. The symbol used will trigger execution of a method on the parser to compute the value of a property.
