### PR TITLE
Adding location led name

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/parser_dictionary_constants.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/parser_dictionary_constants.rb
@@ -31,7 +31,7 @@ module ManageIQ::Providers::Lenovo
     }.freeze
 
     PROPERTIES_MAP = {
-      :led_identify_name => %w(Identification Identify),
+      :led_identify_name => %w(Identification Identify Location),
     }.freeze
 
     # TRANSLATE HASHES BEGIN

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -174,7 +174,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(physical_chassis[:health_state]).to eq("Valid")
       expected_type = "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis"
       expect(physical_chassis[:type]).to eq(expected_type)
-      expect(physical_chassis[:location_led_state]).to be_nil
+      expect(physical_chassis[:location_led_state]).to eq("Off")
     end
 
     it 'will parse physical chassis asset detail data' do


### PR DESCRIPTION
Some identify LEDs of some components has the value `"Location"` in its names