### PR TITLE
Adding ansible-runner config requirement

### DIFF
--- a/content/ansible_runner/requirements.yml
+++ b/content/ansible_runner/requirements.yml
@@ -1,2 +1,3 @@
 # from galaxy
 - src: lenovo.lxca-inventory
+- src: lenovo.lxca-config


### PR DESCRIPTION
This PR adds lxca-config to `requirements.yml` to enable server firmware update ([#18074](https://github.com/ManageIQ/manageiq/pull/18074)).