### PR TITLE
Remove unused dependency to react-ui-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,28 +14,7 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "dependencies": {
-    "@manageiq/react-ui-components": "~0.9.5",
-    "patternfly-react": "^2.21.5",
-    "prop-types": "^15.6.0",
-    "react": "^16.3.1",
-    "react-bootstrap": "^0.32.4",
-    "react-dom": "^16.3.1",
-    "react-redux": "^5.0.7",
-    "redux": "^4.0.0",
-    "redux-form": "^7.0.0",
     "urijs": "^1.19.1"
-  },
-  "devDependencies": {
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-plugin-transform-object-assign": "^6.8.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.6.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-1": "^6.24.1"
   },
   "engines": {
     "node": ">= 6.9.1",


### PR DESCRIPTION
The dependency is not included anywhere in the codebase, so I think it's safe to get rid of that. We should also convert the forms to DDF in the future.

https://github.com/ManageIQ/manageiq-ui-classic/issues/6716#issuecomment-591974680

@miq-bot assign @himdel 
@miq-bot add_label cleanup, react