### PR TITLE
Implementing Ansible Runner engine for Lenovo's provider

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
@@ -2,6 +2,7 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
   extend ActiveSupport::Concern
 
   include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
+  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::AnsibleSender'
 
   def blink_loc_led(server, _options = {})
     change_led_state(server, :blink_loc_led)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/ansible_sender.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/ansible_sender.rb
@@ -1,0 +1,98 @@
+#
+# Mixin to run ansible operations
+#
+module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::AnsibleSender
+  extend ActiveSupport::Concern
+
+  #
+  # Executes ansible resources inside +root_dir+
+  #
+  # @param args [Hash] - The args to run the ansible resource.
+  # @option args [String] 'playbook_name' - The name of the playbook to be executed.
+  #         If this param is filled a yaml file that matches with the specified name
+  #         will be searched inside +playbooks_dir+.
+  #         In cases where the playbook is not in +playbooks_dir+ root, please, specify
+  #         the relative path to it.
+  #         Example:
+  #           run_ansible({'playbook_name' => 'config/firmware_update_all_dev'})
+  #
+  # @option args [String] 'role_name' - The name of the role to be executed.
+  #        If this param is filled it will search the role inside +roles_dir+.
+  #        Example:
+  #           run_ansible({'role_name' => 'lenovo.lxca-inventory'})
+  #
+  # @option args [Hash] vars - The set of vars needed to execute the ansible resource
+  #
+  # @return Ansible::Runner::Response
+  #
+  # @see #root_dir
+  # @see #playbooks_dir
+  # @see #roles_dir
+  #
+  def run_ansible(args = {})
+    playbook_name, role_name, vars = load_params(args)
+    if playbook_name.present?
+      Ansible::Runner.run(
+        {},
+        ansible_default_vars.merge(vars),
+        playbooks_dir.join(playbook_name)
+      )
+    else
+      Ansible::Runner.run_role(
+        {},
+        ansible_default_vars.merge(vars),
+        role_name,
+        :roles_path => roles_dir
+      )
+    end
+  end
+
+  #
+  # The set of default vars to run playbooks.
+  #
+  # @return [Hash] containing the default vars to run playbooks
+  #
+  def ansible_default_vars
+    auth = authentications.first
+
+    {
+      'lxca_user'     => auth.userid,
+      'lxca_password' => auth.password,
+      'lxca_url'      => "https://#{hostname}",
+    }
+  end
+
+  private
+
+  #
+  # The root dir where ansible lives
+  #
+  def root_dir
+    ManageIQ::Providers::Lenovo::Engine.root.join("content/ansible_runner")
+  end
+
+  #
+  # The dir where ansible plabooks lives
+  #
+  def playbooks_dir
+    root_dir.join("playbooks/")
+  end
+
+  #
+  # The dir where ansible roles lives
+  #
+  def roles_dir
+    root_dir.join("roles/")
+  end
+
+  #
+  # Extracts the params from payload
+  #
+  # @param args [Hash] - contains the arguments to run ansible
+  #
+  # @return the params to run ansible
+  #
+  def load_params(args)
+    return args['playbook_name'], args['role_name'], args['vars'] || {}
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/component_ansible_sender.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/component_ansible_sender.rb
@@ -1,0 +1,19 @@
+#
+# Mixin to run ansible operations for physical components
+#
+module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender
+  extend ActiveSupport::Concern
+
+  include parent::AnsibleSender
+
+  #
+  # It adds some extra vars to run playbook against physical components
+  #
+  # @see AnsibleSender#ansible_default_vars
+  #
+  def ansible_default_vars
+    ext_management_system.ansible_default_vars.merge(
+      'endpoint' => try(:ems_ref) || try(:uid_ems)
+    )
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis/operations.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis::Opera
   extend ActiveSupport::Concern
 
   include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
+  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender'
 
   def blink_loc_led
     change_led_state(self, :blink_loc_led_chassis)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
@@ -1,6 +1,7 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalServer < ::PhysicalServer
     include_concern 'RemoteConsole'
+    include_concern 'Operations'
 
     def self.display_name(number = 1)
       n_('Physical Server (Lenovo)', 'Physical Servers (Lenovo)', number)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server/operations.rb
@@ -1,0 +1,5 @@
+module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer::Operations
+  extend ActiveSupport::Concern
+
+  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender'
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch/operations.rb
@@ -5,6 +5,7 @@ module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch::Operat
   extend ActiveSupport::Concern
 
   include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
+  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender'
 
   #
   # Restarts the physical switch.

--- a/content/ansible_runner/requirements.yml
+++ b/content/ansible_runner/requirements.yml
@@ -1,0 +1,2 @@
+# from galaxy
+- src: lenovo.lxca-inventory

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/operations/ansible_sender_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/operations/ansible_sender_spec.rb
@@ -1,0 +1,66 @@
+describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::AnsibleSender do
+  let(:auth) do
+    FactoryGirl.create(:authentication,
+                       :userid   => 'admin',
+                       :password => 'password',
+                       :authtype => 'default')
+  end
+
+  subject(:physical_infra_manager) do
+    manager = FactoryGirl.create(:physical_infra,
+                                 :name      => 'LXCA',
+                                 :hostname  => '10.243.9.123',
+                                 :port      => '443',
+                                 :ipaddress => 'https://10.243.9.123')
+    manager.authentications = [auth]
+    manager
+  end
+
+  it 'should return the right default vars' do
+    expect(subject.ansible_default_vars).to include(
+      'lxca_user'     => subject.authentications.first.userid,
+      'lxca_password' => subject.authentications.first.password,
+      'lxca_url'      => "https://#{subject.hostname}",
+    )
+  end
+
+  context 'when execute playbook' do
+    let(:playbook_payload) do
+      {
+        'playbook_name' => 'name'
+      }
+    end
+
+    let(:reponse) { subject.run_ansible(playbook_payload) }
+
+    let(:message) { 'Ansible::Runner#run' }
+
+    before do
+      allow(Ansible::Runner).to receive(:run) { message }
+    end
+
+    it 'should run Ansible::Runner#run' do
+      expect(reponse).to eq(message)
+    end
+  end
+
+  context 'when execute role' do
+    let(:playbook_payload) do
+      {
+        'role_name' => 'name'
+      }
+    end
+
+    let(:reponse) { subject.run_ansible(playbook_payload) }
+
+    let(:message) { 'Ansible::Runner#run_role' }
+
+    before do
+      allow(Ansible::Runner).to receive(:run_role) { message }
+    end
+
+    it 'should run Ansible::Runner#run_role' do
+      expect(reponse).to eq(message)
+    end
+  end
+end


### PR DESCRIPTION
__This PR is able to__
- Add the capability to run Ansible resources (roles and playbooks) against a LXCA or its components;

__RFC__
- How to embed https://github.com/lenovo/ansible.lenovo-lxca into `manageiq-providers-lenovo`

__Usage__

Run the following rake task to fetch roles with ansible-galaxy
```bash
bundle exec rake evm:ansible_runner:seed
```

After this, the following script is possible
```ruby
ph_manager_lenovo = ManageIQ::Providers::Lenovo::PhysicalInfraManager.first
ph_manager_lenovo.run_ansible({'role_name' => 'lenovo.lxca-inventory'})
```