### PR TITLE
Remove to_json from toolbar data as it's not needed

### DIFF
--- a/app/helpers/manageiq/providers/lenovo/toolbar_overrides/ems_physical_infra_center.rb
+++ b/app/helpers/manageiq/providers/lenovo/toolbar_overrides/ems_physical_infra_center.rb
@@ -22,7 +22,7 @@ module ManageIQ
                       'function-data' => {:controller     => 'provider_dialogs', # this one is required
                                           :button         => :provision_apply_pattern,
                                           :modal_title    => N_('Apply Config Pattern'),
-                                          :component_name => 'ApplyConfigPatternFormProvider'}.to_json
+                                          :component_name => 'ApplyConfigPatternFormProvider'}
                     },
                     :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
                   ),
@@ -36,7 +36,7 @@ module ManageIQ
                       'function-data' => {:controller     => 'provider_dialogs', # this one is required
                                           :button         => :provision_firmware_update,
                                           :modal_title    => N_('Firmware Update'),
-                                          :component_name => 'FirmwareUpdateFormProvider'}.to_json
+                                          :component_name => 'FirmwareUpdateFormProvider'}
                     },
                     :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
                   )


### PR DESCRIPTION
After https://github.com/ManageIQ/manageiq-ui-classic/pull/5997 `to_json` is not needed and will break the data format.

Related to https://github.com/ManageIQ/manageiq-ui-classic/pull/6289 fix but **not** dependent either way.

Before:
Buttons `Firmware Update` and `Provision ` don't work on click.
After:
Buttons work as expected.

@miq-bot add_label ivanchuk/no