### PR TITLE
Adding Chassis Location Led actions

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/sender.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/sender.rb
@@ -1,0 +1,24 @@
+module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender
+  extend ActiveSupport::Concern
+
+  #
+  # Sends the power operation to LXCA.
+  #
+  # @param [symbol] verb - the operation that must be sent
+  #
+  # @return the LXCA response
+  #
+  def change_resource_state(verb)
+    $lenovo_log.info("The :#{verb} for #{self.class.name.demodulize} with uuid: #{uid_ems} is in progress")
+
+    response = {}
+
+    ext_management_system.with_provider_connection do |connection|
+      response = connection.send(verb, uid_ems)
+    end
+
+    $lenovo_log.info("The :#{verb} for #{self.class.name.demodulize} with uuid: #{uid_ems} is completed")
+
+    response
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis.rb
@@ -1,5 +1,7 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalChassis < ::PhysicalChassis
+    include_concern 'Operations'
+
     def self.display_name(number = 1)
       n_('Physical Chassis (Lenovo)', 'Physical Chassis (Lenovo)', number)
     end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis/operations.rb
@@ -1,0 +1,20 @@
+#
+# Has the Power Operation methods for Physical Chassis
+#
+module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis::Operations
+  extend ActiveSupport::Concern
+
+  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
+
+  def blink_loc_led
+    change_resource_state(:blink_loc_led_chassis)
+  end
+
+  def turn_on_loc_led
+    change_resource_state(:turn_on_loc_led_chassis)
+  end
+
+  def turn_off_loc_led
+    change_resource_state(:turn_off_loc_led_chassis)
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch/operations.rb
@@ -4,34 +4,13 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch::Operations
   extend ActiveSupport::Concern
 
+  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
+
   #
   # Restarts the physical switch.
   #   it does the `power_cycle_soft` operation.
   #
   def restart
     change_resource_state(:power_cycle_soft_switch)
-  end
-
-  private
-
-  #
-  # Sends the power operation for a Switch.
-  #
-  # @param [symbol] verb - the operation that must be sent
-  #
-  # @return the LXCA response
-  #
-  def change_resource_state(verb)
-    $lenovo_log.info("The :#{verb} for Physical Switch with uuid: #{uid_ems} is in progress")
-
-    response = {}
-
-    ext_management_system.with_provider_connection do |connection|
-      response = connection.send(verb, uid_ems)
-    end
-
-    $lenovo_log.info("The :#{verb} for Physical Switch with uuid: #{uid_ems} is completed")
-
-    response
   end
 end

--- a/spec/factories/physical_chassis.rb
+++ b/spec/factories/physical_chassis.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :lenovo_physical_chassis, :class => ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis do
+  end
+end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis_spec.rb
@@ -1,0 +1,50 @@
+describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis do
+  describe 'power operations' do
+    let(:physical_chassis) do
+      physical_infra_manager = FactoryGirl.create(
+        :physical_infra,
+        :name      => "LXCA",
+        :hostname  => "10.243.9.123",
+        :port      => "443",
+        :ipaddress => "https://10.243.9.123"
+      )
+
+      auth = FactoryGirl.create(
+        :authentication,
+        :userid   => "admin",
+        :password => "password",
+        :authtype => "default"
+      )
+
+      physical_infra_manager.authentications = [auth]
+
+      FactoryGirl.create(
+        :lenovo_physical_chassis,
+        :name                  => "Physical_Chassis",
+        :uid_ems               => "27997dba5dba11e89c2dfa7ae01bbebc",
+        :ext_management_system => physical_infra_manager
+      )
+    end
+
+    it 'will blink the location led' do
+      VCR.use_cassette("#{described_class.name.underscore}_blink_loc_led") do
+        response = physical_chassis.blink_loc_led
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'will turn on the location led' do
+      VCR.use_cassette("#{described_class.name.underscore}_turn_on_loc_led") do
+        response = physical_chassis.turn_on_loc_led
+        expect(response.status).to eq(200)
+      end
+    end
+
+    it 'will turn off the location led' do
+      VCR.use_cassette("#{described_class.name.underscore}_turn_off_loc_led") do
+        response = physical_chassis.turn_off_loc_led
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/physical_chassis_blink_loc_led.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/physical_chassis_blink_loc_led.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://10.243.9.123/chassis/27997dba5dba11e89c2dfa7ae01bbebc
+    body:
+      encoding: UTF-8
+      string: '{"leds":[{"name":"Location","state":"Blinking"}]}'
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.6.1 (ManageIQ/master)
+      Authorization:
+      - Basic ZGdvdXZlaWE6UGl4b21heG80
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Jul 2018 11:39:26 GMT
+      - Tue, 03 Jul 2018 11:39:26 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local_ldap;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - frame-ancestors 'self'; default-src 'self' ; script-src 'self' 'unsafe-inline'
+        'unsafe-eval'; style-src 'self' 'unsafe-inline'; object-src 'none'; worker-src
+        'self' blob:; child-src 'self' blob:; img-src 'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.1.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"result":"success","statusDescription":"The request completed successfully.","messages":[{"recoveryUrl":"","id":"FQXDM0200","text":"The
+        request completed successfully.","recovery":"","explanation":"The request
+        completed successfully."}],"statusCode":200}'
+    http_version:
+  recorded_at: Tue, 03 Jul 2018 11:38:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/physical_chassis_turn_off_loc_led.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/physical_chassis_turn_off_loc_led.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://10.243.9.123/chassis/27997dba5dba11e89c2dfa7ae01bbebc
+    body:
+      encoding: UTF-8
+      string: '{"leds":[{"name":"Location","state":"Off"}]}'
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.6.1 (ManageIQ/master)
+      Authorization:
+      - Basic ZGdvdXZlaWE6UGl4b21heG80
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Jul 2018 11:39:37 GMT
+      - Tue, 03 Jul 2018 11:39:37 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local_ldap;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - frame-ancestors 'self'; default-src 'self' ; script-src 'self' 'unsafe-inline'
+        'unsafe-eval'; style-src 'self' 'unsafe-inline'; object-src 'none'; worker-src
+        'self' blob:; child-src 'self' blob:; img-src 'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.1.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"result":"success","statusDescription":"The request completed successfully.","messages":[{"recoveryUrl":"","id":"FQXDM0200","text":"The
+        request completed successfully.","recovery":"","explanation":"The request
+        completed successfully."}],"statusCode":200}'
+    http_version:
+  recorded_at: Tue, 03 Jul 2018 11:39:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/physical_chassis_turn_on_loc_led.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/physical_chassis_turn_on_loc_led.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://10.243.9.123/chassis/27997dba5dba11e89c2dfa7ae01bbebc
+    body:
+      encoding: UTF-8
+      string: '{"leds":[{"name":"Location","state":"On"}]}'
+    headers:
+      User-Agent:
+      - LXCA via Ruby Client/0.6.1 (ManageIQ/master)
+      Authorization:
+      - Basic ZGdvdXZlaWE6UGl4b21heG80
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 03 Jul 2018 11:40:09 GMT
+      - Tue, 03 Jul 2018 11:40:09 GMT
+      Set-Cookie:
+      - userAuthenticationMethod=local_ldap;Path=/;Secure
+      Expires:
+      - "-1"
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - frame-ancestors 'self'; default-src 'self' ; script-src 'self' 'unsafe-inline'
+        'unsafe-eval'; style-src 'self' 'unsafe-inline'; object-src 'none'; worker-src
+        'self' blob:; child-src 'self' blob:; img-src 'self' data:;
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      Pragma:
+      - no-cache
+      Content-Type:
+      - application/com.lenovo.lxca-v2.1.0+json; charset=UTF-8
+      Vary:
+      - Accept-Encoding, User-Agent
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"result":"success","statusDescription":"The request completed successfully.","messages":[{"recoveryUrl":"","id":"FQXDM0200","text":"The
+        request completed successfully.","recovery":"","explanation":"The request
+        completed successfully."}],"statusCode":200}'
+    http_version:
+  recorded_at: Tue, 03 Jul 2018 11:39:47 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
__This PR is able to__
- Move the `change_resource_state` method to a shared place to reuse in `physical_switches` and `physical_chassis` actions;
- Support Location LED actions for chassis:
  - blink_loc_led;
  - turn_on_loc_led;
  - turn_off_loc_led;
