### PR TITLE
Add supports :console to PhysicalServers

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server/remote_console.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server/remote_console.rb
@@ -1,23 +1,8 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer::RemoteConsole
   extend ActiveSupport::Concern
 
-  def remote_console_acquire_resource_queue(userid)
-    task_opts = {
-      :action => "Acquiring remote console file or url from a physical server with uuid #{ems_ref} for user #{userid}",
-      :userid => userid
-    }
-
-    queue_opts = {
-      :class_name  => self.class.name,
-      :instance_id => id,
-      :method_name => 'remote_console_acquire_resource',
-      :priority    => MiqQueue::HIGH_PRIORITY,
-      :role        => 'ems_operations',
-      :zone        => my_zone,
-      :args        => [userid, MiqServer.my_server.id]
-    }
-
-    MiqTask.generic_action_with_callback(task_opts, queue_opts)
+  included do
+    supports :console
   end
 
   def remote_console_acquire_resource(_userid, _originating_server)


### PR DESCRIPTION
Add the :console supports feature to Lenovo Physical Servers and extract the _queue method into core.

Depends:
- [x] https://github.com/ManageIQ/manageiq/pull/22211

https://github.com/ManageIQ/manageiq/issues/22210