### PR TITLE
Upgrade Node v14 to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "engines": {
-    "node": ">= 14.0.0",
-    "npm": ">= 6.0.0",
+    "node": ">= 16.0.0",
+    "npm": ">= 8.0.0",
     "yarn": ">= 0.20.1"
   },
   "packageManager": "yarn@3.0.2"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "homepage": "https://github.com/ManageIQ/manageiq#readme",
   "engines": {
-    "node": ">= 16.0.0",
-    "npm": ">= 8.0.0",
+    "node": ">= 18.0.0",
+    "npm": ">= 8.6.0",
     "yarn": ">= 0.20.1"
   },
   "packageManager": "yarn@3.0.2"


### PR DESCRIPTION
Upgrading node version from **14.0.0 to 18.0.0**
Upgrading npm version from **6.0.0 to 8.6.0**

Fixes - https://github.com/ManageIQ/manageiq-ui-classic/issues/8690