### PR TITLE
Fixing error while try to generate the physical switch port uuid

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_network_ports_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_network_ports_parser.rb
@@ -126,7 +126,7 @@ module ManageIQ::Providers::Lenovo
       end
 
       def mount_uuid_switch_port(port, physical_switch)
-        physical_switch.uuid + port["interfaceIndex"]
+        physical_switch.uuid + port['port'].to_s
       end
 
       #


### PR DESCRIPTION
__Current result__
For the ports that doesn't have `interfaceIndex` the following error is raise:
```
no implicit conversion of nil into String
```
__After this PR__
The `port` field is used instead the `interfaceIndex` once it will be always filled