### PR TITLE
Make the default credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -63,6 +63,7 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
                 :id                     => 'authentications.default.valid',
                 :name                   => 'authentications.default.valid',
                 :skipSubmit             => true,
+                :isRequired             => true,
                 :validationDependencies => %w[type],
                 :fields                 => [
                   {


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here.