### PR TITLE
Fix canister UUID selection

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -1,6 +1,9 @@
 module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Parser::PhysicalStorageParser < PhysicalInfraManager::Parser::ComponentParser
     class << self
+      # Unit used to store total disk size information of a physical storage
+      DISK_UNIT = 'GB'
+
       # Mapping between fields inside a [XClarityClient::Storage] to a [Hash] with symbols of PhysicalStorage fields
       PHYSICAL_STORAGE = {
         :name                 => 'name',

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/physical_storage_parser.rb
@@ -1,9 +1,6 @@
 module ManageIQ::Providers::Lenovo
   class PhysicalInfraManager::Parser::PhysicalStorageParser < PhysicalInfraManager::Parser::ComponentParser
     class << self
-      # Unit used to store total disk size information of a physical storage
-      DISK_UNIT = 'GB'
-
       # Mapping between fields inside a [XClarityClient::Storage] to a [Hash] with symbols of PhysicalStorage fields
       PHYSICAL_STORAGE = {
         :name                 => 'name',

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager/refresher_spec.rb
@@ -107,6 +107,7 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
 
   def assert_specific_storage
     storage = PhysicalStorage.find_by(:ems_ref => "208000C0FF2683AF")
+    storage_canister_one = Canister.find_by(:ems_ref => "208000C0FF2683AF_0")
 
     expect(storage.name).to eq("S3200-1")
     expect(storage.uid_ems).to eq("208000C0FF2683AF")
@@ -119,12 +120,19 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager::Refresher do
     expect(storage.drive_bays).to eq(12)
     expect(storage.enclosures).to eq(1)
     expect(storage.canister_slots).to eq(2)
+
+    expect(storage_canister_one.position).to eq("Top")
+    expect(storage_canister_one.status).to eq("Operational")
+    expect(storage_canister_one.health_state).to eq("Normal")
+    expect(storage_canister_one.disks).to eq(0)
+    expect(storage_canister_one.disk_channel).to eq(2)
   end
 
   def assert_table_counts
     expect(PhysicalRack.count).to eq(3)
     expect(PhysicalServer.count).to eq(2)
     expect(PhysicalStorage.count).to eq(2)
+    expect(Canister.count).to eq(4)
     expect(GuestDevice.count).to eq(8)
     expect(PhysicalNetworkPort.count).to eq(50)
   end


### PR DESCRIPTION
This PR is able to:
- Generate a UUID from Canister parent when hash to be parsed doesn't comes with a UUID field
- Fix field `diskChannel` parsed from Canister hash to `diskChannels`

Depends on:
- [ManageIQ/manageiq#18062](https://github.com/ManageIQ/manageiq/pull/18062)