### PR TITLE
Changed Feature Name from native to management_console

### DIFF
--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -15,7 +15,7 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   require_nested :PhysicalSwitch
 
   supports :change_password
-  supports :native_console
+  supports :management_console
   supports :create
   supports :provisioning
 

--- a/spec/models/manageiq/providers/lenovo/manager_mixin_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/manager_mixin_spec.rb
@@ -42,7 +42,7 @@ describe ManageIQ::Providers::Lenovo::ManagerMixin do
   end
 
   it 'console should be supported' do
-    expect(tested_class.new.supports?(:native_console)).to be_truthy
+    expect(tested_class.new.supports?(:management_console)).to be_truthy
   end
 
   describe 'discover' do


### PR DESCRIPTION
Related: https://github.com/ManageIQ/manageiq/pull/22474

Changes the feature name from native_console to management_console since native_console is already used by the RHV provider.