### PR TITLE
[BZ 1581680] Fixing authentication status update

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -85,9 +85,9 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
     def translate_exception(err)
       case err
       when XClarityClient::Error::AuthenticationError
-        MiqException::MiqHostError.new('Login failed due to a bad username or password.')
+        MiqException::MiqInvalidCredentialsError.new('Login failed due to a bad username or password.')
       when XClarityClient::Error::ConnectionFailed
-        MiqException::MiqHostError.new('Execution expired or invalid port.')
+        MiqException::MiqUnreachableError.new('Execution expired or invalid port.')
       when XClarityClient::Error::ConnectionRefused
         MiqException::MiqHostError.new('Connection refused, invalid host.')
       when XClarityClient::Error::HostnameUnknown

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
@@ -189,7 +189,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
       end
 
       it "should raise MiqHostError with correctly translated message" do
-        expect { subject }.to raise_error(MiqException::MiqHostError, "Login failed due to a bad username or password.")
+        expect { subject }.to raise_error(MiqException::MiqInvalidCredentialsError, "Login failed due to a bad username or password.")
       end
     end
 
@@ -201,7 +201,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
       end
 
       it "should raise MiqHostError with correctly translated message" do
-        expect { subject }.to raise_error(MiqException::MiqHostError, "Execution expired or invalid port.")
+        expect { subject }.to raise_error(MiqException::MiqUnreachableError, "Execution expired or invalid port.")
       end
     end
 


### PR DESCRIPTION
__This PR is able to__
- Set the right credentials status when `AuthenticationMixin#authentication_check` is called.

__Current result__
The status is aways set to `Error`

![image](https://user-images.githubusercontent.com/8550928/40444266-3d1424c0-5e9f-11e8-9d95-bfe0d3f43efb.png)

__Expected result__
Set the status to `invalid` or `unreachable`

__Bugzilla__
https://bugzilla.redhat.com/show_bug.cgi?id=1581680