### PR TITLE
fix the firmware parse of guest device

### DIFF
--- a/app/models/manageiq/providers/lenovo/inventory/parser/component_parser/guest_device.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/parser/component_parser/guest_device.rb
@@ -36,7 +36,7 @@ module ManageIQ::Providers::Lenovo
     end
 
     def build_firmwares(device, inventory_object)
-      firmware = device['firmware']
+      firmwares = device['firmware']
 
       parent_collection_name = inventory_object&.inventory_collection&.association
       inventory_collection_name = case parent_collection_name
@@ -44,8 +44,11 @@ module ManageIQ::Providers::Lenovo
                                   when :physical_server_storage_adapters then :physical_server_storage_adapter_firmwares
                                   else raise "Unknown parent inventory collection (#{parent_collection_name})"
                                   end
-      firmware&.each do |fw|
-        components(:firmwares).build(fw,
+      if firmwares.present?
+        versions = firmwares.collect { |fw| fw['version'] }.join(', ')
+        firmware = firmwares.first
+        firmware['version'] = versions
+        components(:firmwares).build(firmware,
                                      inventory_collection_name,
                                      {:belongs_to => :guest_device,
                                       :object     => inventory_object},

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/guest_device_parser.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/parser/guest_device_parser.rb
@@ -39,11 +39,13 @@ module ManageIQ::Providers::Lenovo
       def firmwares(device)
         device_fw = []
 
-        firmware = device['firmware']
-        unless firmware.nil?
-          device_fw = firmware.map do |fw|
-            parent::FirmwareParser.parse_firmware(fw, device)
-          end
+        firmwares = device['firmware']
+
+        if firmwares.present?
+          versions = firmwares.collect { |fw| fw['version'] }.join(', ')
+          firmware = firmwares.first
+          firmware['version'] = versions
+          device_fw.push(parent::FirmwareParser.parse_firmware(firmware, device))
         end
 
         device_fw


### PR DESCRIPTION
This PR is able to:
* Fix the issue reported in the [PR 238](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/238l).

description : The `Firmware parse` of guest devices is parsing the versions of a firmware as a different firmware. The 1st refresh all the firmware are persisted, but in a 2nd refresh the firmware with the same name are [deleted](https://github.com/ManageIQ/manageiq/blob/master/app/models/ems_refresh/save_inventory.rb#L315) and only the last entry with that name remains.