### PR TITLE
Extract a GuestDeviceParser superclass from storage and network (#13)

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
@@ -5,12 +5,6 @@ module ManageIQ::Providers::Lenovo
   #
   class PhysicalInfraManager::Parser::ComponentParser
     class << self
-      GUEST_DEVICE = {
-        :manufacturer           => 'manufacturer',
-        :field_replaceable_unit => 'FRU',
-        :controller_type        => 'class'
-      }.freeze
-
       HEALTH_STATE_MAP = {
         'normal'          => 'Valid',
         'non-critical'    => 'Valid',
@@ -42,7 +36,6 @@ module ManageIQ::Providers::Lenovo
         :led_identify_name => %w(Identification Identify Location),
       }.freeze
 
-      private_constant :GUEST_DEVICE
       private_constant :HEALTH_STATE_MAP
       private_constant :MIQ_TYPES
       private_constant :POWER_STATE_MAP

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/guest_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/guest_device_parser.rb
@@ -1,0 +1,57 @@
+module ManageIQ::Providers::Lenovo
+  class PhysicalInfraManager::Parser::GuestDeviceParser < PhysicalInfraManager::Parser::ComponentParser
+    class << self
+      # Mapping between fields inside [Hash] Guest Device to a [Hash] with symbols as keys
+      GUEST_DEVICE = {
+        :manufacturer           => 'manufacturer',
+        :field_replaceable_unit => 'FRU',
+        :controller_type        => 'class',
+        :uid_ems                => :uid_ems,
+        :device_name            => :device_name,
+        :device_type            => :device_type,
+        :firmwares              => :firmwares,
+        :location               => :location
+      }.freeze
+
+      #
+      # Mounts a Guest Device
+      #
+      # @param [Hash] guest_device - a raw device that needs to be parsed
+      #
+      def parse_guest_device(guest_device)
+        parse(guest_device, GUEST_DEVICE)
+      end
+
+      private
+
+      def uid_ems(device)
+        device['uuid'] || "#{device['pciBusNumber']}#{device['pciDeviceNumber']}"
+      end
+
+      def device_name(device)
+        device['productName'] ? device['productName'] : device['name']
+      end
+
+      def device_type(_device)
+        'guest_device'
+      end
+
+      def firmwares(device)
+        device_fw = []
+
+        firmware = device['firmware']
+        unless firmware.nil?
+          device_fw = firmware.map do |fw|
+            parent::FirmwareParser.parse_firmware(fw)
+          end
+        end
+
+        device_fw
+      end
+
+      def location(device)
+        device['slotNumber'] ? "Bay #{device['slotNumber']}" : nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What this PR does:**
- Creates a Superclass `GuestDeviceParser` that is inherited by `StorageGuestDevice` and `NetworkGuestDevice`;

**Reason:**
- The two existing parsers had a lot of similar structure. However, they need a different `device_type` computation. This way, the creation of a superclass solves the problem and improves code reuse.