### PR TITLE
Moving location_led_state to Asset Detail

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/component_parser.rb
@@ -84,7 +84,11 @@ module ManageIQ::Providers::Lenovo
       def get_location_led_info(leds)
         return if leds.blank?
         identification_led = leds.to_a.find { |led| PROPERTIES_MAP[:led_identify_name].include?(led["name"]) }
-        return identification_led.try(:[], "name"), identification_led.try(:[], "state")
+
+        {
+          :location_led_ems_ref => identification_led.try(:[], "name"),
+          :location_led_state   => identification_led.try(:[], "state")
+        }
       end
     end
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_chassis_parser.rb
@@ -13,15 +13,13 @@ module ManageIQ::Providers::Lenovo
         chassis = XClarityClient::Chassi.new(chassis_hash)
         result = parse(chassis, parent::ParserDictionaryConstants::PHYSICAL_CHASSIS)
 
-        loc_led_name, loc_led_state = get_location_led_info(chassis.leds)
-
         result[:physical_rack]                       = rack if rack
         result[:vendor]                              = "lenovo"
         result[:type]                                = MIQ_TYPES["physical_chassis"]
         result[:health_state]                        = HEALTH_STATE_MAP[chassis.cmmHealthState.nil? ? chassis.cmmHealthState : chassis.cmmHealthState.downcase]
-        result[:asset_detail][:location_led_ems_ref] = loc_led_name
-        result[:location_led_state]                  = loc_led_state
         result[:computer_system][:hardware]          = get_hardwares(chassis)
+
+        result[:asset_detail].merge!(get_location_led_info(chassis.leds))
 
         result
       end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_server_parser.rb
@@ -14,8 +14,6 @@ module ManageIQ::Providers::Lenovo
         node = XClarityClient::Node.new(node_hash)
         result = parse(node, parent::ParserDictionaryConstants::PHYSICAL_SERVER)
 
-        loc_led_name, loc_led_state = get_location_led_info(node.leds)
-
         # Keep track of the rack where this server is in, if it is in any rack
         result[:physical_rack]                       = rack if rack
         result[:physical_chassis]                    = chassis if chassis
@@ -26,9 +24,9 @@ module ManageIQ::Providers::Lenovo
         result[:power_state]                         = POWER_STATE_MAP[node.powerStatus]
         result[:health_state]                        = HEALTH_STATE_MAP[node.cmmHealthState.nil? ? node.cmmHealthState : node.cmmHealthState.downcase]
         result[:host]                                = get_host_relationship(node.serialNumber)
-        result[:asset_detail][:location_led_ems_ref] = loc_led_name
-        result[:location_led_state]                  = loc_led_state
         result[:computer_system][:hardware]          = get_hardwares(node)
+
+        result[:asset_detail].merge!(get_location_led_info(node.leds))
 
         result
       end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -184,7 +184,6 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(physical_chassis[:health_state]).to eq("Valid")
       expected_type = "ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis"
       expect(physical_chassis[:type]).to eq(expected_type)
-      expect(physical_chassis[:location_led_state]).to eq("Off")
     end
 
     it 'will parse physical chassis asset detail data' do
@@ -202,6 +201,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(asset_detail[:rack_name]).to be_nil
       expect(asset_detail[:lowest_rack_unit]).to eq(0)
       expect(asset_detail[:location_led_ems_ref]).to eq("Location")
+      expect(asset_detail[:location_led_state]).to eq("Off")
     end
 
     it 'will parse physical chassis hardware data' do
@@ -294,6 +294,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       description
       lowest_rack_unit
       location_led_ems_ref
+      location_led_state
     ).each do |attr|
       it "will retrieve #{attr} of asset detail" do
         asset_detail = @result[:physical_servers][0][:asset_detail]


### PR DESCRIPTION
__This PR is able to__
- Move the LED state information to `AssetDetail` model;

__Depends on__
~https://github.com/ManageIQ/manageiq-schema/pull/262~ - Merged