### PR TITLE
Remove urijs dependency by using strings for API calls

### DIFF
--- a/app/javascript/components/apply-config-pattern-form-provider.jsx
+++ b/app/javascript/components/apply-config-pattern-form-provider.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import {connect} from "react-redux";
-import URI from "urijs";
 import LenovoForm from "./form/lenovo_form";
 import PhysicalServerField from "./form/fields/physical_server_field";
 import ConfigPatternField from "./form/fields/config_pattern_field";
@@ -21,12 +20,7 @@ const applyPattern = (values) =>{
 };
 
 const getPhysicalServerData = (providerID, patternID) => {
-  const uri = new URI("/api/physical_servers/?")
-    .query({
-      "attributes": "name,href",
-      "expand": "resources",
-      "filter[]": `ems_id=${providerID}`
-    });
+  const uri = `/api/physical_servers?attributes=name,href&expand=resources&filter[]=ems_id=${providerID}`;
   return API.get(uri).then((data) => data.resources.map(resource => ({
     value: resource.href,
     label: resource.name,
@@ -34,16 +28,8 @@ const getPhysicalServerData = (providerID, patternID) => {
 };
 
 const getConfigPatternData = (providerID) => {
-  const uri = new URI("/api/customization_scripts/?")
-    .query({
-      "attributes": "manager_ref,name",
-      "expand": "resources",
-      "filter[]": "type='ManageIQ::Providers::Lenovo::PhysicalInfraManager::ConfigPattern'",
-    })
-    .addQuery({
-      "filter[]": `manager_id=${providerID}`
-    });
-  return API.get(decodeURI(uri.toString())).then((data)=> data.resources.map(resource => ({
+  const uri = `/api/customization_scripts?attributes=manager_ref,name&expand=resources&filter[]=type='ManageIQ::Providers::Lenovo::PhysicalInfraManager::ConfigPattern'&filter[]=manager_id=${providerID}`;
+  return API.get(uri).then((data) => data.resources.map(resource => ({
     value: resource.manager_ref,
     label: resource.name,
   })));

--- a/app/javascript/components/firmware-update-form-provider.jsx
+++ b/app/javascript/components/firmware-update-form-provider.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import {connect} from "react-redux";
-import URI from "urijs";
 import LenovoForm from "./form/lenovo_form";
 import FirmwareField from "./form/fields/firmware_field";
 
@@ -24,12 +23,7 @@ const applyFirmwareUpdate = (values) =>{
 };
 
 const getPhysicalServerData = (providerID) => {
-  const uri = new URI("/api/physical_servers/?")
-    .query({
-      "attributes": "id,name,hardware.firmwares",
-      "expand": "resources",
-      "filter[]": `ems_id=${providerID}`
-    });
+  const uri = `/api/physical_servers?attributes=id,name,hardware.firmwares&expand=resources&filter[]=ems_id=${providerID}`;
   return API.get(uri).then((data) => data.resources.map(resource => ({
     id: resource.id,
     name: resource.name,

--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "url": "https://github.com/ManageIQ/manageiq/issues"
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
-  "dependencies": {
-    "urijs": "^1.19.11"
-  },
   "engines": {
     "node": ">= 14.0.0",
     "npm": ">= 6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,19 +3,9 @@
 
 __metadata:
   version: 4
-  cacheKey: 8
 
 "manageiq-providers-lenovo@workspace:.":
   version: 0.0.0-use.local
   resolution: "manageiq-providers-lenovo@workspace:."
-  dependencies:
-    urijs: ^1.19.11
   languageName: unknown
   linkType: soft
-
-"urijs@npm:^1.19.11":
-  version: 1.19.11
-  resolution: "urijs@npm:1.19.11"
-  checksum: f9b95004560754d30fd7dbee44b47414d662dc9863f1cf5632a7c7983648df11d23c0be73b9b4f9554463b61d5b0a520b70df9e1ee963ebb4af02e6da2cc80f3
-  languageName: node
-  linkType: hard


### PR DESCRIPTION
None of the other providers use urijs instead opting for normal template
strings. urijs is giving problems during build where it hangs on s390x
builds. In addition there have been a number of security issues with
urijs, and this is the only location that uses it.

@kavyanekkalapu @jeffibm I'm not sure how to test this...can you help me out?

cc @agrare