### PR TITLE
Update urijs package to support s390x builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
   "name": "manageiq-providers-lenovo",
   "version": "1.0.0",
-  "lockfileVersion": 2,
-  "requires": true,
+  "description": "ManageIQ Cloud Management Platform",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ManageIQ/manageiq.git"
+  },
   "packages": {
     "": {
       "name": "manageiq-providers-lenovo",

--- a/package.json
+++ b/package.json
@@ -1,25 +1,26 @@
 {
   "name": "manageiq-providers-lenovo",
   "version": "1.0.0",
-  "description": "ManageIQ Cloud Management Platform",
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ManageIQ/manageiq.git"
-  },
-  "author": "ManageIQ",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/ManageIQ/manageiq/issues"
-  },
-  "homepage": "https://github.com/ManageIQ/manageiq#readme",
-  "dependencies": {
-    "urijs": "^1.19.11"
-  },
-  "engines": {
-    "node": ">= 14.0.0",
-    "npm": ">= 6.0.0",
-    "yarn": ">= 0.20.1"
-  },
-  "packageManager": "yarn@3.0.2"
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "manageiq-providers-lenovo",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "urijs": "^1.19.11"
+      },
+      "engines": {
+        "node": ">= 14.0.0",
+        "npm": ">= 6.0.0",
+        "yarn": ">= 0.20.1"
+      }
+    },
+    "urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,19 +3,9 @@
 
 __metadata:
   version: 4
-  cacheKey: 8
 
 "manageiq-providers-lenovo@workspace:.":
   version: 0.0.0-use.local
   resolution: "manageiq-providers-lenovo@workspace:."
-  dependencies:
-    urijs: ^1.19.11
   languageName: unknown
   linkType: soft
-
-"urijs@npm:^1.19.11":
-  version: 1.19.11
-  resolution: "urijs@npm:1.19.11"
-  checksum: f9b95004560754d30fd7dbee44b47414d662dc9863f1cf5632a7c7983648df11d23c0be73b9b4f9554463b61d5b0a520b70df9e1ee963ebb4af02e6da2cc80f3
-  languageName: node
-  linkType: hard

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,19 @@
 
 __metadata:
   version: 4
+  cacheKey: 8
 
 "manageiq-providers-lenovo@workspace:.":
   version: 0.0.0-use.local
   resolution: "manageiq-providers-lenovo@workspace:."
+  dependencies:
+    urijs: ^1.19.11
   languageName: unknown
   linkType: soft
+
+"urijs@npm:^1.19.11":
+  version: 1.19.11
+  resolution: "urijs@npm:1.19.11"
+  checksum: f9b95004560754d30fd7dbee44b47414d662dc9863f1cf5632a7c7983648df11d23c0be73b9b4f9554463b61d5b0a520b70df9e1ee963ebb4af02e6da2cc80f3
+  languageName: node
+  linkType: hard


### PR DESCRIPTION
Hi @Fryguy,
Raising this PR with some modification for urijs package and with these changes **yarn** command is executed without any conflict.

```
[root@a6a8530586d9 manageiq-providers-lenovo]# yarn
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 1s 512ms
➤ YN0000: Done in 1s 601ms
```
