### PR TITLE
3° - Add provision button

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,31 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [
+            "> 1%",
+            "last 2 versions",
+            "Firefox ESR",
+            "IE 10",
+            "IE 11"
+          ]
+        }
+      }
+    ],
+    "react",
+    "es2015",
+  ],
+  "plugins": [
+    "transform-class-properties",
+    "transform-export-extensions",
+    "transform-object-rest-spread",
+    "transform-object-assign"
+  ],
+  "env": {
+    "test": {
+      "plugins": ["transform-es2015-modules-commonjs"]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 
 /spec/manageiq
 
-/.idea/
+node_modules/
+yarn.lock

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "content_tmp/ansible/test"]
+	path = content_tmp/ansible/test
+	url = https://github.com/lenovo/ansible.lenovo-lxca.git

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# using yarn
+package-lock = false

--- a/.postcssrc.yml
+++ b/.postcssrc.yml
@@ -1,0 +1,4 @@
+plugins:
+  postcss-smart-import: {}
+  precss: {}
+  autoprefixer: {}

--- a/app/helpers/manageiq/providers/lenovo/toolbar_overrides/ems_physical_infra_center.rb
+++ b/app/helpers/manageiq/providers/lenovo/toolbar_overrides/ems_physical_infra_center.rb
@@ -1,0 +1,51 @@
+module ManageIQ
+  module Providers
+    module Lenovo
+      module ToolbarOverrides
+        class EmsPhysicalInfraCenter < ::ApplicationHelper::Toolbar::Override
+          button_group(
+            'provider_provision',
+            [
+              select(
+                :provider_provision_choice,
+                'pficon pficon-process-automation pficon-lg',
+                N_('Provision'),
+                :enabled => true,
+                :items   => [
+                  button(
+                    :provision_apply_pattern,
+                    'fa fa-clipboard fa-lg',
+                    t = N_('Apply Config Pattern'),
+                    t,
+                    :data  => {
+                      'function'      => 'sendDataWithRx',
+                      'function-data' => {:controller     => 'provider_dialogs', # this one is required
+                                          :button         => :provision_apply_pattern,
+                                          :modal_title    => N_('Apply Config Pattern'),
+                                          :component_name => 'ApplyConfigPatternFormProvider'}.to_json
+                    },
+                    :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                  ),
+                  button(
+                    :provision_firmware_update,
+                    'fa fa-clipboard fa-lg',
+                    t = N_('Firmware Update'),
+                    t,
+                    :data  => {
+                      'function'      => 'sendDataWithRx',
+                      'function-data' => {:controller     => 'provider_dialogs', # this one is required
+                                          :button         => :provision_firmware_update,
+                                          :modal_title    => N_('Firmware Update'),
+                                          :component_name => 'FirmwareUpdateFormProvider'}.to_json
+                    },
+                    :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                  )
+                ]
+              )
+            ]
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/components/apply-config-pattern-form-provider.jsx
+++ b/app/javascript/components/apply-config-pattern-form-provider.jsx
@@ -1,0 +1,130 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {connect} from "react-redux";
+import URI from "urijs";
+import LenovoForm from "./form/lenovo_form";
+import PhysicalServerField from "./form/fields/physical_server_field";
+import ConfigPatternField from "./form/fields/config_pattern_field";
+
+const API = window.API;
+
+const applyPattern = (values) =>{
+  const resources = values["physicalServerField"].map(href => (
+    {
+      href: href,
+      pattern_id: values["configPatternField"]
+    }));
+  API.post("/api/physical_servers/", {
+    action: "apply_config_pattern_ansible",
+    resources: resources,
+   });
+};
+
+const getPhysicalServerData = (providerID, patternID) => {
+  const uri = new URI("/api/physical_servers/?")
+    .query({
+      "attributes": "name,href",
+      "expand": "resources",
+      "filter[]": `ems_id=${providerID}`
+    });
+  return API.get(uri).then((data) => data.resources.map(resource => ({
+    value: resource.href,
+    label: resource.name,
+  })));
+};
+
+const getConfigPatternData = (providerID) => {
+  const uri = new URI("/api/customization_scripts/?")
+    .query({
+      "attributes": "manager_ref,name",
+      "expand": "resources",
+      "filter[]": "type='ManageIQ::Providers::Lenovo::PhysicalInfraManager::ConfigPattern'",
+    })
+    .addQuery({
+      "filter[]": `manager_id=${providerID}`
+    });
+  return API.get(decodeURI(uri.toString())).then((data)=> data.resources.map(resource => ({
+    value: resource.manager_ref,
+    label: resource.name,
+  })));
+};
+
+class ApplyConfigPatternFormProvider extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      configPatternList: [],
+      physicalServerList: [],
+      physicalServerFieldDisabled: true,
+      values: {},
+      fieldsDataLoading: {
+        configPatternLoading: true,
+      },
+    };
+  }
+
+  updateFieldsDataLoading = (name, status) => {
+    const fieldsDataLoading= this.state.fieldsDataLoading;
+    fieldsDataLoading[name]=status;
+    return fieldsDataLoading;
+  };
+
+  componentDidMount() {
+    this.props.dispatch({
+      type: "FormButtons.init",
+      payload: {
+        newRecord: true,
+        pristine: true,
+        addClicked: () => {
+          applyPattern(this.state.values);
+        },
+      },
+    });
+    this.props.dispatch({
+      type: "FormButtons.customLabel",
+      payload: "Apply",
+    });
+    getConfigPatternData(ManageIQ.record.recordId)
+      .then((configPatternList) => this.setState(
+        {
+          configPatternList: configPatternList,
+          fieldsDataLoading: this.updateFieldsDataLoading("configPatternLoading", false),
+        }
+      ));
+  };
+
+  updateValues = (values) => {
+    this.setState({values});
+  };
+
+  updateServers = (resourceID) => {
+    getPhysicalServerData(ManageIQ.record.recordId, resourceID)
+      .then(physicalServerList => this.setState({ physicalServerList: physicalServerList, physicalServerFieldDisabled: false }));
+  };
+
+  render() {
+    return (
+      <LenovoForm
+        fieldsDataLoading={this.state.fieldsDataLoading}
+        handleValues={this.updateValues}
+        dispatch={this.props.dispatch}>
+        <ConfigPatternField
+          name="configPatternField"
+          validate={true}
+          updateChildren={this.updateServers}
+          configPatternData={this.state.configPatternList}/>
+        <PhysicalServerField
+          validate={true}
+          name="physicalServerField"
+          physicalServerData={this.state.physicalServerList}
+          disabled={this.state.physicalServerFieldDisabled}/>
+      </LenovoForm>
+    )
+  }
+}
+
+ApplyConfigPatternFormProvider.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+};
+
+export default connect()(ApplyConfigPatternFormProvider);

--- a/app/javascript/components/firmware-update-form-provider.jsx
+++ b/app/javascript/components/firmware-update-form-provider.jsx
@@ -1,0 +1,104 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {connect} from "react-redux";
+import URI from "urijs";
+import LenovoForm from "./form/lenovo_form";
+import FirmwareField from "./form/fields/firmware_field";
+
+
+const API = window.API;
+
+const applyFirmwareUpdate = (values) =>{
+
+  const firmwareField = values['firmwareField'];
+
+  const resources = Object.keys(firmwareField).map(id => ({
+    href: `${window.location.origin}/api/physical_servers/${id}`,
+    firmware_names: firmwareField[id]
+  }));
+
+  API.post("/api/physical_servers/", {
+    action: "apply_firmware_update_ansible",
+    resources: resources,
+   });
+};
+
+const getPhysicalServerData = (providerID) => {
+  const uri = new URI("/api/physical_servers/?")
+    .query({
+      "attributes": "id,name,hardware.firmwares",
+      "expand": "resources",
+      "filter[]": `ems_id=${providerID}`
+    });
+  return API.get(uri).then((data) => data.resources.map(resource => ({
+    id: resource.id,
+    name: resource.name,
+    firmwares: resource.hardware.firmwares,
+  })));
+};
+
+class FirmwareUpdateFormProvider extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      physicalServerList: [],
+      values: {},
+      fieldsDataLoading: {
+        physicalServerLoading: true,
+      },
+    };
+  }
+
+  updateFieldsDataLoading = (name, status) => {
+    const fieldsDataLoading= this.state.fieldsDataLoading;
+    fieldsDataLoading[name]=status;
+    return fieldsDataLoading;
+  };
+
+  updateValues = (values) => {
+    this.setState({values});
+  };
+
+  componentDidMount() {
+    this.props.dispatch({
+      type: "FormButtons.init",
+      payload: {
+        newRecord: true,
+        pristine: true,
+        addClicked: () => {
+          applyFirmwareUpdate(this.state.values);
+        },
+      },
+    });
+    this.props.dispatch({
+      type: "FormButtons.customLabel",
+      payload: "Apply",
+    });
+    getPhysicalServerData(ManageIQ.record.recordId).then((physicalServerList) => {
+      this.setState(
+        {physicalServerList,
+         fieldsDataLoading: this.updateFieldsDataLoading("physicalServerLoading", false),
+        });
+    });
+  }
+
+  render() {
+    return (
+      <LenovoForm
+        fieldsDataLoading={this.state.fieldsDataLoading}
+        handleValues={this.updateValues}
+        dispatch={this.props.dispatch}>
+        <FirmwareField
+          name="firmwareField"
+          validate={true}
+          physicalServerData={this.state.physicalServerList}/>
+      </LenovoForm>
+    )
+  }
+}
+
+FirmwareUpdateFormProvider.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+};
+
+export default connect()(FirmwareUpdateFormProvider);

--- a/app/javascript/components/form/fields/config_pattern_field.js
+++ b/app/javascript/components/form/fields/config_pattern_field.js
@@ -1,0 +1,79 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {ControlLabel, FormControl, FormGroup} from "react-bootstrap";
+
+class ConfigPatternField extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      touched: false,
+      value: "",
+      valid: false
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  getValidationState() {
+    let {valid, touched} = this.state;
+    if (valid) {
+      return "success";
+    }else if (touched) {
+      return "warning";
+    }
+   }
+
+  handleChange(e) {
+    let value = e.target.value;
+    if (!! this.props.updateChildren) {
+      this.props.updateChildren(value);
+    }
+
+    this.setState({
+      value: value,
+      valid: e.target.validity.valid
+    });
+  }
+
+  onClick = () => {
+    this.setState({touched: true})
+  };
+
+  componentDidMount() {
+    $(".selectpicker").selectpicker();
+  }
+
+  render() {
+    const patternComponentOptions = this.props.configPatternData.map((pattern) => {
+      return <option key={pattern.value} value={pattern.value}>{pattern.label}</option>
+    });
+
+    return (
+      <FormGroup
+        controlId="selectPattern"
+        validationState={this.getValidationState()}>
+          <ControlLabel>Config Pattern</ControlLabel>
+          <div onClick={this.onClick}>
+            <FormControl
+              componentClass="select"
+              className="selectpicker"
+              name={this.props.name}
+              value={this.state.value}
+              title="Choose a pattern"
+              onChange={this.handleChange}>
+              { patternComponentOptions }
+            </FormControl>
+          </div>
+      </FormGroup>
+    );
+  }
+}
+
+ConfigPatternField.propTypes = {
+  configPatternData: PropTypes.array.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export default ConfigPatternField;

--- a/app/javascript/components/form/fields/firmware_check_list_field.js
+++ b/app/javascript/components/form/fields/firmware_check_list_field.js
@@ -1,0 +1,48 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {Checkbox, ControlLabel, FormGroup} from "react-bootstrap";
+
+class FirmwareCheckListField extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {};
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(event) {
+    const target = event.target;
+    this.props.updateNavItem(target.value, target.labels[0].textContent, target.checked)
+  }
+
+  render() {
+    const firmwareCheckList = this.props.firmwareData.map((firmware) => {
+      return(
+        <Checkbox
+          key={firmware.name}
+          value={this.props.serverID}
+          onChange={this.handleChange}
+          name={this.props.parentName}>
+          {firmware.name}
+        </Checkbox>
+      )
+    });
+
+    return (
+      <FormGroup>
+        <ControlLabel>Firmwares</ControlLabel>
+        {firmwareCheckList}
+      </FormGroup>
+    );
+  }
+}
+
+FirmwareCheckListField.propTypes = {
+  firmwareData: PropTypes.array.isRequired,
+  parentName: PropTypes.string.isRequired,
+  updateNavItem: PropTypes.func.isRequired,
+  serverID: PropTypes.string.isRequired,
+};
+
+export default FirmwareCheckListField;

--- a/app/javascript/components/form/fields/firmware_field.js
+++ b/app/javascript/components/form/fields/firmware_field.js
@@ -1,0 +1,104 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Col,
+  ControlLabel,
+  Nav,
+  NavItem,
+  Row,
+  Tab,
+} from "react-bootstrap";
+import FirmwareCheckListField from "./firmware_check_list_field";
+import "../../style/firmware-update-field.css";
+
+class FirmwareField extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      navItemSelected: {},
+    };
+
+  }
+
+  updateNavItem = (id, firmwareName, checked) => {
+    let navItemSelected= this.state.navItemSelected;
+    let values = navItemSelected[id] || {};
+    values[firmwareName] = checked;
+    navItemSelected[id] = values;
+    this.setState({navItemSelected})
+  };
+
+  hideNavItem = (id) => {
+    let navItemSelected= this.state.navItemSelected;
+    if (navItemSelected.hasOwnProperty(id)) {
+      return !Object.values(navItemSelected[id]).includes(true);
+    }
+    return true;
+  };
+
+
+  render() {
+    const serverNavItens = this.props.physicalServerData.map((physicalServer) => {
+      const visibility = this.hideNavItem(physicalServer.id) ? "invisible" : "visible";
+      return(
+        <NavItem
+          eventKey={physicalServer.id}
+          key={physicalServer.id}>
+          <div className="media">
+            <div className="media-left">
+              <i className="pficon pficon-server serverIcon"/>
+              {physicalServer.name}
+            </div>
+            <div className="media-right">
+              <i className={"fa fa-check " + visibility}/>
+            </div>
+
+          </div>
+        </NavItem>
+      )
+    });
+    const firmwareTabPane = this.props.physicalServerData.map((physicalServer) => {
+      return(
+        <Tab.Pane
+          key={physicalServer.id}
+          eventKey={physicalServer.id}>
+          <h4>{physicalServer.name}</h4>
+          <FirmwareCheckListField
+            updateNavItem={this.updateNavItem}
+            firmwareData={physicalServer.firmwares}
+            parentName={this.props.name}
+            serverID={physicalServer.id}/>
+        </Tab.Pane>
+      )
+    });
+
+    return (
+      <div>
+        <Tab.Container id="left-tabs-firmware" defaultActiveKey={this.props.physicalServerData[0].id}>
+          <Row className="clearfix tabRow">
+            <Col sm={4} className="serversCol">
+              <ControlLabel>Physical Servers</ControlLabel>
+              <Nav bsStyle="pills" stacked>
+                {serverNavItens}
+              </Nav>
+            </Col>
+            <Col sm={8} className="firmwaresCol">
+              <Tab.Content animation>
+                {firmwareTabPane}
+              </Tab.Content>
+            </Col>
+          </Row>
+        </Tab.Container>
+      </div>
+    );
+  }
+}
+
+FirmwareField.propTypes = {
+  physicalServerData: PropTypes.array.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export default FirmwareField;

--- a/app/javascript/components/form/fields/physical_server_field.js
+++ b/app/javascript/components/form/fields/physical_server_field.js
@@ -1,0 +1,86 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {ControlLabel, FormControl, FormGroup} from "react-bootstrap";
+
+class PhysicalServerField extends React.Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      touched: false,
+      pristine: true,
+      valid: false
+    };
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  getValidationState() {
+    let {valid, pristine, touched} = this.state;
+    if (valid) {
+      return "success";
+    }else if (touched && pristine) {
+      return "warning";
+    }else if (!pristine && !valid){
+      return "error";
+    }
+  }
+
+  handleChange(e) {
+    const selectedOptions = $(e.target).val();
+    this.setState({
+      valid: !!selectedOptions,
+      pristine: false
+    });
+  }
+
+  onClick = () => {
+    this.setState({touched: true})
+  };
+
+  componentDidMount() {
+    $(".selectpicker").selectpicker();
+  }
+
+  componentDidUpdate() {
+    $(".selectpicker").selectpicker("refresh");
+  }
+
+  render() {
+    const serverComponentOptions = this.props.physicalServerData.map((server) => {
+      return <option data-icon="pficon pficon-server" key={server.value} value={server.value}>{server.label}</option>;
+    });
+
+    return (
+      <FormGroup
+        controlId="selectServer"
+        validationState={this.getValidationState()}>
+          <ControlLabel>Physical Server</ControlLabel>
+          <div onClick={this.onClick}>
+            <FormControl
+              disabled={this.props.disabled}
+              componentClass="select"
+              className="selectpicker"
+              name={this.props.name}
+              multiple
+              data-live-search="true"
+              data-selected-text-format="count"
+              data-actions-box="true"
+              title="Choose a Server"
+              onChange={this.handleChange}>
+              { serverComponentOptions }
+            </FormControl>
+          </div>
+      </FormGroup>
+    );
+  }
+}
+
+PhysicalServerField.propTypes = {
+  physicalServerData: PropTypes.array.isRequired,
+  name: PropTypes.string.isRequired,
+  disabled: PropTypes.bool.isRequired,
+};
+
+export default PhysicalServerField;

--- a/app/javascript/components/form/lenovo_form.js
+++ b/app/javascript/components/form/lenovo_form.js
@@ -1,0 +1,98 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {Spinner} from "patternfly-react";
+import connect from "react-redux/es/connect/connect";
+
+class LenovoForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const fields = [].concat.apply([], [this.props.children]);
+    const fieldsStatus = {};
+    for (let i = 0; i < fields.length; i++) {
+      let field = fields[i];
+      fieldsStatus[field.props.name]=!field.props.validate || false ;
+    }
+
+    this.state = {
+      fieldsStatus: fieldsStatus,
+      fieldsValues: {},
+    };
+
+    this.updateModalState = this.updateModalState.bind(this);
+    this.handleFormStateUpdate = this.handleFormStateUpdate.bind(this);
+  }
+
+  handleFormStateUpdate(formState) {
+    this.props.dispatch({
+      type: "FormButtons.saveable",
+      payload: formState.valid,
+    });
+    this.props.dispatch({
+      type: "FormButtons.pristine",
+      payload: formState.pristine,
+    });
+    this.props.handleValues(formState.values);
+  }
+
+  checkboxParser = (checked, targetLabel, targetValue, fieldName, fieldsValues) => {
+    let values = fieldsValues[fieldName] || {};
+    let fieldValue = values[targetValue] || [];
+    if (checked) {
+      fieldValue.push(targetLabel);
+    }else {
+      fieldValue.splice(targetLabel, 1)
+    }
+
+    if (fieldValue.length === 0) {
+      delete values[targetValue];
+    } else {
+      values[targetValue] = fieldValue;
+    }
+    return values;
+  };
+
+  updateModalState(event){
+    let { fieldsStatus, fieldsValues } = this.state;
+    let target = event.target;
+    let value = $(target).val();
+    let fieldName = target.name;
+
+    if (target.type === "checkbox") {
+      value = this.checkboxParser(target.checked, target.labels[0].textContent, value, fieldName, fieldsValues)
+    }
+
+    fieldsStatus[fieldName] = !!Object.values(value).length;
+
+    let formStatus = !Object.values(fieldsStatus).includes(false);
+
+    if (fieldsStatus[fieldName]) fieldsValues[fieldName]=value;
+    this.handleFormStateUpdate({valid: formStatus, pristine: false, values: fieldsValues});
+
+    this.setState({fieldsStatus: fieldsStatus, values: fieldsValues});
+  }
+
+  render() {
+    if (Object.values(this.props.fieldsDataLoading).includes(true)) {
+      return <Spinner loading size="lg" />;
+    }
+
+    return (
+      <form onChange={this.updateModalState}>
+        { this.props.children }
+      </form>
+    );
+  }
+}
+
+LenovoForm.propTypes = {
+  fieldsDataLoading: PropTypes.object.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  handleValues: PropTypes.func.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.object
+  ]).isRequired,
+};
+
+export default connect()(LenovoForm);

--- a/app/javascript/components/style/firmware-update-field.css
+++ b/app/javascript/components/style/firmware-update-field.css
@@ -1,0 +1,27 @@
+.tabRow {
+  padding: 0px;
+  margin-left: 0px;
+  margin-right: 0px;
+}
+
+.serversCol {
+  overflow: auto;
+  padding:0;
+  box-sizing: border-box;
+  box-shadow: 5px 0 5px -5px #333;
+  min-height: 250px;
+}
+
+.serverIcon{
+  margin-right: 5px;
+}
+
+.firmwaresCol {
+  overflow: auto;
+  margin-right: 0;
+  height: 250px;
+}
+
+.modal-footer {
+  margin-top: 0px;
+}

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -1,0 +1,5 @@
+import ApplyConfigPatternFormProvider from "../components/apply-config-pattern-form-provider";
+import FirmwareUpdateFormProvider from "../components/firmware-update-form-provider";
+
+ManageIQ.component.addReact("ApplyConfigPatternFormProvider", ApplyConfigPatternFormProvider);
+ManageIQ.component.addReact("FirmwareUpdateFormProvider", FirmwareUpdateFormProvider);

--- a/app/models/manageiq/providers/lenovo/inventory/parser/component_parser/config_pattern.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/parser/component_parser/config_pattern.rb
@@ -6,7 +6,8 @@ module ManageIQ::Providers::Lenovo
       :name         => 'name',
       :description  => 'description',
       :user_defined => 'userDefined',
-      :in_use       => 'inUse'
+      :in_use       => 'inUse',
+      :type         => :type
     }.freeze
 
     def build(config_pattern)
@@ -25,6 +26,10 @@ module ManageIQ::Providers::Lenovo
     #
     def parse_config_pattern(config_pattern)
       parse(config_pattern, CONFIG_PATTERNS)
+    end
+
+    def type(_config_pattern)
+      'ManageIQ::Providers::Lenovo::PhysicalInfraManager::ConfigPattern'
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "manageiq-providers-lenovo",
+  "version": "1.0.0",
+  "description": "ManageIQ Cloud Management Platform",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ManageIQ/manageiq.git"
+  },
+  "author": "ManageIQ",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/ManageIQ/manageiq/issues"
+  },
+  "homepage": "https://github.com/ManageIQ/manageiq#readme",
+  "dependencies": {
+    "@manageiq/react-ui-components": "~0.9.5",
+    "patternfly-react": "^2.21.5",
+    "prop-types": "^15.6.0",
+    "react": "^16.3.1",
+    "react-bootstrap": "^0.32.4",
+    "react-dom": "^16.3.1",
+    "react-redux": "^5.0.7",
+    "redux": "^4.0.0",
+    "redux-form": "^7.0.0",
+    "urijs": "^1.19.1"
+  },
+  "devDependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-export-extensions": "^6.22.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-1": "^6.24.1"
+  },
+  "engines": {
+    "node": ">= 6.9.1",
+    "npm": ">= 3.10.3",
+    "yarn": ">= 0.20.1"
+  }
+}


### PR DESCRIPTION
This PR is able to:
* Add the Provision select button to make possible apply a config pattern and update the server firmware using react form. 

Depends on: 
- [ ] [Pr 249 - Add the config pattern type ](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/249)
- [ ] [Pr 250 - 2º - React components  ](https://github.com/ManageIQ/manageiq-providers-lenovo/pull/250)