### PR TITLE
Fix verify_credentials for an existing EMS

### DIFF
--- a/app/models/manageiq/providers/lenovo/manager_mixin.rb
+++ b/app/models/manageiq/providers/lenovo/manager_mixin.rb
@@ -126,7 +126,7 @@ module ManageIQ::Providers::Lenovo::ManagerMixin
       userid, password = authentication&.values_at("userid", "password")
 
       password = ManageIQ::Password.try_decrypt(password)
-      password ||= find(args["id"]).authentication_password(endpoint_name) if args["id"]
+      password ||= find(args["id"]).authentication_password("default") if args["id"]
 
       !!raw_connect(userid, password, hostname, port, "token", false, Vmdb::Appliance.USER_AGENT, true)
     end

--- a/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/lenovo/physical_infra_manager_spec.rb
@@ -6,4 +6,36 @@ describe ManageIQ::Providers::Lenovo::PhysicalInfraManager do
   it "description should be 'Lenovo XClarity'" do
     expect(described_class.description).to eq("Lenovo XClarity")
   end
+
+  describe ".verify_credentials" do
+    let(:params_for_create) do
+      {
+        "endpoints"       => {"default" => {"hostname" => "xclarity.localdomain", "port" => 443}},
+        "authentications" => {"default" => {"userid" => "admin", "password" => "password"}}
+      }
+    end
+
+    it "calls validate_configuration on xclarity client" do
+      expect(described_class).to receive(:validate_connection)
+
+      described_class.verify_credentials(params_for_create)
+    end
+
+    context "with an existing provider" do
+      let(:ems) { FactoryBot.create(:physical_infra_with_authentication) }
+      let(:params_for_create) do
+        {
+          "id"              => ems.id,
+          "endpoints"       => {"default" => {"hostname" => "xclarity.localdomain", "port" => 443}},
+          "authentications" => {"default" => {"userid" => "admin"}}
+        }
+      end
+
+      it "uses the existing password if another isn't specified" do
+        expect(described_class).to receive(:validate_connection)
+
+        described_class.verify_credentials(params_for_create)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The code which looks up the password for an existing provider had a bug where endpoint_name was not defined.  This code would work if you were adding a new provider or changing the password on an existing provider.