### PR TITLE
Drop version dependency on webmock

### DIFF
--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "xclarity_client", "~> 0.6.0"
 
-  spec.add_development_dependency "faker", "= 1.8.3"
+  spec.add_development_dependency "faker"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "webmock", "~> 2.1.0"
 end


### PR DESCRIPTION
ManageIQ core brings this as a test dependency with a more-recent version (~> 3.7)