### PR TITLE
remove inventory object refresh from settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -370,7 +370,6 @@
           :warning: []
 :ems_refresh:
   :lenovo_ph_infra:
-    :inventory_object_refresh: true
     :inventory_collections:
       :saver_strategy: default
 :http_proxy:


### PR DESCRIPTION
just what it says on the tin

@miq-bot add_label cleanup
@miq-bot assign @agrare