### PR TITLE
Fix storage disk type to be controller_type

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -76,14 +76,14 @@ module ManageIQ::Providers::Lenovo
 
       def parse_driver(driver)
         {
-          :model         => driver['model'],
-          :vendor        => driver['vendorName'],
-          :status        => driver['status'],
-          :location      => driver['location'],
-          :serial_number => driver['serialNumber'],
-          :health_state  => driver['health'],
-          :type          => driver['type'],
-          :disk_size     => driver['size']
+          :model           => driver['model'],
+          :vendor          => driver['vendorName'],
+          :status          => driver['status'],
+          :location        => driver['location'],
+          :serial_number   => driver['serialNumber'],
+          :health_state    => driver['health'],
+          :controller_type => driver['type'],
+          :disk_size       => driver['size']
         }
       end
 

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -174,7 +174,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(physical_disk_one[:location]).to eq("0.22")
       expect(physical_disk_one[:serial_number]).to eq("6XN43QX50000B349D4LY")
       expect(physical_disk_one[:health_state]).to eq("OK")
-      expect(physical_disk_one[:type]).to eq("SAS")
+      expect(physical_disk_one[:controller_type]).to eq("SAS")
       expect(physical_disk_one[:disk_size]).to eq("300.0GB")
     end
 


### PR DESCRIPTION
This PR is able to:
- Rename the `type` column name to `controller_type` on PhysicalStorageParser

Depends on:
- [~ManageIQ/manageiq-schema#276 - Merged~](https://github.com/ManageIQ/manageiq-schema/pull/276)