### PR TITLE
Convert `supports_#{op}?` to `supports?(op)`

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   require_nested :PhysicalSwitch
 
   supports :change_password
+  supports :provisioning
 
   def self.ems_type
     @ems_type ||= "lenovo_ph_infra".freeze
@@ -22,9 +23,5 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
 
   def self.description
     @description ||= "Lenovo XClarity"
-  end
-
-  def supports_provisioning?
-    true
   end
 end


### PR DESCRIPTION
Additionally, convert method definitions such as

```ruby
def supports_port?
  true
end
```

to

```ruby
supports :port
```