### PR TITLE
converting supported_for_create to supports :create

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   require_nested :PhysicalSwitch
 
   supports :change_password
+  supports :create
   supports :provisioning
 
   def self.ems_type


### PR DESCRIPTION
remove supports from lenovo provider

followup to ManageIQ/manageiq#21573 and #343 