### PR TITLE
Mark the event monitor as running before first event

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/runner.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher/runner.rb
@@ -8,8 +8,8 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher::Runner < 
   def monitor_events
     $log.info('Starting LXCA event catcher ...')
     raise "LXCA event_monitor_handle is nil" if event_monitor_handle.nil?
+    event_monitor_running
     event_monitor_handle.each_batch do |events|
-      event_monitor_running
       if events.present?
         $log.info("Quantity of new LXCA events: #{events.size}")
         @queue.enq(events)


### PR DESCRIPTION
If we don't mark the event monitor thread as running until the first
event is delivered the worker doesn't heartbeat and won't shutdown
cleanly.