### PR TITLE
Carbon 11 migration: Lenovo form

### DIFF
--- a/app/javascript/components/form/lenovo_form.js
+++ b/app/javascript/components/form/lenovo_form.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Loading } from 'carbon-components-react';
+import { Loading } from '@carbon/react';
 import connect from "react-redux/es/connect/connect";
 
 class LenovoForm extends React.Component {


### PR DESCRIPTION
Part of the Carbon-11 migration in manageiq-ui(https://github.com/ManageIQ/manageiq-ui-classic/pull/9799).

Without this change, the component would still look for Carbon-10 styles and break after the stylesheet swap:
<img width="2546" height="1904" alt="image" src="https://github.com/user-attachments/assets/714bec0a-d6e7-4a9b-afc0-6069914fface" />

Updating the import fixes that:
<img width="2550" height="1926" alt="image" src="https://github.com/user-attachments/assets/e3ecd7ae-0613-4253-9a02-db71140f131f" />

**Note: Adding wip because this should probably go out after the manageiq-ui migration PR lands**

@miq-bot add-label wip
@miq-bot add-label technical debt
@miq-bot add-reviewer @GilbertCherrie 
@miq-bot add-reviewer @Fryguy 
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
