### PR TITLE
Remove unused ems_inv_to_hashes method

### DIFF
--- a/app/models/manageiq/providers/lenovo/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/parser/physical_infra_manager.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers::Lenovo
   class Inventory::Parser::PhysicalInfraManager < ::ManageIQ::Providers::Lenovo::Inventory::Parser
-    include ManageIQ::Providers::Lenovo::RefreshHelperMethods
-
     def parse
       physical_racks do |persister_rack, rack|
         # Retrieve and parse the servers that are inside the rack, but not inside any chassis.

--- a/app/models/manageiq/providers/lenovo/refresh_helper_methods.rb
+++ b/app/models/manageiq/providers/lenovo/refresh_helper_methods.rb
@@ -1,9 +1,0 @@
-module ManageIQ::Providers::Lenovo::RefreshHelperMethods
-  extend ActiveSupport::Concern
-
-  module ClassMethods
-    def ems_inv_to_hashes(ems, options = nil)
-      new(ems, options).ems_inv_to_hashes
-    end
-  end
-end


### PR DESCRIPTION
The RefreshParser.ems_inv_to_hashes method was used by legacy refresh
and no longer needed

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/102