### PR TITLE
Fix factory inheritence to fix issues with defaults (zone)

### DIFF
--- a/spec/factories/physical_infra_manager.rb
+++ b/spec/factories/physical_infra_manager.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
-  factory :physical_infra,
-          :class => "ManageIQ::Providers::Lenovo::PhysicalInfraManager" do
-  end
+  factory :physical_infra, :parent => :ems_physical_infra, :class => "ManageIQ::Providers::Lenovo::PhysicalInfraManager"
 
   factory :physical_infra_with_authentication,
           :parent => :physical_infra do


### PR DESCRIPTION
Other repos using this factory aren't expecting to have to set zone and other attributes since they're handled by the `:ext_management_system` base factory.  Setting the parent factory fixes this.