### PR TITLE
Add event group names in setting.yml

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -146,6 +146,7 @@
           :warning:
           - 'IMM0013'
           - 'IMM0059'
+          :name: Network
         :login:
           :critical: []
           :detail:
@@ -162,6 +163,7 @@
           :warning:
           - 'IMM0016'
           - 'IMM0017'
+          :name: Login
         :security:
           :detail:
           - 'IMM0206'
@@ -360,6 +362,7 @@
           - 'PLAT0126'
           :warning:
           - 'IMM0012'
+          :name: Status
         :addition:
           :critical: []
           :detail:
@@ -368,6 +371,7 @@
           - 'IMM0100'
           - 'IMM0096'
           :warning: []
+          :name: Addition
 :ems_refresh:
   :lenovo_ph_infra:
     :inventory_collections:


### PR DESCRIPTION
<img width="1098" alt="Screenshot 2020-07-31 at 15 30 34" src="https://user-images.githubusercontent.com/14937244/89055343-7f087700-d35a-11ea-908c-6b69730d8922.png">


Issue: Management Events from TimeLines have an empty selection

Blank selection is event `Login` and as you can see in screenshot the section with `:name:` is missing for login (for example `:name:` is present for the `:power:`)

Names are missing also for groups: Status, Network and Addition 


@miq-bot assign @agrare 

@miq-bot add_label bug


options in select box are generated by method :


```
./app/models/event_stream.rb
```

```ruby

  def self.event_groups
    core_event_groups = ::Settings.event_handling.event_groups.to_hash
    Settings.ems.each_with_object(core_event_groups) do |(_provider_type, provider_settings), event_groups|
      provider_event_groups = provider_settings.fetch_path(:event_handling, :event_groups)
      next unless provider_event_groups
      DeepMerge.deep_merge!(
        provider_event_groups.to_hash, event_groups,
        :preserve_unmergeables => false,
        :overwrite_arrays      => false
      )
    end
  end
```

