### PR TITLE
Replace local inventory-related definitions

### DIFF
--- a/app/models/manageiq/providers/lenovo/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/persister/definitions/physical_infra_collections.rb
@@ -2,15 +2,29 @@ module ManageIQ::Providers::Lenovo::Inventory::Persister::Definitions::PhysicalI
   extend ActiveSupport::Concern
 
   def initialize_physical_infra_inventory_collections
-    %i(canisters
-       customization_scripts
-       physical_chassis
-       physical_disks
-       physical_racks
-       physical_servers
-       physical_storages
-       physical_switches).each do |name|
-
+    %i[
+      canisters
+      customization_scripts
+      physical_chassis
+      physical_chassis_details
+      physical_chassis_computer_systems
+      physical_chassis_hardwares
+      physical_disks
+      physical_racks
+      physical_servers
+      physical_server_details
+      physical_server_computer_systems
+      physical_server_hardwares
+      physical_server_network_devices
+      physical_server_storage_adapters
+      physical_storages
+      physical_storage_details
+      physical_storage_computer_systems
+      physical_storage_hardwares
+      physical_switches
+      physical_switch_details
+      physical_switch_hardwares
+    ].each do |name|
       add_collection(physical_infra, name)
     end
 
@@ -18,17 +32,7 @@ module ManageIQ::Providers::Lenovo::Inventory::Persister::Definitions::PhysicalI
 
     add_physical_disks
 
-    add_asset_details
-
-    add_computer_systems
-
-    add_computer_system_hardwares
-    add_physical_switch_hardwares
-
     add_firmwares
-
-    add_physical_server_network_devices
-    add_physical_server_storage_adapters
 
     add_management_devices
 
@@ -39,82 +43,6 @@ module ManageIQ::Providers::Lenovo::Inventory::Persister::Definitions::PhysicalI
   end
 
   # ------ IC provider specific definitions -------------------------
-  def add_asset_details
-    %i(physical_server
-       physical_chassis
-       physical_storage
-       physical_switch).each do |asset_detail_assoc|
-
-      add_collection(physical_infra, "#{asset_detail_assoc}_details".to_sym) do |builder|
-        builder.add_properties(
-          :model_class                  => ::AssetDetail,
-          :manager_ref                  => %i(resource),
-          :parent_inventory_collections => [asset_detail_assoc.to_s.pluralize.to_sym]
-        )
-      end
-    end
-  end
-
-  def add_computer_systems
-    %i(physical_server
-       physical_chassis
-       physical_storage).each do |computer_system_assoc|
-
-      add_collection(physical_infra, "#{computer_system_assoc}_computer_systems".to_sym) do |builder|
-        builder.add_properties(
-          :model_class                  => ::ComputerSystem,
-          :manager_ref                  => %i(managed_entity),
-          :parent_inventory_collections => [computer_system_assoc.to_s.pluralize.to_sym]
-        )
-      end
-    end
-  end
-
-  def add_computer_system_hardwares
-    %i(physical_server
-       physical_chassis
-       physical_storage).each do |computer_system_assoc|
-
-      add_collection(physical_infra, "#{computer_system_assoc}_hardwares".to_sym) do |builder|
-        builder.add_properties(
-          :model_class                  => ManageIQ::Providers::Lenovo::PhysicalInfraManager::Hardware,
-          :manager_ref                  => %i(computer_system),
-          :parent_inventory_collections => [computer_system_assoc.to_s.pluralize.to_sym]
-        )
-      end
-    end
-  end
-
-  def add_physical_switch_hardwares
-    add_collection(physical_infra, :physical_switch_hardwares) do |builder|
-      builder.add_properties(
-        :model_class                  => ManageIQ::Providers::Lenovo::PhysicalInfraManager::Hardware,
-        :manager_ref                  => %i(physical_switch),
-        :parent_inventory_collections => %i(physical_switches),
-      )
-    end
-  end
-
-  def add_physical_server_network_devices
-    add_collection(physical_infra, :physical_server_network_devices) do |builder|
-      builder.add_properties(
-        :model_class                  => ::GuestDevice,
-        :manager_ref                  => %i(device_type uid_ems),
-        :parent_inventory_collections => %i(physical_servers)
-      )
-    end
-  end
-
-  def add_physical_server_storage_adapters
-    add_collection(physical_infra, :physical_server_storage_adapters) do |builder|
-      builder.add_properties(
-        :model_class                  => ::GuestDevice,
-        :manager_ref                  => %i(device_type uid_ems),
-        :parent_inventory_collections => %i(physical_servers)
-      )
-    end
-  end
-
   # Special :guest_device
   def add_management_devices
     %i(physical_server

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -11,7 +11,6 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   require_nested :RefreshWorker
 
   require_nested :Firmware
-  require_nested :Hardware
   require_nested :PhysicalChassis
   require_nested :PhysicalRack
   require_nested :PhysicalServer

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -20,53 +20,6 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
 
   supports :change_password
 
-  # Asset details
-  has_many :physical_server_details,  :through => :physical_servers,  :source => :asset_detail
-  has_many :physical_chassis_details, :through => :physical_chassis,  :source => :asset_detail
-  has_many :physical_storage_details, :through => :physical_storages, :source => :asset_detail
-  has_many :physical_switch_details,  :through => :physical_switches, :source => :asset_detail
-
-  # Computer systems
-  has_many :physical_server_computer_systems,  :through => :physical_servers,  :source => :computer_system
-  has_many :physical_chassis_computer_systems, :through => :physical_chassis,  :source => :computer_system
-  has_many :physical_storage_computer_systems, :through => :physical_storages, :source => :canister_computer_systems
-
-  # Hardwares
-  has_many :physical_server_hardwares,  :through => :physical_server_computer_systems,  :source => :hardware
-  has_many :physical_chassis_hardwares, :through => :physical_chassis_computer_systems, :source => :hardware
-  has_many :physical_storage_hardwares, :through => :physical_storage_computer_systems, :source => :hardware
-  has_many :physical_switch_hardwares,  :through => :physical_switches, :source => :hardware
-
-  # Guest devices
-  has_many :physical_server_network_devices,     :through => :physical_server_hardwares,  :source => :nics
-  has_many :physical_server_storage_adapters,    :through => :physical_server_hardwares,  :source => :storage_adapters
-  has_many :physical_server_management_devices,  :through => :physical_server_hardwares,  :source => :management_devices
-  has_many :physical_chassis_management_devices, :through => :physical_chassis_hardwares, :source => :management_devices
-  has_many :physical_storage_management_devices, :through => :physical_storage_hardwares, :source => :management_devices
-
-  # Firmwares
-  has_many :physical_server_firmwares,                 :through => :physical_server_hardwares,        :source => :firmwares
-  has_many :physical_server_network_device_firmwares,  :through => :physical_server_network_devices,  :source => :firmwares
-  has_many :physical_server_storage_adapter_firmwares, :through => :physical_server_storage_adapters, :source => :firmwares
-  has_many :physical_switch_firmwares,                 :through => :physical_switch_hardwares,        :source => :firmwares
-
-  # Network
-  has_many :physical_server_networks,  :through => :physical_server_management_devices,  :source => :network
-  has_many :physical_chassis_networks, :through => :physical_chassis_management_devices, :source => :network
-  has_many :physical_storage_networks, :through => :physical_storage_management_devices, :source => :network
-  has_many :physical_switch_networks,  :through => :physical_switch_hardwares,           :source => :networks
-
-  # Physical network ports
-  has_many :physical_server_network_ports, :through => :physical_server_network_devices,      :source => :physical_network_ports
-  has_many :physical_switch_network_ports, :through => :physical_switches,                    :source => :physical_network_ports
-  has_many :physical_storage_network_ports, :through => :physical_storage_management_devices, :source => :physical_network_ports
-
-  # Physical disks
-  has_many :physical_disks, :through => :physical_storages
-
-  # Canisters
-  has_many :canisters, :through => :physical_storages
-
   def self.ems_type
     @ems_type ||= "lenovo_ph_infra".freeze
   end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/hardware.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/hardware.rb
@@ -1,5 +1,0 @@
-module ManageIQ::Providers
-  class Lenovo::PhysicalInfraManager::Hardware < ::Hardware
-    has_many :management_devices, -> { where("device_type = 'management'") }, :class_name => "GuestDevice", :foreign_key => :hardware_id
-  end
-end


### PR DESCRIPTION
Since all of the relationships and inventory definitions that we are using are included in the core repo, we can drop the local definitions and replace them with the definitions from the core repo.

This PR depends on:

  * [ ] https://github.com/ManageIQ/manageiq/pull/18953

@miq-bot assign @agrare 