### PR TITLE
Parse disks into canisters

### DIFF
--- a/app/models/manageiq/providers/lenovo/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/persister/definitions/physical_infra_collections.rb
@@ -224,8 +224,8 @@ module ManageIQ::Providers::Lenovo::Inventory::Persister::Definitions::PhysicalI
   def add_physical_disks
     add_collection(physical_infra, :physical_disks) do |builder|
       builder.add_properties(
-        :manager_ref             => %i(physical_storage location),
-        :manager_ref_allowed_nil => %i(location)
+        :manager_ref             => %i(physical_storage ems_ref),
+        :manager_ref_allowed_nil => %i(ems_ref)
       )
     end
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_disk_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_disk_parser.rb
@@ -1,0 +1,36 @@
+module ManageIQ::Providers::Lenovo
+  class PhysicalInfraManager::Parser::PhysicalDiskParser < PhysicalInfraManager::Parser::ComponentParser
+    class << self
+      # Mapping between fields inside a [XClarityClient::Storage] to a [Hash] with symbols of PhysicalDisk fields
+      PHYSICAL_DISK = {
+        :model           => 'model',
+        :vendor          => 'vendorName',
+        :status          => 'status',
+        :location        => 'location',
+        :serial_number   => 'serialNumber',
+        :health_state    => 'health',
+        :controller_type => 'type',
+        :disk_size       => :disk_size
+      }.freeze
+
+      #
+      # Parse disk into a hash
+      #
+      # @param [Hash] disk_hash - hash containing physical disk raw data
+      # @param [Hash] canister - parsed canister data
+      #
+      # @return [Hash] containing the physical disk information
+      #
+      def parse_physical_disk(disk, canister: nil)
+        result = parse(disk, PHYSICAL_DISK)
+        result[:canister] = canister if canister
+
+        result
+      end
+
+      def disk_size(disk)
+        disk['size']
+      end
+    end
+  end
+end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -1,6 +1,9 @@
 module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Parser::PhysicalStorageParser < PhysicalInfraManager::Parser::ComponentParser
     class << self
+      # Unit used to store total disk size information of a physical storage
+      DISK_UNIT = 'GB'
+
       # Mapping between fields inside a [XClarityClient::Storage] to a [Hash] with symbols of PhysicalStorage fields
       PHYSICAL_STORAGE = {
         :name                 => 'name',

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -1,9 +1,6 @@
 module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Parser::PhysicalStorageParser < PhysicalInfraManager::Parser::ComponentParser
     class << self
-      # Unit used to store total disk size information of a physical storage
-      DISK_UNIT = 'GB'
-
       # Mapping between fields inside a [XClarityClient::Storage] to a [Hash] with symbols of PhysicalStorage fields
       PHYSICAL_STORAGE = {
         :name                 => 'name',

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/physical_infra_spec_common.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/physical_infra_spec_common.rb
@@ -1,0 +1,35 @@
+module PhysicalInfraSpecCommon
+  extend ActiveSupport::Concern
+
+  MODELS = %i(
+    ext_management_system physical_rack physical_chassis physical_server
+    physical_switch physical_storage physical_disk customization_script
+  ).freeze
+
+  def serialize_inventory
+    skip_atributes = %w(created_at updated_at last_refresh_date updated_on)
+    inventory = {}
+    PhysicalInfraSpecCommon::MODELS.each do |rel|
+      inventory[rel] = rel.to_s.classify.constantize.all.collect do |e|
+        e.attributes.except(*skip_atributes)
+      end
+    end
+
+    inventory
+  end
+
+  def assert_models_not_changed(inventory_before, inventory_after)
+    aggregate_failures do
+      PhysicalInfraSpecCommon::MODELS.each do |model|
+        expect(inventory_after[model].count).to eq(inventory_before[model].count), "#{model} count"\
+               " doesn't fit \nexpected: #{inventory_before[model].count}\ngot#{inventory_after[model].count}"
+
+        inventory_after[model].each do |item_after|
+          item_before = inventory_before[model].detect { |i| i["id"] == item_after["id"] }
+          expect(item_after).to eq(item_before), \
+                                "class: #{model.to_s.classify}\nexpected: #{item_before}\ngot: #{item_after}"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresh_parser_spec.rb
@@ -169,6 +169,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(physical_disk_three).to_not be_nil
       expect(physical_disk_four).to_not be_nil
 
+      expect(physical_disk_one[:ems_ref]).to eq("208000C0FF2683AF_0")
       expect(physical_disk_one[:model]).to eq("ST9300653SS")
       expect(physical_disk_one[:vendor]).to eq("IBM-ESXS")
       expect(physical_disk_one[:status]).to eq("Up")
@@ -177,6 +178,22 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshParser do
       expect(physical_disk_one[:health_state]).to eq("OK")
       expect(physical_disk_one[:controller_type]).to eq("SAS")
       expect(physical_disk_one[:disk_size]).to eq("300.0GB")
+    end
+
+    it 'will parse physical disks inside a canister' do
+      physical_storage = @result[:physical_storages].first
+      canister_one = physical_storage[:canisters].first
+      canister_disk_one = canister_one[:physical_disks].first
+
+      expect(canister_disk_one[:ems_ref]).to eq("457784225BA511E18290B4F27BD253A5_0")
+      expect(canister_disk_one[:model]).to eq("Canister_Driver_Model")
+      expect(canister_disk_one[:vendor]).to eq("Canister_Driver_Vendor")
+      expect(canister_disk_one[:status]).to eq("Up")
+      expect(canister_disk_one[:location]).to eq("0.50")
+      expect(canister_disk_one[:serial_number]).to eq("20183QX50000B3492018")
+      expect(canister_disk_one[:health_state]).to eq("OK")
+      expect(canister_disk_one[:controller_type]).to eq("SAS")
+      expect(canister_disk_one[:disk_size]).to eq("300.0GB")
     end
 
     it 'will have a reference to the physical rack where the storage is inside' do

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/full_refresh.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/full_refresh.yml
@@ -1942,11 +1942,57 @@ http_interactions:
                                     "healthRecommendation":""
                                   }
                               ],
-                              "drives":[
-
-                              ],
+                              "drives":[{
+                                "model": "ST9300653SS",
+                                "vendorName": "IBM-ESXS",
+                                "status": "Up",
+                                "location": "0.22",
+                                "serialNumber": "6XN43QX50000B349D4LY",
+                                "healthReason": "",
+                                "health": "OK",
+                                "type": "SAS",
+                                "healthRecommendation": "",
+                                "size": "300.0GB"
+                              },
+                              {
+                                "model": "ST9300605SS",
+                                "vendorName": "IBM-ESXS",
+                                "status": "Up",
+                                "location": "0.17",
+                                "serialNumber": "6XP5L6ZE0000B344HRZG",
+                                "healthReason": "",
+                                "health": "OK",
+                                "type": "SAS",
+                                "healthRecommendation": "",
+                                "size": "300.0GB"
+                              },
+                              {
+                                "model": "ST9300653SS",
+                                "vendorName": "IBM-ESXS",
+                                "status": "Up",
+                                "location": "0.23",
+                                "serialNumber": "6XN43QR90000B350B5G2",
+                                "healthReason": "A disk that was previously a member of a disk group has been detected.",
+                                "health": "Degraded",
+                                "type": "SAS",
+                                "healthRecommendation": "- If the associated disk group is offline or quarantined, contact technical support. Otherwise, clear the disks metadata to reuse the disk.",
+                                "size": "300.0GB"
+                              },
+                              {
+                                "model": "ST9300605SS",
+                                "vendorName": "IBM-ESXS",
+                                "status": "Up",
+                                "location": "0.16",
+                                "serialNumber": "6XP5L7QP0000B344HS0E",
+                                "healthReason": "",
+                                "health": "OK",
+                                "type": "SAS",
+                                "healthRecommendation": "",
+                                "size": "300.0GB"
+                              }],
                               "canisters":[
                                   {
+                                    "uuid": "457784225BA511E18290B4F27BD253A5",
                                     "position":"Top",
                                     "systemCacheMemory":6144,
                                     "diskBusType":"SAS",

--- a/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/mock_storages.yml
+++ b/spec/vcr_cassettes/manageiq/providers/lenovo/physical_infra_manager/mock_storages.yml
@@ -242,6 +242,7 @@ http_interactions:
                               ],
                               "canisters":[
                                   {
+                                    "uuid":"457784225BA511E18290B4F27BD253A5",
                                     "position":"Top",
                                     "systemCacheMemory":6144,
                                     "diskBusType":"SAS",
@@ -260,6 +261,19 @@ http_interactions:
                                         "healthRecommendation":"",
                                         "ipAddress":"10.243.5.61"
                                     },
+                                    "drives":[{
+                                        "model": "Canister_Driver_Model",
+                                        "vendorName": "Canister_Driver_Vendor",
+                                        "status": "Up",
+                                        "location": "0.50",
+                                        "serialNumber": "20183QX50000B3492018",
+                                        "healthReason": "",
+                                        "health": "OK",
+                                        "type": "SAS",
+                                        "healthRecommendation": "",
+                                        "size": "300.0GB"
+                                      }
+                                    ],
                                     "diskChannels":2,
                                     "revision":"0",
                                     "cmmDisplayName":"controller_a",


### PR DESCRIPTION
This PR is able to:
- Parse PhysicalDisks inside a Canister
- Generate a `ems_ref` for a PhysicalDisk, since it doesn't have any field that resembles to an unique ID

Depends on:
- [ManageIQ/manageiq-schema#285](https://github.com/ManageIQ/manageiq-schema/pull/285)
- [ManageIQ/manageiq#18053](https://github.com/ManageIQ/manageiq/pull/18053)