### PR TITLE
config/settings - add missing fields, fixing ui-classic breakage

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -71,6 +71,7 @@
           - 'IMM0133'
           :detail:
           - 'PLAT0187'
+          :warning: []
           :name: Firmware
         :devices:
           :critical:
@@ -127,6 +128,7 @@
           - 'PLAT0520'
           :name: Devices
         :network:
+          :critical: []
           :detail:
           - 'IMM0056'
           - 'IMM0025'
@@ -143,6 +145,7 @@
           - 'IMM0013'
           - 'IMM0059'
         :login:
+          :critical: []
           :detail:
           - 'IMM0014'
           - 'IMM0154'
@@ -180,6 +183,7 @@
           - 'PLAT0036'
           - 'IMM0034'
           - 'PLAT0446'
+          :warning: []
           :name: Security
         :status:
           :detail:
@@ -355,11 +359,13 @@
           :warning:
           - 'IMM0012'
         :addition:
+          :critical: []
           :detail:
           - 'IMM0106'
           - 'PLAT0084'
           - 'IMM0100'
           - 'IMM0096'
+          :warning: []
 :http_proxy:
   :lenovo:
     :host:


### PR DESCRIPTION
Every event group in settings needs to have 3 arrays: `critical`, `detail`, `warning`.

ManageIQ/manageiq-providers-lenovo#217 introduces a couple of groups missing one or two of the required arrays, which breaks 54 ui-classic specs :): https://gist.github.com/himdel/c7b682676542936c8e4533ee58da7ebb (example https://travis-ci.org/ManageIQ/manageiq-ui-classic/jobs/413927437)

Adding the missing ones here.

Cc: @matheuscmelo, @CharlleDaniel , @agrare 