### PR TITLE
Adapting LED operations to parse the LED name

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
@@ -1,44 +1,46 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
   extend ActiveSupport::Concern
 
-  def blink_loc_led(server, options = {})
-    change_resource_state(:blink_loc_led, server, options)
+  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
+
+  def blink_loc_led(server, _options = {})
+    change_led_state(server, :blink_loc_led)
   end
 
-  def turn_on_loc_led(server, options = {})
-    change_resource_state(:turn_on_loc_led, server, options)
+  def turn_on_loc_led(server, _options = {})
+    change_led_state(server, :turn_on_loc_led)
   end
 
-  def turn_off_loc_led(server, options = {})
-    change_resource_state(:turn_off_loc_led, server, options)
+  def turn_off_loc_led(server, _options = {})
+    change_led_state(server, :turn_off_loc_led)
   end
 
-  def power_on(args, options = {})
-    change_resource_state(:power_on_node, args, options)
+  def power_on(server, _options = {})
+    change_resource_state(server, :power_on_node)
   end
 
-  def power_off(args, options = {})
-    change_resource_state(:power_off_node, args, options)
+  def power_off(server, _options = {})
+    change_resource_state(server, :power_off_node)
   end
 
-  def power_off_now(args, options = {})
-    change_resource_state(:power_off_node_now, args, options)
+  def power_off_now(server, _options = {})
+    change_resource_state(server, :power_off_node_now)
   end
 
-  def restart(args, options = {})
-    change_resource_state(:power_restart_node, args, options)
+  def restart(server, _options = {})
+    change_resource_state(server, :power_restart_node)
   end
 
-  def restart_now(args, options = {})
-    change_resource_state(:power_restart_node_now, args, options)
+  def restart_now(server, _options = {})
+    change_resource_state(server, :power_restart_node_now)
   end
 
-  def restart_to_sys_setup(args, options = {})
-    change_resource_state(:power_restart_node_to_setup, args, options)
+  def restart_to_sys_setup(server, _options = {})
+    change_resource_state(server, :power_restart_node_to_setup)
   end
 
-  def restart_mgmt_controller(args, options = {})
-    change_resource_state(:power_restart_node_controller, args, options)
+  def restart_mgmt_controller(server, _options = {})
+    change_resource_state(server, :power_restart_node_controller)
   end
 
   def apply_config_pattern(args, options = {})
@@ -56,20 +58,6 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
   end
 
   private
-
-  def change_resource_state(verb, args, options = {})
-    $lenovo_log.info("Entering change resource state for #{verb} and uuid: #{args.ems_ref} ")
-
-    # Retrieve a connection to the LXCA instance
-    client = create_client_connection
-
-    # Execute the action via the client
-    response = client.send(verb, args.ems_ref)
-
-    $lenovo_log.info("Exiting change resource state for #{verb} and uuid: #{args.ems_ref}")
-
-    response
-  end
 
   def create_client_connection
     auth = authentications.first

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/sender.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/sender.rb
@@ -4,21 +4,53 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender
   #
   # Sends the power operation to LXCA.
   #
-  # @param [symbol] verb - the operation that must be sent
+  # @param [Object] component - component that will suffer the action
+  # @param [symbol] verb      - the operation that must be sent
   #
   # @return the LXCA response
   #
-  def change_resource_state(verb)
-    $lenovo_log.info("The :#{verb} for #{self.class.name.demodulize} with uuid: #{uid_ems} is in progress")
+  def change_resource_state(component, verb)
+    prepare_to_send_operation(component, verb) { |connection| connection.send(verb, discover_uuid(component)) }
+  end
+
+  #
+  # Sends the L.E.D. operation to LXCA.
+  #   If the component has `location_led_ems_ref` setted, it is parsed to xclarity_client
+  #   else the name is not sent, and the xclarity_client will use the default name.
+  #
+  # @param [Object] component - component that will suffer the action
+  # @param [symbol] verb      - the operation that must be sent
+  #
+  # @return the LXCA response
+  #
+  def change_led_state(component, verb)
+    prepare_to_send_operation(component, verb) do |connection|
+      location_led_name = component.asset_detail&.location_led_ems_ref
+      location_led_name.present? ? connection.send(verb, discover_uuid(component), location_led_name) : connection.send(verb, discover_uuid(component))
+    end
+  end
+
+  private
+
+  #
+  # This is the template method to send operation requests
+  #   through xclarity_client.
+  #
+  def prepare_to_send_operation(component, verb)
+    $lenovo_log.info("The :#{verb} for #{component.class.name.demodulize} with uuid: #{discover_uuid(component)} is in progress")
 
     response = {}
 
     ext_management_system.with_provider_connection do |connection|
-      response = connection.send(verb, uid_ems)
+      response = yield(connection)
     end
 
-    $lenovo_log.info("The :#{verb} for #{self.class.name.demodulize} with uuid: #{uid_ems} is completed")
+    $lenovo_log.info("The :#{verb} for #{component.class.name.demodulize} with uuid: #{discover_uuid(component)} is completed")
 
     response
+  end
+
+  def discover_uuid(component)
+    component.try(:ems_ref) || component.try(:uid_ems)
   end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis/operations.rb
@@ -7,14 +7,14 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis::Opera
   include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
 
   def blink_loc_led
-    change_resource_state(:blink_loc_led_chassis)
+    change_led_state(self, :blink_loc_led_chassis)
   end
 
   def turn_on_loc_led
-    change_resource_state(:turn_on_loc_led_chassis)
+    change_led_state(self, :turn_on_loc_led_chassis)
   end
 
   def turn_off_loc_led
-    change_resource_state(:turn_off_loc_led_chassis)
+    change_led_state(self, :turn_off_loc_led_chassis)
   end
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch/operations.rb
@@ -11,6 +11,6 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch::Operat
   #   it does the `power_cycle_soft` operation.
   #
   def restart
-    change_resource_state(:power_cycle_soft_switch)
+    change_resource_state(self, :power_cycle_soft_switch)
   end
 end


### PR DESCRIPTION
__This PR is able to__
- Refactor the routine to send `LED` and `power` operations to share between all components;
- Send the name of location LED on LED operations.

__Depends on__
~https://github.com/ManageIQ/manageiq-providers-lenovo/pull/207~ - Merged