### PR TITLE
Autoload the constant on first use due to several places using it.

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -1,4 +1,5 @@
-require 'xclarity_client'
+# Delay load a fairly expensive library until first use.
+autoload(:XClarityClient, 'xclarity_client')
 
 module ManageIQ::Providers::Lenovo::ManagerMixin
   extend ActiveSupport::Concern


### PR DESCRIPTION
Saves 226 required files, around 7 MB and some time when you load the ManageIQ::Providers::Lenovo::PhysicalInfraManager.  Note, if we want to load the manager for non-operations, such as getting inventory data from the database, we shouldn't need this library.