### PR TITLE
Parsing Location LED name

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
@@ -36,5 +36,11 @@ module ManageIQ::Providers::Lenovo
       end
       result
     end
+
+    def self.get_location_led_info(leds)
+      return if leds.blank?
+      identification_led = leds.to_a.find { |led| parent::ParserDictionaryConstants::PROPERTIES_MAP[:led_identify_name].include?(led["name"]) }
+      return identification_led.try(:[], "name"), identification_led.try(:[], "state")
+    end
   end
 end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -191,6 +191,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(asset_detail[:room]).to be_nil
       expect(asset_detail[:rack_name]).to be_nil
       expect(asset_detail[:lowest_rack_unit]).to eq(0)
+      expect(asset_detail[:location_led_ems_ref]).to eq("Location")
     end
 
     it 'will parse physical chassis hardware data' do
@@ -282,6 +283,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       serial_number
       description
       lowest_rack_unit
+      location_led_ems_ref
     ).each do |attr|
       it "will retrieve #{attr} of asset detail" do
         asset_detail = @result[:physical_servers][0][:asset_detail]


### PR DESCRIPTION
__This PR is able to__
- Parse the Location LED name to `physical_servers` and `physical_chassis`

__Depends on__
- ~https://github.com/ManageIQ/manageiq-schema/pull/231~ - Merged