### PR TITLE
The addition Event group name is Creation/Addition

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -371,7 +371,7 @@
           - 'IMM0100'
           - 'IMM0096'
           :warning: []
-          :name: Addition
+          :name: Creation/Addition
 :ems_refresh:
   :lenovo_ph_infra:
     :inventory_collections:


### PR DESCRIPTION
Missing event group names were added recently but the addition group is formally named "Creation/Addition" and was causing core spec failures

https://github.com/ManageIQ/manageiq-providers-lenovo/pull/308
https://travis-ci.com/github/ManageIQ/manageiq/jobs/367195159#L717-L746