### PR TITLE
remove use of faker

### DIFF
--- a/manageiq-providers-lenovo.gemspec
+++ b/manageiq-providers-lenovo.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "xclarity_client", "~> 0.6.0"
 
-  spec.add_development_dependency "faker"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov"
 end

--- a/spec/models/manageiq/providers/lenovo/manager_mixin_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/manager_mixin_spec.rb
@@ -1,5 +1,3 @@
-require 'faker'
-
 describe ManageIQ::Providers::Lenovo::ManagerMixin do
   let(:auth) do
     {
@@ -49,8 +47,8 @@ describe ManageIQ::Providers::Lenovo::ManagerMixin do
 
   describe 'discover' do
     let(:port)            { Random.rand(10_000).to_s }
-    let(:address)         { URI("https://#{Faker::Internet.ip_v4_address}:#{port}/aicc") }
-    let(:invalid_address) { URI("https://#{Faker::Internet.ip_v4_address}:#{port}") }
+    let(:address)         { URI("https://10.10.10.10:#{port}/aicc") }
+    let(:invalid_address) { URI("https://10.10.10.12:#{port}") }
 
     before :each do
       EvmSpecHelper.local_miq_server(:zone => Zone.seed)


### PR DESCRIPTION
I was getting faker ruby 3.0 errors. This looked like low hanging fruit 

There is no reason to depend upon this gem just to make up an ip address

---

I also removed faker from our only dependency that requires it. so it will hopefully disapear

https://github.com/lenovo/xclarity_client/pull/155

@Fryguy are you someone who can merge / push the xclarity gem over there?
(they seemed to suggest that it could be  brought over into miq but unsure where that ended)

I ran the test locally but there are a ton of issues with that gem. it needs some love to get away from a number of abandoned gem dependencies.