### PR TITLE
Calculate and store Physical Storage total space

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -43,6 +43,7 @@ module ManageIQ::Providers::Lenovo
 
         result[:physical_rack]    = rack if rack
         result[:physical_chassis] = chassis if chassis
+        result[:total_space]      = get_total_space(result)
 
         result
       end
@@ -85,6 +86,20 @@ module ManageIQ::Providers::Lenovo
           :controller_type => driver['type'],
           :disk_size       => driver['size']
         }
+      end
+
+      #
+      # @param storage [Hash] Hash with parsed storage data (including physical_disks in it)
+      #
+      def get_total_space(storage)
+        total_space = 0
+        disks = storage[:physical_disks]
+
+        disks&.each do |disk|
+          total_space += disk[:disk_size].to_i
+        end
+
+        total_space.zero? ? nil : total_space.gigabytes # returns the size in bytes
       end
 
       def canisters(storage)

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -112,6 +112,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(physical_storage[:canister_slots]).to eq(2)
       expect(physical_storage[:physical_disks].count).to eq(4)
       expect(physical_storage[:canisters].count).to eq(2)
+      expect(physical_storage[:total_space]).to eq(128_849_018_880_0)
     end
 
     it 'will parse physical storage asset detail data' do


### PR DESCRIPTION
This PR is able to get disk information from `PhysicalDisks` inside a physical storage to calculate the total disk size and store it on `total_space`.

Depends on:
- [~ManageIQ/manageiq-schema#283~](https://github.com/ManageIQ/manageiq-schema/pull/283)