### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/lenovo/inventory.rb
+++ b/app/models/manageiq/providers/lenovo/inventory.rb
@@ -1,8 +1,4 @@
 class ManageIQ::Providers::Lenovo::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
   # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name

--- a/app/models/manageiq/providers/lenovo/inventory/collector.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/collector.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Lenovo::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :PhysicalInfraManager
-
   def initialize(_manager, _target)
     super
 

--- a/app/models/manageiq/providers/lenovo/inventory/parser.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/parser.rb
@@ -1,5 +1,3 @@
 class ManageIQ::Providers::Lenovo::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :PhysicalInfraManager
-
   VENDOR_LENOVO = "lenovo".freeze
 end

--- a/app/models/manageiq/providers/lenovo/inventory/parser/component_parser.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/parser/component_parser.rb
@@ -4,23 +4,6 @@ module ManageIQ::Providers::Lenovo
   # to a MiQ format
   #
   class Inventory::Parser::ComponentParser
-    require_nested :Canister
-    require_nested :CompliancePolicy
-    require_nested :ComputerSystem
-    require_nested :ConfigPattern
-    require_nested :Firmware
-    require_nested :GuestDevice
-    require_nested :ManagementDevice
-    require_nested :NetworkDevice
-    require_nested :PhysicalDisk
-    require_nested :PhysicalChassis
-    require_nested :PhysicalNetworkPort
-    require_nested :PhysicalRack
-    require_nested :PhysicalServer
-    require_nested :PhysicalStorage
-    require_nested :PhysicalSwitch
-    require_nested :StorageDevice
-
     attr_reader :persister, :parser
 
     delegate :components,

--- a/app/models/manageiq/providers/lenovo/inventory/persister.rb
+++ b/app/models/manageiq/providers/lenovo/inventory/persister.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Lenovo::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :PhysicalInfraManager
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -3,17 +3,6 @@ class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::P
   include Operations
   include AuthenticatableProvider
 
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :Parser
-  require_nested :RefreshWorker
-  require_nested :Firmware
-  require_nested :PhysicalChassis
-  require_nested :PhysicalRack
-  require_nested :PhysicalServer
-  require_nested :PhysicalStorage
-  require_nested :PhysicalSwitch
-
   supports :change_password
   supports :native_console
   supports :create

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager.rb
@@ -1,7 +1,7 @@
 class ManageIQ::Providers::Lenovo::PhysicalInfraManager < ManageIQ::Providers::PhysicalInfraManager
   include ManageIQ::Providers::Lenovo::ManagerMixin
-  include_concern 'Operations'
-  include_concern 'AuthenticatableProvider'
+  include Operations
+  include AuthenticatableProvider
 
   require_nested :EventCatcher
   require_nested :EventParser

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/event_catcher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Lenovo::PhysicalInfraManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations.rb
@@ -1,8 +1,7 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
-  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::AnsibleSender'
+  include ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender
+  include ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::AnsibleSender
 
   def blink_loc_led(server, _options = {})
     change_led_state(server, :blink_loc_led)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/ansible_sender.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/operations/ansible_sender.rb
@@ -3,8 +3,7 @@
 #
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::AnsibleSender
   extend ActiveSupport::Concern
-
-  include_concern 'NotificationMixin'
+  include NotificationMixin
 
   #
   # Executes ansible resources inside +root_dir+

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalChassis < ::PhysicalChassis
-    include_concern 'Operations'
+    include Operations
 
     def self.display_name(number = 1)
       n_('Physical Chassis (Lenovo)', 'Physical Chassis (Lenovo)', number)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_chassis/operations.rb
@@ -3,9 +3,8 @@
 #
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalChassis::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
-  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender'
+  include ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender
+  include ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender
 
   def blink_loc_led
     change_led_state(self, :blink_loc_led_chassis)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalServer < ::PhysicalServer
-    include_concern 'RemoteConsole'
-    include_concern 'Operations'
+    include RemoteConsole
+    include Operations
 
     def self.display_name(number = 1)
       n_('Physical Server (Lenovo)', 'Physical Servers (Lenovo)', number)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_server/operations.rb
@@ -1,7 +1,6 @@
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalServer::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender'
+  include ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender
 
   #
   # Makes the provision of a server step-by-step using ansible methods.

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers
   class Lenovo::PhysicalInfraManager::PhysicalSwitch < ::PhysicalSwitch
-    include_concern 'Operations'
+    include Operations
 
     def self.display_name(number = 1)
       n_('Physical Switch (Lenovo)', 'Physical Switches (Lenovo)', number)

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch/operations.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/physical_switch/operations.rb
@@ -3,9 +3,8 @@
 #
 module ManageIQ::Providers::Lenovo::PhysicalInfraManager::PhysicalSwitch::Operations
   extend ActiveSupport::Concern
-
-  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender'
-  include_concern 'ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender'
+  include ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::Sender
+  include ManageIQ::Providers::Lenovo::PhysicalInfraManager::Operations::ComponentAnsibleSender
 
   #
   # Restarts the physical switch.

--- a/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/lenovo/physical_infra_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Lenovo::PhysicalInfraManager::RefreshWorker < ::MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_lenovo_physical_infra
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854