### PR TITLE
Parsing physical_swtich_id and physical_chassis_id into events

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_parser.rb
@@ -1,38 +1,64 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser
-  def self.event_to_hash(data, ems_id)
-    event = filter_data(data)
-    event_hash = {
-      :event_type         => event[:event_type],
-      :ems_ref            => event[:ems_ref],
-      :source             => event[:source],
-      :physical_server_id => get_physical_server_id(event[:component_id]),
-      :message            => event[:message],
-      :timestamp          => event[:timestamp],
-      :full_data          => event,
-      :ems_id             => ems_id
-    }
-    event_hash
-  end
+  CHASSIS = 'Chassis'.freeze
+  SERVER  = %w(Node Power Processor System).freeze
+  SWITCH  = 'Switch'.freeze
 
-  def self.filter_data(data)
-    {
-      :component_id   => data.componentID,
-      :component_type => data.typeText,
-      :event_type     => data.msgID,
-      :ems_ref        => data.cn,
-      :message        => data.msg,
-      :parent_uuid    => data.senderUUID,
-      :parent_name    => data.systemName,
-      :parent_model   => data.systemTypeModelText,
-      :parent_type    => data.systemTypeText,
-      :severity_id    => data.severity,
-      :severity       => data.severityText,
-      :source         => 'LenovoXclarity',
-      :timestamp      => data.timeStamp,
-    }
-  end
+  class << self
+    def event_to_hash(data, ems_id)
+      event = filter_data(data)
+      event_hash = {
+        :event_type => event[:event_type],
+        :ems_ref    => event[:ems_ref],
+        :source     => event[:source],
+        :message    => event[:message],
+        :timestamp  => event[:timestamp],
+        :full_data  => event,
+        :ems_id     => ems_id
+      }
 
-  def self.get_physical_server_id(ems_ref)
-    PhysicalServer.find_by(:ems_ref => ems_ref).try(:id)
+      event_hash.merge!(event_resources(event))
+    end
+
+    def filter_data(data)
+      {
+        :component_id   => data.componentID,
+        :component_type => data.typeText,
+        :event_type     => data.msgID,
+        :ems_ref        => data.cn,
+        :message        => data.msg,
+        :parent_uuid    => data.sourceID,
+        :parent_name    => data.systemName,
+        :parent_model   => data.systemTypeModelText,
+        :parent_type    => data.systemTypeText,
+        :severity_id    => data.severity,
+        :severity       => data.severityText,
+        :source         => 'LenovoXclarity',
+        :timestamp      => data.timeStamp,
+      }
+    end
+
+    private
+
+    def event_resources(event)
+      event_resources = {}
+
+      if event[:parent_type] == CHASSIS
+        event_resources[:physical_chassis_id] = get_resource_id(PhysicalChassis, event[:parent_uuid])
+      end
+
+      if event[:component_type] == SWITCH
+        event_resources[:physical_switch_id] = get_resource_id(PhysicalSwitch, event[:component_id])
+      elsif SERVER.include?(event[:component_type])
+        event_resources[:physical_server_id] = get_resource_id(PhysicalServer, event[:component_id])
+      else
+        $log.error("The event of type #{event[:component_type]} is not supported")
+      end
+
+      event_resources
+    end
+
+    def get_resource_id(resource, uid_ems)
+      resource.find_by(:uid_ems => uid_ems).try(:id)
+    end
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/event_parser_spec.rb
@@ -3,24 +3,65 @@ require 'xclarity_client'
 describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventParser do
   let(:event_attrs1) do
     {
-      :msgID              => 1,
-      :source             => "LenovoXclarity",
-      :msg                => "This is a test event.",
-      :timeStamp          => "2017-04-26T13:55:49.749552",
-      :physical_server_id => "",
-      :to_hash            => "",
-      :ems_id             => 3
+      :msgID       => 1,
+      :source      => 'LenovoXclarity',
+      :msg         => 'This is a test event.',
+      :timeStamp   => '2017-04-26T13:55:49.749552',
+      :typeText    => 'Switch',
+      :componentID => 'FFFFFFFFFFFFFFFFFFFFFFFF',
+      :to_hash     => '',
+      :ems_id      => 3,
     }
   end
 
-  let(:event1) { XClarityClient::Event.new(event_attrs1) }
+  let(:event_attrs2) do
+    {
+      :msgID          => 1,
+      :source         => 'LenovoXclarity',
+      :sourceID       => 'AAAAAAAAAAAAAAAAAAAAAAA',
+      :msg            => 'This is also a test event.',
+      :timeStamp      => '2018-07-11T13:55:49.749552',
+      :typeText       => 'Power',
+      :systemTypeText => 'Chassis',
+      :componentID    => '00FF00FF00FF00FF00FF00FF',
+      :to_hash        => '',
+      :ems_id         => 3,
+    }
+  end
 
-  it 'will parse events' do
-    event_hash = described_class.event_to_hash(event1, 3)
-    expect(event_hash[:event_type]).to eq(1)
-    expect(event_hash[:source]).to eq("LenovoXclarity")
-    expect(event_hash[:message]).to eq("This is a test event.")
-    expect(event_hash[:timestamp]).to eq("2017-04-26T13:55:49.749552")
-    expect(event_hash[:ems_id]).to eq(3)
+  let(:physical_chassis) { FactoryGirl.create(:physical_chassis, :uid_ems => 'AAAAAAAAAAAAAAAAAAAAAAA') }
+
+  let(:event1) { XClarityClient::Event.new(event_attrs1) }
+  let(:physical_switch) { FactoryGirl.create(:physical_switch, :uid_ems => 'FFFFFFFFFFFFFFFFFFFFFFFF') }
+
+  let(:event2) { XClarityClient::Event.new(event_attrs2) }
+  let(:physical_server) { FactoryGirl.create(:physical_server, :uid_ems => '00FF00FF00FF00FF00FF00FF') }
+
+  context 'events are parsed' do
+    it 'should belong to a switch' do
+      physical_switch
+      event_hash = described_class.event_to_hash(event1, 3)
+      expect(event_hash[:event_type]).to eq(1)
+      expect(event_hash[:source]).to eq('LenovoXclarity')
+      expect(event_hash[:message]).to eq('This is a test event.')
+      expect(event_hash[:timestamp]).to eq('2017-04-26T13:55:49.749552')
+      expect(event_hash[:physical_server_id]).to be_nil
+      expect(event_hash[:physical_switch_id]).to eq(physical_switch.id)
+      expect(event_hash[:ems_id]).to eq(3)
+    end
+
+    it 'should belong to a server' do
+      physical_server
+      physical_chassis
+      event_hash = described_class.event_to_hash(event2, 3)
+      expect(event_hash[:event_type]).to eq(1)
+      expect(event_hash[:source]).to eq('LenovoXclarity')
+      expect(event_hash[:message]).to eq('This is also a test event.')
+      expect(event_hash[:timestamp]).to eq('2018-07-11T13:55:49.749552')
+      expect(event_hash[:physical_chassis_id]).to eq(physical_chassis.id)
+      expect(event_hash[:physical_server_id]).to eq(physical_server.id)
+      expect(event_hash[:physical_switch_id]).to be_nil
+      expect(event_hash[:ems_id]).to eq(3)
+    end
   end
 end


### PR DESCRIPTION
This PR is able to parse `physical_switch_id` into events, so we can handle events for switches.
Depends on: https://github.com/ManageIQ/manageiq-schema/pull/229