### PR TITLE
Fix the firmware name

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/firmware_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/firmware_parser.rb
@@ -9,6 +9,24 @@ module ManageIQ::Providers::Lenovo
         :name         => :name
       }.freeze
 
+      FORMAT_BY_TYPE_ROLE = %w(UEFI IMM2 XCC).freeze
+      FORMAT_BY_NAME = %w(DRVWN LXPM DRVLN).freeze
+      FORMAT_BY_DISTINCT_NAME = {
+        'DSA' => 'Diagnostic',
+      }.freeze
+
+      RULES = {
+        :format_by_name          => FORMAT_BY_NAME,
+        :format_by_type_role     => FORMAT_BY_TYPE_ROLE,
+        :format_by_distinct_name => FORMAT_BY_DISTINCT_NAME
+      }.freeze
+
+      PARSER_FIRMWARE_TYPE = {
+        'UEFI-Backup' => 'UEFI',
+        'IMM2-Backup' => 'IMM2',
+        'XCC-Backup'  => 'XCC'
+      }.freeze
+
       #
       # Parses a firmware into a Hash
       #
@@ -16,12 +34,40 @@ module ManageIQ::Providers::Lenovo
       #
       # @return [Hash] the firmware as required by the application
       #
-      def parse_firmware(firmware)
+      def parse_firmware(firmware, component = nil)
+        @component = component
         parse(firmware, FIRMWARE)
       end
 
       def name(firmware)
-        "#{firmware['role']} #{firmware['name']}-#{firmware['status']}".strip
+        firmware_name = @component&.[]('name') == 'N/A' ? firmware['name'] : @component&.[]('name')
+        return firmware_name if firmware_name.present?
+        send(method_name(firmware), firmware)
+      end
+
+      private
+
+      def method_name(firmware)
+        type = PARSER_FIRMWARE_TYPE[firmware['type']] || firmware['type']
+        method, _value = RULES.detect { |_method, value| value.include?(type) }
+        method.nil? ? "default_name" : method
+      end
+
+      def format_by_name(firmware)
+        firmware['name'] || default_name(firmware)
+      end
+
+      def format_by_type_role(firmware)
+        type = PARSER_FIRMWARE_TYPE[firmware['type']] || firmware['type']
+        firmware['role'].present? ? "#{type} (#{firmware['role']})" : default_name(firmware)
+      end
+
+      def format_by_distinct_name(firmware)
+        FORMAT_BY_DISTINCT_NAME[firmware['type']]
+      end
+
+      def default_name(firmware)
+        "#{firmware['role']} #{firmware['name']} - #{firmware['status'].titleize}".strip
       end
     end
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/guest_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/guest_device_parser.rb
@@ -42,7 +42,7 @@ module ManageIQ::Providers::Lenovo
         firmware = device['firmware']
         unless firmware.nil?
           device_fw = firmware.map do |fw|
-            parent::FirmwareParser.parse_firmware(fw)
+            parent::FirmwareParser.parse_firmware(fw, device)
           end
         end
 

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -128,24 +128,10 @@ module ManageIQ::Providers::Lenovo
           :hardware_version             => canister['hardwareVersion'],
           :computer_system              => {
             :hardware => {
-              :firmwares     => canister_firmwares(canister),
               :guest_devices => canister_guest_devices(canister)
             }
           }
         }
-      end
-
-      def canister_firmwares(canister)
-        firmwares = []
-        firmware = canister['firmware']
-
-        if firmware.present? && firmware['storageControllerCpuType'] != 'Not Present'
-          result = parent::FirmwareParser.parse_firmware(firmware)
-          result[:resource_type] = 'Hardware'
-          firmwares << result
-        end
-
-        firmwares
       end
 
       def canister_guest_devices(canister)

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -69,7 +69,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       switch   = @result[:physical_switches].first
       firmware = switch[:hardware][:firmwares].first
 
-      expect(firmware[:name]).to eq("Uboot-N/A")
+      expect(firmware[:name]).to eq("Uboot - N/A")
       expect(firmware[:version]).to eq("10.4.2.0")
     end
 
@@ -287,7 +287,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
 
       expect(guest_device[:device_name]).to eq("Broadcom 2-port 1GbE NIC Card for IBM")
       expect(guest_device[:device_type]).to eq("ethernet")
-      expect(guest_device[:firmwares][0][:name]).to eq("Primary 17.4.4.2a-Active")
+      expect(guest_device[:firmwares][0][:name]).to eq("Broadcom 2-port 1GbE NIC Card for IBM")
       expect(guest_device[:firmwares][0][:version]).to eq("17.4.4.2a")
       expect(guest_device[:manufacturer]).to eq("IBM")
       expect(guest_device[:field_replaceable_unit]).to eq("90Y9373")


### PR DESCRIPTION
This pr is able to:
Fix the firmware name in the `FirmwareParse` to add support run a firmware update action by playbook.
 * map the firmware name by rules
 * remove the firmware parse inside canisters. 